### PR TITLE
Handle missing Dataverse metadata during DEV authoring

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -67,10 +67,11 @@ function Invoke-DataverseRequest {
             $arguments += @('--body', "@$($tempFile.FullName)")
         }
 
-        $output = & az @arguments
-        if ($LASTEXITCODE -ne 0) {
+        $output = & az @arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
             $detail = ($output | Out-String).Trim()
-            throw "Dataverse request failed ($Method $Path); az rest exited with code $LASTEXITCODE. $detail"
+            throw "Dataverse request failed ($Method $Path); az rest exited with code $exitCode. $detail"
         }
         if (-not [string]::IsNullOrWhiteSpace(($output | Out-String))) {
             return ($output | Out-String) | ConvertFrom-Json

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -231,6 +231,28 @@ Describe 'az rest transport' {
         } | Should -Throw '*exited with code 17*'
         Test-Path -LiteralPath $script:bodyFile | Should -BeFalse
     }
+
+    It 'treats a Dataverse Not Found error emitted by az on stderr as absent metadata' {
+        function global:az {
+            Write-Error 'ERROR: {"error":{"code":"0x80060888","message":"Not Found"}}' `
+                -ErrorAction Continue
+            $global:LASTEXITCODE = 3
+        }
+
+        Get-GlobalOptionSet 'crmshow_accounttype' | Should -BeNullOrEmpty
+    }
+
+    It 'does not hide a non-404 Dataverse error emitted by az on stderr' {
+        function global:az {
+            Write-Error 'ERROR: {"error":{"code":"0x80040265","message":"Permission denied"}}' `
+                -ErrorAction Continue
+            $global:LASTEXITCODE = 4
+        }
+
+        {
+            Get-GlobalOptionSet 'crmshow_accounttype'
+        } | Should -Throw '*exited with code 4*Permission denied*'
+    }
 }
 
 Describe 'Insurance Foundation reconciliation' {


### PR DESCRIPTION
Follow-up to #10/#11 and #8. The live DEV run reached OIDC, PAC auth, and language reconciliation, then failed before metadata mutation because `az rest` wrote the expected option-set 404 to stderr. Capture both native streams so missing metadata converges to create while non-404 errors still fail. Failed run: https://github.com/urruegg/CRMShowcase/actions/runs/31271011323