### PR TITLE
fix(datamodel): publish tables before dependent metadata

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1233,6 +1233,25 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
     }
 }
 
+function Publish-TableMetadata {
+    param([Parameter(Mandatory)] $Table)
+    $escapedLogicalName = [System.Security.SecurityElement]::Escape(
+        [string]$Table.logicalName
+    )
+    Invoke-PlannedRequest ([pscustomobject]@{
+        Method = 'POST'
+        Path = '/PublishXml'
+        Solution = $Table.solution
+        Body = @{
+            ParameterXml = (
+                '<importexportxml><entities><entity>' +
+                $escapedLogicalName +
+                '</entity></entities></importexportxml>'
+            )
+        }
+    }) | Out-Null
+}
+
 function Invoke-TableReconciliation {
     param($Table)
     $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),OneToManyRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
@@ -1242,6 +1261,7 @@ function Invoke-TableReconciliation {
             Get-TableCreateRequest $Table $choiceMetadataIds
         ) | Out-Null
         Write-Output "$($Table.logicalName): Created"
+        Publish-TableMetadata $Table
 
         # Dataverse requires the global action for a polymorphic Customer lookup.
         foreach ($customer in @($Table.columns | Where-Object type -eq 'Customer')) {
@@ -1367,6 +1387,7 @@ function Invoke-TableReconciliation {
             }
         }
         Write-Output "$($Table.logicalName): Unchanged"
+        Publish-TableMetadata $Table
     }
     $objectTypeCode = Resolve-TableObjectTypeCode $Table.logicalName
     Invoke-TableChildren $Table $objectTypeCode

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1270,6 +1270,7 @@ function Invoke-TableReconciliation {
         }
     } else {
         Assert-SolutionOwnership $existing $Table.solution $Table.logicalName
+        Publish-TableMetadata $Table
         if ([string]$existing.OwnershipType -and [string]$existing.OwnershipType -ne $Table.ownership) {
             throw "Structural ownership conflict for '$($Table.logicalName)'."
         }

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1270,10 +1270,10 @@ function Invoke-TableReconciliation {
         }
     } else {
         Assert-SolutionOwnership $existing $Table.solution $Table.logicalName
-        Publish-TableMetadata $Table
         if ([string]$existing.OwnershipType -and [string]$existing.OwnershipType -ne $Table.ownership) {
             throw "Structural ownership conflict for '$($Table.logicalName)'."
         }
+        Publish-TableMetadata $Table
         foreach ($customer in @($Table.columns | Where-Object type -eq 'Customer')) {
             Invoke-ExistingCustomerRelationshipReconciliation $Table $customer `
                 -ExistingAttributes @($existing.Attributes)

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -420,6 +420,11 @@ Describe 'Insurance Foundation reconciliation' {
         $created = @($script:calls | Where-Object Method -eq 'POST')
         @($created | Where-Object Path -eq '/GlobalOptionSetDefinitions').Count | Should -Be 5
         @($created | Where-Object Path -eq '/EntityDefinitions').Count | Should -Be 3
+        @($created | Where-Object Path -eq '/PublishXml').Count | Should -Be 3
+        foreach ($publish in @($created | Where-Object Path -eq '/PublishXml')) {
+            $publish.Body.ParameterXml |
+                Should -Match '^<importexportxml><entities><entity>crmshow_[a-z]+</entity></entities></importexportxml>$'
+        }
         @($created | Where-Object Path -match "EntityDefinitions\(LogicalName='(?:account|contact)'\)/Attributes").Count |
             Should -Be 2
         @($created | Where-Object Path -match '/Keys$').Count | Should -Be 3
@@ -486,7 +491,7 @@ Describe 'Insurance Foundation reconciliation' {
         }).Count | Should -Be 3
     }
 
-    It 'creates the Customer relationship immediately after its owning table and once' {
+    It 'creates the Customer relationship after publishing its owning table and once' {
         $script:choicesExist = $true
         Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope DataModel -Confirm:$false
         $mutations = @($script:calls | Where-Object Method -ne 'GET')
@@ -500,7 +505,8 @@ Describe 'Insurance Foundation reconciliation' {
 
         }
         $tableIndex | Should -BeGreaterOrEqual 0
-        $mutations[$tableIndex + 1].Path | Should -Be '/CreateCustomerRelationships'
+        $mutations[$tableIndex + 1].Path | Should -Be '/PublishXml'
+        $mutations[$tableIndex + 2].Path | Should -Be '/CreateCustomerRelationships'
         @($mutations | Where-Object Path -eq '/CreateCustomerRelationships').Count | Should -Be 1
     }
 
@@ -722,18 +728,18 @@ Describe 'Insurance Foundation reconciliation' {
             '/GlobalOptionSetDefinitions',
             "/EntityDefinitions(LogicalName='account')/Attributes",
             "/EntityDefinitions(LogicalName='contact')/Attributes",
-            '/EntityDefinitions',
+            '/EntityDefinitions','/PublishXml',
             "/EntityDefinitions(LogicalName='crmshow_accountcontactrole')/Keys",
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/systemforms','/SetLocLabels','/SetLocLabels',
-            '/EntityDefinitions',
+            '/EntityDefinitions','/PublishXml',
             "/EntityDefinitions(LogicalName='crmshow_policyprojection')/Keys",
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/systemforms','/SetLocLabels','/SetLocLabels',
-            '/EntityDefinitions','/CreateCustomerRelationships',
+            '/EntityDefinitions','/PublishXml','/CreateCustomerRelationships',
             "/EntityDefinitions(LogicalName='crmshow_policypartyrole')/Keys",
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
@@ -936,6 +942,9 @@ Describe 'Insurance Foundation reconciliation' {
             $_.Method -eq 'GET' -and
             $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.(?:String|DateTime|Lookup)AttributeMetadata\?'
         }).Count | Should -Be 7
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
+        }).Count | Should -Be 1
     }
 
     It 'binds a missing choice column on an existing table by metadata ID' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -814,6 +814,9 @@ Describe 'Insurance Foundation reconciliation' {
     It 'throws rather than replacing a structural conflict' {
         Mock Invoke-DataverseRequest {
             param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
+            })
             if ($Method -eq 'GET' -and $Path -like "/EntityDefinitions*") {
                 return [pscustomobject]@{
                     value = @([pscustomobject]@{
@@ -833,6 +836,8 @@ Describe 'Insurance Foundation reconciliation' {
 
         { Invoke-InsuranceFoundationReconciliation -Contract $oneTable -Scope DataModel -Confirm:$false } |
             Should -Throw '*ownership*'
+        @($script:calls | Where-Object Method -ne 'GET') |
+            Should -BeNullOrEmpty
     }
 
     It 'does not recreate a compatible existing table or its lookups' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -622,8 +622,13 @@ Describe 'Insurance Foundation reconciliation' {
 
         { Invoke-TableReconciliation $table } |
             Should -Throw '*simulated interruption*'
+        $beforeRecovery = $script:calls.Count
         { Invoke-TableReconciliation $table } | Should -Not -Throw
 
+        $recoveryMutations = @($script:calls[$beforeRecovery..($script:calls.Count - 1)] |
+            Where-Object Method -ne 'GET')
+        $recoveryMutations[0].Path | Should -Be '/PublishXml'
+        $recoveryMutations[1].Path | Should -Be '/CreateCustomerRelationships'
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
         }).Count | Should -Be 1
@@ -944,7 +949,7 @@ Describe 'Insurance Foundation reconciliation' {
         }).Count | Should -Be 7
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
-        }).Count | Should -Be 1
+        }).Count | Should -Be 2
     }
 
     It 'binds a missing choice column on an existing table by metadata ID' {


### PR DESCRIPTION
## Outcome

Publishes newly created or recovered Dataverse tables before authoring dependent Customer relationships and alternate keys, allowing Sprint 3 Insurance Foundation authoring to continue in DEV.

## Traceability

- Stories: US-702 through US-706
- Issue: Relates to #8
- ADR: [ADR-0021](docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md)

## Behavior

- Uses targeted `PublishXml` for the affected table only.
- Validates solution membership and component ownership before publication.
- Publishes before interrupted-run recovery mutations and dependent metadata.
- Preserves fail-closed and idempotent reconciliation behavior.

## Evidence

- Publish-InsuranceFoundation tests: 45/45 pass
- Full Pester suite: 118/118 pass
- Focused code review: ready to proceed