### PR TITLE
fix(datamodel): query derived attribute metadata safely

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -876,20 +876,31 @@ function Test-AttributeCompatibility {
     if ($actualType -and $actualType -ne $expectedType) {
         throw "Structural type conflict for '$Owner/$($Column.logicalName)': expected $expectedType, found $actualType."
     }
-    if ($Column.type -in @('Lookup', 'Customer') -and
-        $Existing.Targets -and
-        (@($Existing.Targets | Sort-Object) -join ',') -ne
-        (@($Column.lookup.targets | Sort-Object) -join ',')) {
-        throw "Structural target conflict for '$Owner/$($Column.logicalName)'."
+    if ($Column.type -in @('Lookup', 'Customer')) {
+        if ($null -eq $Existing.Targets) {
+            throw "Incomplete typed lookup metadata for '$Owner/$($Column.logicalName)'."
+        }
+        if ((@($Existing.Targets | Sort-Object) -join ',') -ne
+            (@($Column.lookup.targets | Sort-Object) -join ',')) {
+            throw "Structural target conflict for '$Owner/$($Column.logicalName)'."
+        }
     }
-    if ($Column.type -eq 'Text' -and $Existing.MaxLength -and
-        [int]$Existing.MaxLength -lt [int]$Column.maxLength) {
-        throw "Structural length conflict for '$Owner/$($Column.logicalName)'."
+    if ($Column.type -eq 'Text') {
+        if ($null -eq $Existing.MaxLength) {
+            throw "Incomplete typed string metadata for '$Owner/$($Column.logicalName)'."
+        }
+        if ([int]$Existing.MaxLength -lt [int]$Column.maxLength) {
+            throw "Structural length conflict for '$Owner/$($Column.logicalName)'."
+        }
     }
-    if ($Column.type -eq 'GlobalChoice' -and $Existing.GlobalOptionSet -and
-        $Existing.GlobalOptionSet.Name -and
-        $Existing.GlobalOptionSet.Name -ne $Column.choice) {
-        throw "Structural choice-binding conflict for '$Owner/$($Column.logicalName)'."
+    if ($Column.type -eq 'GlobalChoice') {
+        if (-not $Existing.GlobalOptionSet -or
+            [string]::IsNullOrWhiteSpace([string]$Existing.GlobalOptionSet.Name)) {
+            throw "Incomplete typed choice metadata for '$Owner/$($Column.logicalName)'."
+        }
+        if ($Existing.GlobalOptionSet.Name -ne $Column.choice) {
+            throw "Structural choice-binding conflict for '$Owner/$($Column.logicalName)'."
+        }
     }
     if ($Column.type -in @('DateOnly', 'DateTime')) {
         $expectedBehavior = if ($Column.type -eq 'DateOnly') {
@@ -951,7 +962,7 @@ function Get-TypedAttributeMetadata {
     $escapedAttributeName = ConvertTo-ODataKeyString $Column.logicalName
     return Get-One (
         "/EntityDefinitions(LogicalName='$escapedTableName')/Attributes/" +
-        "Microsoft.Dynamics.CRM.$type?" +
+        "Microsoft.Dynamics.CRM.${type}?" +
         "`$select=MetadataId,LogicalName,SchemaName,AttributeType," +
         "DisplayName,Description,$derivedProperties&" +
         "`$filter=LogicalName eq '$escapedAttributeName'"
@@ -1304,11 +1315,16 @@ function Invoke-TableReconciliation {
                 if ($base.Count -eq 1 -and $actual.Count -eq 0) {
                     throw "Structural type conflict for '$($Table.logicalName)/$($column.logicalName)': base metadata exists but typed metadata is unavailable."
                 }
-                if ($base.Count -eq 1 -and $actual.Count -eq 1 -and
-                    $base[0].MetadataId -and $actual[0].MetadataId -and
-                    [string]$base[0].MetadataId -ne
-                    [string]$actual[0].MetadataId) {
-                    throw "Structural metadata conflict for '$($Table.logicalName)/$($column.logicalName)': base and typed metadata IDs differ."
+                if ($base.Count -eq 1 -and $actual.Count -eq 1) {
+                    foreach ($property in 'MetadataId', 'LogicalName', 'SchemaName',
+                        'AttributeType') {
+                        if ($null -eq $base[0].$property -or
+                            $null -eq $actual[0].$property -or
+                            [string]$base[0].$property -ne
+                            [string]$actual[0].$property) {
+                            throw "Structural metadata conflict for '$($Table.logicalName)/$($column.logicalName)': base and typed '$property' values differ or are incomplete."
+                        }
+                    }
                 }
             } else {
                 $actual = $base

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -924,6 +924,40 @@ function Get-PicklistAttributeMetadata {
     )
 }
 
+function Get-TypedAttributeMetadata {
+    param(
+        [Parameter(Mandatory)] [string]$TableLogicalName,
+        [Parameter(Mandatory)] $Column
+    )
+    if ($Column.type -eq 'GlobalChoice') {
+        return Get-PicklistAttributeMetadata $TableLogicalName $Column.logicalName
+    }
+    $type = @{
+        Text = 'StringAttributeMetadata'
+        DateOnly = 'DateTimeAttributeMetadata'
+        DateTime = 'DateTimeAttributeMetadata'
+        Lookup = 'LookupAttributeMetadata'
+    }[$Column.type]
+    $derivedProperties = @{
+        Text = 'MaxLength'
+        DateOnly = 'Format,DateTimeBehavior'
+        DateTime = 'Format,DateTimeBehavior'
+        Lookup = 'Targets'
+    }[$Column.type]
+    if (-not $type) {
+        throw "Unsupported typed metadata query for '$($Column.type)' column '$($Column.logicalName)'."
+    }
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    $escapedAttributeName = ConvertTo-ODataKeyString $Column.logicalName
+    return Get-One (
+        "/EntityDefinitions(LogicalName='$escapedTableName')/Attributes/" +
+        "Microsoft.Dynamics.CRM.$type?" +
+        "`$select=MetadataId,LogicalName,SchemaName,AttributeType," +
+        "DisplayName,Description,$derivedProperties&" +
+        "`$filter=LogicalName eq '$escapedAttributeName'"
+    )
+}
+
 function Invoke-NativeExtensionReconciliation {
     param($Extension)
     $existing = Get-PicklistAttributeMetadata $Extension.table `
@@ -1190,7 +1224,7 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
 
 function Invoke-TableReconciliation {
     param($Table)
-    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,Targets,MaxLength,Format,DateTimeBehavior,DisplayName,Description),OneToManyRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
+    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),OneToManyRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
     if ($null -eq $existing) {
         $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
         Invoke-PlannedRequest (
@@ -1248,30 +1282,36 @@ function Invoke-TableReconciliation {
         }
         foreach ($column in $Table.columns) {
             if ($column.type -eq 'Customer') { continue }
-            if ($column.type -eq 'GlobalChoice') {
-                $typedChoice = Get-PicklistAttributeMetadata $Table.logicalName `
-                    $column.logicalName
-                $actual = @($typedChoice)
+            $base = @($existing.Attributes |
+                Where-Object LogicalName -eq $column.logicalName)
+            if ($base.Count -gt 1) {
+                throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
+            }
+            $needsTypedMetadata = $column.type -eq 'GlobalChoice' -or
+                ($base.Count -eq 1 -and (
+                    ($column.type -eq 'Text' -and $null -eq $base[0].MaxLength) -or
+                    ($column.type -in @('DateOnly', 'DateTime') -and
+                        ($null -eq $base[0].Format -or
+                            $null -eq $base[0].DateTimeBehavior)) -or
+                    ($column.type -eq 'Lookup' -and $null -eq $base[0].Targets)
+                ))
+            if ($needsTypedMetadata) {
+                $typed = Get-TypedAttributeMetadata $Table.logicalName $column
+                $actual = @($typed)
                 if ($actual.Count -eq 1 -and $null -eq $actual[0]) {
                     $actual = @()
                 }
-                $baseChoice = @($existing.Attributes |
-                    Where-Object LogicalName -eq $column.logicalName)
-                if ($baseChoice.Count -gt 1) {
-                    throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
+                if ($base.Count -eq 1 -and $actual.Count -eq 0) {
+                    throw "Structural type conflict for '$($Table.logicalName)/$($column.logicalName)': base metadata exists but typed metadata is unavailable."
                 }
-                if ($baseChoice.Count -eq 1 -and $actual.Count -eq 0) {
-                    throw "Structural type conflict for '$($Table.logicalName)/$($column.logicalName)': base metadata exists but typed Picklist metadata is unavailable."
-                }
-                if ($baseChoice.Count -eq 1 -and $actual.Count -eq 1 -and
-                    $baseChoice[0].MetadataId -and $actual[0].MetadataId -and
-                    [string]$baseChoice[0].MetadataId -ne
+                if ($base.Count -eq 1 -and $actual.Count -eq 1 -and
+                    $base[0].MetadataId -and $actual[0].MetadataId -and
+                    [string]$base[0].MetadataId -ne
                     [string]$actual[0].MetadataId) {
                     throw "Structural metadata conflict for '$($Table.logicalName)/$($column.logicalName)': base and typed metadata IDs differ."
                 }
             } else {
-                $actual = @($existing.Attributes |
-                    Where-Object LogicalName -eq $column.logicalName)
+                $actual = $base
             }
             if ($actual.Count -eq 0) {
                 if ($column.type -in @('Lookup', 'Customer')) {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -851,22 +851,11 @@ Describe 'Insurance Foundation reconciliation' {
                         [pscustomobject]@{
                             MetadataId = "compatible-$($_.logicalName)"
                             LogicalName = $_.logicalName
+                            SchemaName = $_.schemaName
                             AttributeType = @{
                                 Text='String'; Lookup='Lookup'; GlobalChoice='Picklist'
                                 DateOnly='DateTime'; DateTime='DateTime'; Customer='Customer'
                             }[$_.type]
-                            Targets = @($_.lookup.targets)
-                            MaxLength = $_.maxLength
-                            DateTimeBehavior = $(if ($_.type -eq 'DateOnly') {
-                                @{ Value = 'DateOnly' }
-                            } elseif ($_.type -eq 'DateTime') {
-                                @{ Value = 'TimeZoneIndependent' }
-                            })
-                            Format = $(if ($_.type -eq 'DateOnly') {
-                                'DateOnly'
-                            } elseif ($_.type -eq 'DateTime') {
-                                'DateAndTime'
-                            })
                             DisplayName = ConvertTo-LocalizedLabel $_.metadata.label
                             Description = ConvertTo-LocalizedLabel $_.metadata.description
                         }
@@ -892,6 +881,38 @@ Describe 'Insurance Foundation reconciliation' {
                 }) }
             }
             if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.(String|DateTime|Lookup)AttributeMetadata') {
+                $typeName = $Matches[1]
+                $logicalName = [regex]::Match(
+                    $Path, "LogicalName eq '([^']+)'"
+                ).Groups[1].Value
+                $column = $table.columns |
+                    Where-Object logicalName -eq $logicalName
+                $attributeType = @{
+                    String='String'; DateTime='DateTime'; Lookup='Lookup'
+                }[$typeName]
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId="compatible-$($column.logicalName)"
+                    LogicalName=$column.logicalName
+                    SchemaName=$column.schemaName
+                    AttributeType=$attributeType
+                    Targets=@($column.lookup.targets)
+                    MaxLength=$column.maxLength
+                    DateTimeBehavior=$(if ($column.type -eq 'DateOnly') {
+                        @{ Value='DateOnly' }
+                    } elseif ($column.type -eq 'DateTime') {
+                        @{ Value='TimeZoneIndependent' }
+                    })
+                    Format=$(if ($column.type -eq 'DateOnly') {
+                        'DateOnly'
+                    } elseif ($column.type -eq 'DateTime') {
+                        'DateAndTime'
+                    })
+                    DisplayName=ConvertTo-LocalizedLabel $column.metadata.label
+                    Description=ConvertTo-LocalizedLabel $column.metadata.description
+                }) }
+            }
+            if ($Method -eq 'GET' -and
                 $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
                 return [pscustomobject]@{ value = @() }
             }
@@ -911,6 +932,10 @@ Describe 'Insurance Foundation reconciliation' {
             $_.Method -eq 'GET' -and
             $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?'
         }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.(?:String|DateTime|Lookup)AttributeMetadata\?'
+        }).Count | Should -Be 7
     }
 
     It 'binds a missing choice column on an existing table by metadata ID' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -435,6 +435,14 @@ Describe 'Insurance Foundation reconciliation' {
             Should -Be @('Global')
         @($created | Where-Object Path -eq '/savedqueries').Body.layoutxml |
             Should -Match 'object="10427"'
+        $tableMetadataReads = @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -like '/EntityDefinitions?*' -and
+            $_.Path -match '\$expand=Attributes'
+        })
+        $tableMetadataReads.Count | Should -Be 3
+        $tableMetadataReads.Path |
+            Should -Not -Match 'Targets|MaxLength|DateTimeBehavior|Format'
         $choiceBindings = @(
             $created |
                 Where-Object Path -match '/Attributes$' |


### PR DESCRIPTION
## Summary
- keep expanded table attributes on valid base metadata properties
- query String, DateTime, Lookup, and Picklist metadata through typed endpoints
- fail closed when base and typed metadata disagree or are incomplete

## Traceability
- Stories: US-703, US-704, US-705, US-706, US-707, US-708
- Feature: #8
- ADR: `docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md`
- Live failure: [workflow run 31273981628](https://github.com/urruegg/CRMShowcase/actions/runs/31273981628)

## Evidence
- 118 Pester tests passed
- all review findings corrected; follow-up review found no issues