### PR TITLE
fix(datamodel): read referencing relationships correctly

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1158,7 +1158,7 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
         "`$select=MetadataId,LogicalName,SchemaName,AttributeType,Targets"
     )
     $relationshipResponse = Invoke-DataverseRequest -Method GET -Path (
-        "/EntityDefinitions(LogicalName='$escapedLogicalName')/OneToManyRelationships?" +
+        "/EntityDefinitions(LogicalName='$escapedLogicalName')/ManyToOneRelationships?" +
         "`$select=MetadataId,SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute"
     )
 
@@ -1254,7 +1254,7 @@ function Publish-TableMetadata {
 
 function Invoke-TableReconciliation {
     param($Table)
-    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),OneToManyRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
+    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
     if ($null -eq $existing) {
         $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
         Invoke-PlannedRequest (
@@ -1286,7 +1286,7 @@ function Invoke-TableReconciliation {
                 ReferencedEntity = [string]$relationship.referencedTables[0]
             }
             foreach ($wanted in @($expected)) {
-                $actualRelationship = @($existing.OneToManyRelationships |
+                $actualRelationship = @($existing.ManyToOneRelationships |
                     Where-Object SchemaName -eq $wanted.SchemaName)
                 if ($actualRelationship.Count -ne 1) {
                     throw "Structural relationship conflict for '$($wanted.SchemaName)': the expected relationship is missing or ambiguous."

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -563,7 +563,7 @@ Describe 'Insurance Foundation reconciliation' {
                                 Description=ConvertTo-LocalizedLabel $_.metadata.description
                             }
                         })
-                    OneToManyRelationships=@($table.relationships |
+                    ManyToOneRelationships=@($table.relationships |
                         Where-Object authoring -eq 'InitialTableCreate' |
                         ForEach-Object {
                             [pscustomobject]@{
@@ -593,7 +593,7 @@ Describe 'Insurance Foundation reconciliation' {
                     Description=ConvertTo-LocalizedLabel $column.metadata.description
                 }) }
             }
-            if ($Method -eq 'GET' -and $Path -match '/OneToManyRelationships\?') {
+            if ($Method -eq 'GET' -and $Path -match '/ManyToOneRelationships\?') {
                 return [pscustomobject]@{ value=@() }
             }
             if ($Method -eq 'GET' -and
@@ -650,7 +650,7 @@ Describe 'Insurance Foundation reconciliation' {
                 $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.LookupAttributeMetadata') {
                 return [pscustomobject]@{ value=@() }
             }
-            if ($Method -eq 'GET' -and $Path -match '/OneToManyRelationships\?') {
+            if ($Method -eq 'GET' -and $Path -match '/ManyToOneRelationships\?') {
                 return [pscustomobject]@{ value=@([pscustomobject]@{
                     SchemaName='crmshow_PolicyPartyRole_Party_account'
                     ReferencedEntity='account'
@@ -855,7 +855,7 @@ Describe 'Insurance Foundation reconciliation' {
                     SolutionUniqueName = 'crmshow_DataModel'
                     DisplayName = ConvertTo-LocalizedLabel $table.metadata.label
                     Description = ConvertTo-LocalizedLabel $table.metadata.description
-                    OneToManyRelationships = @($table.relationships | ForEach-Object {
+                    ManyToOneRelationships = @($table.relationships | ForEach-Object {
                         [pscustomobject]@{
                             SchemaName = $_.schemaName
                             ReferencedEntity = [string]$_.referencedTables[0]
@@ -953,6 +953,10 @@ Describe 'Insurance Foundation reconciliation' {
             $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.(?:String|DateTime|Lookup)AttributeMetadata\?'
         }).Count | Should -Be 7
         @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -match '\$expand=.*ManyToOneRelationships'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
         }).Count | Should -Be 2
     }
@@ -984,7 +988,7 @@ Describe 'Insurance Foundation reconciliation' {
                     DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
                     Description=ConvertTo-LocalizedLabel $table.metadata.description
                     Attributes=@()
-                    OneToManyRelationships=@()
+                    ManyToOneRelationships=@()
                 }) }
             }
             if ($Method -eq 'GET' -and


### PR DESCRIPTION
## Outcome

Fixes the DEV authoring failure in [run 31278340901](https://github.com/urruegg/CRMShowcase/actions/runs/31278340901). Dataverse exposes relationships from the lookup-owning custom table through `ManyToOneRelationships`; the reconciliation previously queried the inverse collection and falsely reported missing metadata.

## Traceability

- Stories: US-702 through US-706
- Issue: Relates to #8
- ADR: [ADR-0021](docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md)

## Change

- Read ordinary lookup relationships from `ManyToOneRelationships`.
- Read polymorphic Customer relationship recovery metadata from the same referencing-side collection.
- Add a live-shape regression proving compatible relationships are retained and not recreated.

## Evidence

- Regression observed failing before implementation.
- Targeted authoring suite: 45/45 pass.
- Full solution suite: 118/118 pass.
- Code review: ready to proceed.