### PR TITLE
Read typed Dataverse global option sets

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -610,7 +610,10 @@ function Get-One {
 function Get-GlobalOptionSet {
     param([Parameter(Mandatory)] [string]$Name)
     $escaped = ConvertTo-ODataKeyString $Name
-    $path = "/GlobalOptionSetDefinitions(Name='$escaped')?`$expand=Options"
+    $path = (
+        "/GlobalOptionSetDefinitions(Name='$escaped')/" +
+        'Microsoft.Dynamics.CRM.OptionSetMetadata'
+    )
     try {
         $response = Invoke-DataverseRequest -Method GET -Path $path
     } catch {
@@ -732,7 +735,8 @@ function Invoke-ChoiceReconciliation {
         }
         if ($metadataChanged) {
             $complete = Get-CompleteMetadata `
-                "/GlobalOptionSetDefinitions($($existing.MetadataId))" OptionSet
+                ("/GlobalOptionSetDefinitions($($existing.MetadataId))/" +
+                    'Microsoft.Dynamics.CRM.OptionSetMetadata') OptionSet
             Invoke-DataverseRequest -Method PUT `
                 -Path "/GlobalOptionSetDefinitions($($existing.MetadataId))" `
                 -Body (New-CompleteLocalizedMetadataUpdateBody $complete $Choice.metadata OptionSet) `
@@ -785,7 +789,8 @@ function Invoke-ChoiceReconciliation {
             throw "Cannot update localized metadata for '$($Choice.logicalName)' without its metadata ID."
         }
         $complete = Get-CompleteMetadata `
-            "/GlobalOptionSetDefinitions($($existing.MetadataId))" OptionSet
+            ("/GlobalOptionSetDefinitions($($existing.MetadataId))/" +
+                'Microsoft.Dynamics.CRM.OptionSetMetadata') OptionSet
         Invoke-DataverseRequest -Method PUT `
             -Path "/GlobalOptionSetDefinitions($($existing.MetadataId))" `
             -Body (New-CompleteLocalizedMetadataUpdateBody $complete $Choice.metadata OptionSet) `

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -118,17 +118,34 @@ Describe 'Insurance Foundation request builders' {
         $dateTime.Format | Should -Be 'DateAndTime'
     }
 
-    It 'uses the escaped global-option-set alternate key without filter' {
+    It 'uses the typed global-option-set alternate key without expand or filter' {
         $script:choicePath = $null
         Mock Invoke-DataverseRequest {
             param($Method, $Path)
             $script:choicePath = $Path
+            return [pscustomobject]@{
+                Name = "crmshow_broker's_choice"
+                Options = @([pscustomobject]@{ Value = 100000000 })
+            }
+        }
+        $result = Get-GlobalOptionSet "crmshow_broker's_choice"
+        @($result.Options).Count | Should -Be 1
+        $script:choicePath | Should -BeExactly `
+            ("/GlobalOptionSetDefinitions(Name='crmshow_broker''s_choice')/" +
+                'Microsoft.Dynamics.CRM.OptionSetMetadata')
+        $script:choicePath | Should -Not -Match '\$(?:expand|filter)'
+
+        $source = Get-Content $script:publisherPath -Raw
+        $source | Should -Not -Match '\$expand=Options'
+    }
+
+    It 'returns null when the typed global-option-set lookup returns 404' {
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path)
             throw '404 Not Found'
         }
-        Get-GlobalOptionSet "crmshow_broker's_choice" | Should -BeNullOrEmpty
-        $script:choicePath | Should -BeExactly `
-            "/GlobalOptionSetDefinitions(Name='crmshow_broker''s_choice')?`$expand=Options"
-        $script:choicePath | Should -Not -Match '\$filter'
+
+        Get-GlobalOptionSet 'crmshow_missing' | Should -BeNullOrEmpty
     }
 
     It 'queries choice attributes only through typed metadata collections' {
@@ -708,6 +725,14 @@ Describe 'Insurance Foundation reconciliation' {
         $oneChoice.roles = @()
 
         Invoke-InsuranceFoundationReconciliation -Contract $oneChoice -Scope Foundation -Confirm:$false
+        $reads = @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and $_.Path -like '/GlobalOptionSetDefinitions*'
+        })
+        $reads.Count | Should -Be 1
+        $reads[0].Path | Should -Be (
+            "/GlobalOptionSetDefinitions(Name='crmshow_accounttype')/" +
+            'Microsoft.Dynamics.CRM.OptionSetMetadata'
+        )
         @($script:calls | Where-Object {
             $_.Method -ne 'GET' -and $_.Path -like '/GlobalOptionSetDefinitions*'
         }) | Should -BeNullOrEmpty
@@ -984,6 +1009,13 @@ Describe 'Insurance Foundation reconciliation' {
         $update = @($script:calls | Where-Object Method -eq 'PUT')
         $update.Count | Should -Be 1
         $update[0].Path | Should -Be '/GlobalOptionSetDefinitions(localized-choice)'
+        @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -eq (
+                '/GlobalOptionSetDefinitions(localized-choice)/' +
+                'Microsoft.Dynamics.CRM.OptionSetMetadata'
+            )
+        }).Count | Should -Be 1
         $update[0].Headers.'MSCRM.MergeLabels' | Should -Be 'true'
         $update[0].Body.Name | Should -Be $choice.logicalName
         $update[0].Body.IsGlobal | Should -BeTrue


### PR DESCRIPTION
Follow-up to #8. The DEV rerun reached existing choices but failed because `Options` is a typed complex property, not an expandable navigation property on OptionSetMetadataBase. Read the typed OptionSetMetadata alternate-key endpoint. Failed run: https://github.com/urruegg/CRMShowcase/actions/runs/31272339185