### PR TITLE
fix(datamodel): bind global choices by metadata id

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1252,6 +1252,9 @@ function Invoke-TableReconciliation {
                 $typedChoice = Get-PicklistAttributeMetadata $Table.logicalName `
                     $column.logicalName
                 $actual = @($typedChoice)
+                if ($actual.Count -eq 1 -and $null -eq $actual[0]) {
+                    $actual = @()
+                }
                 $baseChoice = @($existing.Attributes |
                     Where-Object LogicalName -eq $column.logicalName)
                 if ($baseChoice.Count -gt 1) {
@@ -1278,7 +1281,10 @@ function Invoke-TableReconciliation {
                     Method = 'POST'
                     Path = "/EntityDefinitions(LogicalName='$($Table.logicalName)')/Attributes"
                     Solution = $Table.solution
-                    Body = New-AttributeMetadata $column
+                    Body = New-AttributeMetadata $column `
+                        -GlobalChoiceMetadataIds (
+                            Get-GlobalChoiceMetadataIds @($column)
+                        )
                 }
                 Invoke-PlannedRequest $request | Out-Null
                 Write-Output "$($Table.logicalName)/$($column.logicalName): Created"

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -157,7 +157,10 @@ function New-CompleteLocalizedMetadataUpdateBody {
 }
 
 function New-AttributeMetadata {
-    param([Parameter(Mandatory)] $Column)
+    param(
+        [Parameter(Mandatory)] $Column,
+        [System.Collections.IDictionary] $GlobalChoiceMetadataIds
+    )
 
     $common = [ordered]@{
         LogicalName = $Column.logicalName
@@ -186,8 +189,13 @@ function New-AttributeMetadata {
         }
         'GlobalChoice' {
             $common['@odata.type'] = 'Microsoft.Dynamics.CRM.PicklistAttributeMetadata'
-            $common['GlobalOptionSet@odata.bind'] =
+            $binding = if ($GlobalChoiceMetadataIds -and
+                $GlobalChoiceMetadataIds.Contains($Column.choice)) {
+                "/GlobalOptionSetDefinitions($($GlobalChoiceMetadataIds[$Column.choice]))"
+            } else {
                 "/GlobalOptionSetDefinitions(Name='$($Column.choice)')"
+            }
+            $common['GlobalOptionSet@odata.bind'] = $binding
         }
         'Lookup' {
             $common['@odata.type'] = 'Microsoft.Dynamics.CRM.LookupAttributeMetadata'
@@ -204,10 +212,16 @@ function New-AttributeMetadata {
 
 function Get-TableCreateRequest {
     [CmdletBinding()]
-    param([Parameter(Mandatory)] $Table)
+    param(
+        [Parameter(Mandatory)] $Table,
+        [System.Collections.IDictionary] $GlobalChoiceMetadataIds
+    )
 
     $attributes = foreach ($column in $Table.columns) {
-        if ($column.type -ne 'Customer') { New-AttributeMetadata -Column $column }
+        if ($column.type -ne 'Customer') {
+            New-AttributeMetadata -Column $column `
+                -GlobalChoiceMetadataIds $GlobalChoiceMetadataIds
+        }
     }
     $relationships = foreach ($relationship in @($Table.relationships | Where-Object {
         $_.authoring -eq 'InitialTableCreate'
@@ -359,12 +373,16 @@ function New-ChoiceRequest {
 }
 
 function New-NativeAttributeRequest {
-    param([Parameter(Mandatory)] $Extension)
+    param(
+        [Parameter(Mandatory)] $Extension,
+        [System.Collections.IDictionary] $GlobalChoiceMetadataIds
+    )
     return [pscustomobject]@{
         Method = 'POST'
         Path = "/EntityDefinitions(LogicalName='$($Extension.table)')/Attributes"
         Solution = $Extension.solution
-        Body = New-AttributeMetadata -Column $Extension
+        Body = New-AttributeMetadata -Column $Extension `
+            -GlobalChoiceMetadataIds $GlobalChoiceMetadataIds
     }
 }
 
@@ -642,6 +660,22 @@ function Get-GlobalOptionSet {
     return $response
 }
 
+function Get-GlobalChoiceMetadataIds {
+    param([Parameter(Mandatory)] [object[]]$Columns)
+    $metadataIds = @{}
+    foreach ($column in @($Columns | Where-Object type -eq 'GlobalChoice')) {
+        if ($metadataIds.Contains($column.choice)) { continue }
+        $choice = Get-GlobalOptionSet $column.choice
+        $metadataId = [guid]::Empty
+        if ($null -eq $choice -or
+            -not [guid]::TryParse([string]$choice.MetadataId, [ref]$metadataId)) {
+            throw "Cannot bind '$($column.logicalName)' to global choice '$($column.choice)': a valid metadata ID was not returned."
+        }
+        $metadataIds[$column.choice] = $metadataId.ToString()
+    }
+    return $metadataIds
+}
+
 function Get-CompleteMetadata {
     param(
         [Parameter(Mandatory)] [string]$Path,
@@ -895,7 +929,10 @@ function Invoke-NativeExtensionReconciliation {
     $existing = Get-PicklistAttributeMetadata $Extension.table `
         $Extension.logicalName
     if ($null -eq $existing) {
-        Invoke-PlannedRequest (New-NativeAttributeRequest $Extension) | Out-Null
+        $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Extension)
+        Invoke-PlannedRequest (
+            New-NativeAttributeRequest $Extension $choiceMetadataIds
+        ) | Out-Null
         Write-Output "$($Extension.table)/$($Extension.logicalName): Created"
         return
     }
@@ -1155,7 +1192,10 @@ function Invoke-TableReconciliation {
     param($Table)
     $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,Targets,MaxLength,Format,DateTimeBehavior,DisplayName,Description),OneToManyRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
     if ($null -eq $existing) {
-        Invoke-PlannedRequest (Get-TableCreateRequest $Table) | Out-Null
+        $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
+        Invoke-PlannedRequest (
+            Get-TableCreateRequest $Table $choiceMetadataIds
+        ) | Out-Null
         Write-Output "$($Table.logicalName): Created"
 
         # Dataverse requires the global action for a polymorphic Customer lookup.

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -905,6 +905,64 @@ Describe 'Insurance Foundation reconciliation' {
         }).Count | Should -Be 1
     }
 
+    It 'binds a missing choice column on an existing table by metadata ID' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $choiceColumn = $table.columns |
+            Where-Object type -eq 'GlobalChoice' | Select-Object -First 1
+        $table.columns = @($choiceColumn)
+        $table.relationships = @()
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+        $metadataId = '22222222-2222-2222-2222-222222222222'
+
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
+            })
+            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId='existing-table'
+                    LogicalName=$table.logicalName
+                    OwnershipType=$table.ownership
+                    SolutionUniqueName=$table.solution
+                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
+                    Description=ConvertTo-LocalizedLabel $table.metadata.description
+                    Attributes=@()
+                    OneToManyRelationships=@()
+                }) }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata') {
+                return [pscustomobject]@{ value=@() }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{ MetadataId=$metadataId }
+            }
+            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
+                return [pscustomobject]@{ ObjectTypeCode=10427 }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $create = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq (
+                "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+            )
+        })
+        $create.Count | Should -Be 1
+        $create[0].Body.'GlobalOptionSet@odata.bind' |
+            Should -Be "/GlobalOptionSetDefinitions($metadataId)"
+    }
+
     It 'throws on lookup target and alternate-key structural conflicts' {
         $column = $script:contract.tables[0].columns |
             Where-Object logicalName -eq 'crmshow_accountid'

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -29,6 +29,27 @@ Describe 'Insurance Foundation request builders' {
         }
     }
 
+    It 'binds choice columns by metadata ID when one is resolved' {
+        $metadataId = '11111111-1111-1111-1111-111111111111'
+        $extension = $script:contract.nativeExtensions[0]
+        $native = New-NativeAttributeRequest $extension @{
+            $extension.choice = $metadataId
+        }
+        $native.Body.'GlobalOptionSet@odata.bind' |
+            Should -Be "/GlobalOptionSetDefinitions($metadataId)"
+
+        $table = $script:contract.tables[0]
+        $choiceColumn = $table.columns | Where-Object type -eq 'GlobalChoice' |
+            Select-Object -First 1
+        $request = Get-TableCreateRequest $table @{
+            $choiceColumn.choice = $metadataId
+        }
+        ($request.Body.Attributes | Where-Object {
+            $_.LogicalName -eq $choiceColumn.logicalName
+        }).'GlobalOptionSet@odata.bind' |
+            Should -Be "/GlobalOptionSetDefinitions($metadataId)"
+    }
+
     It 'accepts a complete typed-endpoint response without an odata type annotation' {
         $existing = [pscustomobject][ordered]@{
             MetadataId = 'attribute-id'; LogicalName = 'crmshow_name'
@@ -299,6 +320,7 @@ Describe 'Insurance Foundation reconciliation' {
     BeforeEach {
         $script:calls = [System.Collections.Generic.List[object]]::new()
         $script:choicesExist = $false
+        $script:createdChoices = [System.Collections.Generic.HashSet[string]]::new()
         Mock Invoke-DataverseRequest {
             param($Method, $Path, $Body, $Headers)
             $script:calls.Add([pscustomobject]@{
@@ -338,17 +360,20 @@ Describe 'Insurance Foundation reconciliation' {
             }
             if ($Method -eq 'GET' -and
                 $Path -like "/GlobalOptionSetDefinitions(Name='*") {
-                if ($script:choicesExist) {
-                    $name = [regex]::Match(
-                        $Path, "Name='([^']+)'"
-                    ).Groups[1].Value
+                $name = [regex]::Match(
+                    $Path, "Name='([^']+)'"
+                ).Groups[1].Value
+                if ($script:choicesExist -or $script:createdChoices.Contains($name)) {
                     $choice = $script:contract.choices |
                         Where-Object logicalName -eq $name
                     $desired = (New-ChoiceRequest $choice).Body
+                    $choiceIndex = [array]::IndexOf(
+                        @($script:contract.choices.logicalName), $name
+                    ) + 1
                     return [pscustomobject]@{
                         Name = $choice.logicalName
                         '@odata.type' = 'Microsoft.Dynamics.CRM.OptionSetMetadata'
-                        MetadataId = "existing-$($choice.logicalName)"
+                        MetadataId = '00000000-0000-0000-0000-{0:D12}' -f $choiceIndex
                         IsGlobal = $true
                         OptionSetType = 'Picklist'
                         SolutionUniqueName = $choice.solution
@@ -366,6 +391,9 @@ Describe 'Insurance Foundation reconciliation' {
                 return [pscustomobject]@{ RolePrivileges = @() }
             }
             if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Method $Path" }
+            if ($Method -eq 'POST' -and $Path -eq '/GlobalOptionSetDefinitions') {
+                $script:createdChoices.Add([string]$Body.Name) | Out-Null
+            }
             if ($Path -eq '/savedqueries') {
                 return [pscustomobject]@{ savedqueryid = 'new-view' }
             }
@@ -407,6 +435,24 @@ Describe 'Insurance Foundation reconciliation' {
             Should -Be @('Global')
         @($created | Where-Object Path -eq '/savedqueries').Body.layoutxml |
             Should -Match 'object="10427"'
+        $choiceBindings = @(
+            $created |
+                Where-Object Path -match '/Attributes$' |
+                ForEach-Object { $_.Body.'GlobalOptionSet@odata.bind' }
+            $created |
+                Where-Object Path -eq '/EntityDefinitions' |
+                ForEach-Object {
+                    $_.Body.Attributes |
+                        Where-Object { $_.'GlobalOptionSet@odata.bind' } |
+                        ForEach-Object { $_.'GlobalOptionSet@odata.bind' }
+                }
+        )
+        $choiceBindings.Count | Should -BeGreaterThan 0
+        $choiceBindings | Should -Not -Match 'Name='
+        $choiceBindings | Should -Match (
+            '^/GlobalOptionSetDefinitions\(' +
+            '[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\)$'
+        )
     }
 
     It 'continues after all five choices already exist and creates schema components' {
@@ -433,6 +479,7 @@ Describe 'Insurance Foundation reconciliation' {
     }
 
     It 'creates the Customer relationship immediately after its owning table and once' {
+        $script:choicesExist = $true
         Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope DataModel -Confirm:$false
         $mutations = @($script:calls | Where-Object Method -ne 'GET')
         $tableIndex = -1
@@ -534,6 +581,12 @@ Describe 'Insurance Foundation reconciliation' {
             }
             if ($Method -eq 'GET' -and $Path -match '/OneToManyRelationships\?') {
                 return [pscustomobject]@{ value=@() }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId='11111111-1111-1111-1111-111111111111'
+                }
             }
             if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
                 return [pscustomobject]@{ ObjectTypeCode=10427 }
@@ -688,6 +741,7 @@ Describe 'Insurance Foundation reconciliation' {
     }
 
     It 'reports deferred business rules and never schedules workflow mutation' {
+        $script:choicesExist = $true
         $messages = @(Invoke-InsuranceFoundationReconciliation -Contract $script:contract `
             -Scope DataModel -Confirm:$false)
         @($messages | Where-Object { $_ -like '*Deferred: OR-001/#9*' }).Count | Should -Be 3


### PR DESCRIPTION
## Summary
- resolve global choice metadata IDs before creating choice columns
- use GUID navigation bindings for native extensions, initial table creates, and existing-table upgrades
- fail explicitly when a valid choice metadata ID cannot be resolved

## Traceability
- Stories: US-702, US-703, US-707, US-708
- Feature: #8
- ADR: `docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md`
- Live failure: [workflow run 31273173854](https://github.com/urruegg/CRMShowcase/actions/runs/31273173854)

## Evidence
- 118 Pester tests passed
- focused review finding fixed; follow-up review found no issues