### PR TITLE
Fix PAC resolution in DEV authoring workflow

### DIFF
--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Authenticate Power Platform CLI
         shell: pwsh
         run: |
-          pac auth create `
+          . ./scripts/solution/Resolve-PacCommand.ps1
+          $pac = Resolve-PacCommand
+          & $pac auth create `
             --name insurance-authoring `
             --githubFederated `
             --applicationId $env:AZURE_CLIENT_ID `


### PR DESCRIPTION
Follow-up to #10 and #8. The first live authoring run failed before Dataverse mutation because the Power Platform installer exported `POWERPLATFORMTOOLS_PACPATH` without placing `pac` on PATH. This change uses the repository-tested `Resolve-PacCommand` helper. Failed run: https://github.com/urruegg/CRMShowcase/actions/runs/31270866986