### PR TITLE
fix(datamodel): sanitize global choice metadata updates

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -126,6 +126,21 @@ function New-CompleteLocalizedMetadataUpdateBody {
         }
     }
 
+    if ($Kind -eq 'OptionSet') {
+        $body = [ordered]@{
+            '@odata.type' = 'Microsoft.Dynamics.CRM.OptionSetMetadata'
+            Name = $Existing.Name
+            DisplayName = ConvertTo-LocalizedLabel $Metadata.label
+            Description = ConvertTo-LocalizedLabel $Metadata.description
+            IsGlobal = [bool]$Existing.IsGlobal
+            OptionSetType = $Existing.OptionSetType
+        }
+        if ($Existing.MetadataId) {
+            $body.MetadataId = $Existing.MetadataId
+        }
+        return $body
+    }
+
     $body = [ordered]@{}
     foreach ($property in $Existing.PSObject.Properties) {
         if ($property.Name -notmatch '^@odata\.(?:context|etag)$' -and

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -995,6 +995,8 @@ Describe 'Insurance Foundation reconciliation' {
                     '@odata.type'='Microsoft.Dynamics.CRM.OptionSetMetadata'
                     Name=$choice.logicalName; IsGlobal=$true; MetadataId='localized-choice'
                     OptionSetType='Picklist'
+                    ParentOptionSetName='read-only-parent'
+                    IsCustomOptionSet=$true; IsManaged=$false; HasChanged=$false
                     Options=$desired.Options; DisplayName=$wrongDisplay
                     Description=$desired.Description; SolutionUniqueName='crmshow_Foundation'
                 }
@@ -1021,6 +1023,11 @@ Describe 'Insurance Foundation reconciliation' {
         $update[0].Body.IsGlobal | Should -BeTrue
         $update[0].Body.OptionSetType | Should -Be 'Picklist'
         $update[0].Body.Contains('Options') | Should -BeFalse
+        $update[0].Body.Contains('ParentOptionSetName') | Should -BeFalse
+        $update[0].Body.Contains('IsCustomOptionSet') | Should -BeFalse
+        $update[0].Body.Contains('IsManaged') | Should -BeFalse
+        $update[0].Body.Contains('HasChanged') | Should -BeFalse
+        $update[0].Body.Contains('SolutionUniqueName') | Should -BeFalse
     }
 
     It 'updates choice localization for missing or incorrect non-English option labels' {


### PR DESCRIPTION
## Summary
- sanitize global choice metadata updates to the supported `OptionSetMetadataBase` shape
- exclude live-response read-only fields such as `ParentOptionSetName`
- add a regression fixture matching the DEV Dataverse response

## Traceability
- Story: US-702, US-707, US-708
- Feature: #8
- ADR: `docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md`

## Evidence
- 116 Pester tests passed
- focused code review found no issues