### PR TITLE
fix(datamodel): deep insert and recover lookup relationships

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -218,7 +218,7 @@ function Get-TableCreateRequest {
     )
 
     $attributes = foreach ($column in $Table.columns) {
-        if ($column.type -ne 'Customer') {
+        if ($column.type -notin @('Lookup', 'Customer')) {
             New-AttributeMetadata -Column $column `
                 -GlobalChoiceMetadataIds $GlobalChoiceMetadataIds
         }
@@ -226,18 +226,7 @@ function Get-TableCreateRequest {
     $relationships = foreach ($relationship in @($Table.relationships | Where-Object {
         $_.authoring -eq 'InitialTableCreate'
     })) {
-        @{
-            SchemaName = $relationship.schemaName
-            ReferencedEntity = [string]$relationship.referencedTables[0]
-            ReferencingEntity = $Table.logicalName
-            ReferencingAttribute = $relationship.lookupColumn
-            AssociatedMenuConfiguration = @{
-                Behavior = 'UseLabel'
-                Group = 'Details'
-                Label = ConvertTo-LocalizedLabel $relationship.metadata.label
-                Order = 10000
-            }
-        }
+        New-OrdinaryRelationshipMetadata -Table $Table -Relationship $relationship
     }
     return [pscustomobject]@{
         Method = 'POST'
@@ -259,6 +248,69 @@ function Get-TableCreateRequest {
             Attributes = @($attributes)
             OneToManyRelationships = @($relationships)
         }
+    }
+}
+
+function New-OrdinaryRelationshipMetadata {
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Relationship
+    )
+
+    $columns = @($Table.columns | Where-Object {
+        $_.logicalName -eq $Relationship.lookupColumn -and $_.type -eq 'Lookup'
+    })
+    if ($columns.Count -ne 1) {
+        throw "Relationship '$($Relationship.schemaName)' must resolve one ordinary lookup column."
+    }
+    $column = $columns[0]
+    $target = [string]$Relationship.referencedTables[0]
+    return [ordered]@{
+        '@odata.type' = 'Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata'
+        SchemaName = $Relationship.schemaName
+        ReferencedAttribute = "${target}id"
+        ReferencedEntity = $target
+        ReferencingEntity = $Table.logicalName
+        AssociatedMenuConfiguration = @{
+            Behavior = 'UseLabel'
+            Group = 'Details'
+            Label = ConvertTo-LocalizedLabel $Relationship.metadata.label
+            Order = 10000
+        }
+        CascadeConfiguration = @{
+            Assign = 'NoCascade'
+            Delete = 'Restrict'
+            Merge = 'NoCascade'
+            Reparent = 'NoCascade'
+            Share = 'NoCascade'
+            Unshare = 'NoCascade'
+        }
+        Lookup = [ordered]@{
+            '@odata.type' = 'Microsoft.Dynamics.CRM.LookupAttributeMetadata'
+            LogicalName = $column.logicalName
+            SchemaName = $column.schemaName
+            AttributeType = 'Lookup'
+            AttributeTypeName = @{ Value = 'LookupType' }
+            DisplayName = ConvertTo-LocalizedLabel $column.metadata.label
+            Description = ConvertTo-LocalizedLabel $column.metadata.description
+            RequiredLevel = ConvertTo-RequiredLevel ([bool]$column.required)
+            IsAuditEnabled = @{ Value = [bool]$column.auditing }
+        }
+    }
+}
+
+function Get-OrdinaryRelationshipRequest {
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Relationship
+    )
+
+    return [pscustomobject]@{
+        Method = 'POST'
+        Path = '/RelationshipDefinitions'
+        Solution = $Table.solution
+        Body = New-OrdinaryRelationshipMetadata -Table $Table `
+            -Relationship $Relationship
     }
 }
 
@@ -1274,6 +1326,7 @@ function Invoke-TableReconciliation {
             throw "Structural ownership conflict for '$($Table.logicalName)'."
         }
         Publish-TableMetadata $Table
+        $createdOrdinaryLookups = @{}
         foreach ($customer in @($Table.columns | Where-Object type -eq 'Customer')) {
             Invoke-ExistingCustomerRelationshipReconciliation $Table $customer `
                 -ExistingAttributes @($existing.Attributes)
@@ -1285,11 +1338,24 @@ function Invoke-TableReconciliation {
                 SchemaName = $relationship.schemaName
                 ReferencedEntity = [string]$relationship.referencedTables[0]
             }
+            $attributeCandidates = @($existing.Attributes | Where-Object {
+                $_.LogicalName -eq $relationship.lookupColumn
+            })
             foreach ($wanted in @($expected)) {
                 $actualRelationship = @($existing.ManyToOneRelationships |
                     Where-Object SchemaName -eq $wanted.SchemaName)
-                if ($actualRelationship.Count -ne 1) {
-                    throw "Structural relationship conflict for '$($wanted.SchemaName)': the expected relationship is missing or ambiguous."
+                if ($actualRelationship.Count -eq 0 -and
+                    $attributeCandidates.Count -eq 0) {
+                    Invoke-PlannedRequest (
+                        Get-OrdinaryRelationshipRequest $Table $relationship
+                    ) | Out-Null
+                    $createdOrdinaryLookups[$relationship.lookupColumn] = $true
+                    Write-Output "$($Table.logicalName)/$($relationship.lookupColumn): Created"
+                    continue
+                }
+                if ($actualRelationship.Count -ne 1 -or
+                    $attributeCandidates.Count -ne 1) {
+                    throw "Structural relationship conflict for '$($wanted.SchemaName)': relationship and lookup metadata must both be wholly present or wholly absent."
                 }
                 $actualRelationship = $actualRelationship[0]
                 if (($actualRelationship.ReferencedEntity -and
@@ -1314,6 +1380,7 @@ function Invoke-TableReconciliation {
         }
         foreach ($column in $Table.columns) {
             if ($column.type -eq 'Customer') { continue }
+            if ($createdOrdinaryLookups.ContainsKey($column.logicalName)) { continue }
             $base = @($existing.Attributes |
                 Where-Object LogicalName -eq $column.logicalName)
             if ($base.Count -gt 1) {

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1358,12 +1358,21 @@ function Invoke-TableReconciliation {
                     throw "Structural relationship conflict for '$($wanted.SchemaName)': relationship and lookup metadata must both be wholly present or wholly absent."
                 }
                 $actualRelationship = $actualRelationship[0]
-                if (($actualRelationship.ReferencedEntity -and
-                    $actualRelationship.ReferencedEntity -ne $wanted.ReferencedEntity) -or
-                    ($actualRelationship.ReferencingEntity -and
-                    $actualRelationship.ReferencingEntity -ne $Table.logicalName) -or
-                    ($actualRelationship.ReferencingAttribute -and
-                    $actualRelationship.ReferencingAttribute -ne $relationship.lookupColumn)) {
+                if ([string]::IsNullOrWhiteSpace(
+                        [string]$actualRelationship.ReferencedEntity
+                    ) -or
+                    [string]$actualRelationship.ReferencedEntity -ne
+                        $wanted.ReferencedEntity -or
+                    [string]::IsNullOrWhiteSpace(
+                        [string]$actualRelationship.ReferencingEntity
+                    ) -or
+                    [string]$actualRelationship.ReferencingEntity -ne
+                        $Table.logicalName -or
+                    [string]::IsNullOrWhiteSpace(
+                        [string]$actualRelationship.ReferencingAttribute
+                    ) -or
+                    [string]$actualRelationship.ReferencingAttribute -ne
+                        $relationship.lookupColumn) {
                     throw "Structural relationship target conflict for '$($wanted.SchemaName)'."
                 }
                 $expectedCascade = @{

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1306,7 +1306,7 @@ function Publish-TableMetadata {
 
 function Invoke-TableReconciliation {
     param($Table)
-    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute)&`$filter=LogicalName eq '$($Table.logicalName)'"
+    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration)&`$filter=LogicalName eq '$($Table.logicalName)'"
     if ($null -eq $existing) {
         $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
         Invoke-PlannedRequest (
@@ -1365,6 +1365,16 @@ function Invoke-TableReconciliation {
                     ($actualRelationship.ReferencingAttribute -and
                     $actualRelationship.ReferencingAttribute -ne $relationship.lookupColumn)) {
                     throw "Structural relationship target conflict for '$($wanted.SchemaName)'."
+                }
+                $expectedCascade = @{
+                    Assign='NoCascade'; Delete='Restrict'; Merge='NoCascade'
+                    Reparent='NoCascade'; Share='NoCascade'; Unshare='NoCascade'
+                }
+                foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
+                    if ([string]$actualRelationship.CascadeConfiguration.$action -ne
+                        [string]$expectedCascade[$action]) {
+                        throw "Structural relationship cascade conflict for '$($wanted.SchemaName)': '$action' must be '$($expectedCascade[$action])'."
+                    }
                 }
             }
         }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -110,15 +110,18 @@ Describe 'Insurance Foundation request builders' {
         }
     }
 
-    It 'puts every ordinary lookup in the initial table create' {
+    It 'deep inserts every ordinary lookup relationship in the initial table create' {
         $table = $script:contract.tables[0]
         $request = Get-TableCreateRequest -Table $table
         @($request.Body.Attributes |
-            Where-Object { $_.'@odata.type' -eq 'Microsoft.Dynamics.CRM.LookupAttributeMetadata' } |
-            ForEach-Object LogicalName) |
-            Should -Be @('crmshow_accountid', 'crmshow_contactid')
+            Where-Object { $_.'@odata.type' -eq 'Microsoft.Dynamics.CRM.LookupAttributeMetadata' }) |
+            Should -BeNullOrEmpty
         @($request.Body.OneToManyRelationships.ReferencingAttribute) |
+            Should -BeNullOrEmpty
+        @($request.Body.OneToManyRelationships.Lookup.LogicalName) |
             Should -Be @('crmshow_accountid', 'crmshow_contactid')
+        @($request.Body.OneToManyRelationships.Lookup.Targets) |
+            Should -BeNullOrEmpty
     }
 
     It 'marks only crmshow_name as primary name on every custom table create' {
@@ -959,6 +962,58 @@ Describe 'Insurance Foundation reconciliation' {
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
         }).Count | Should -Be 2
+    }
+
+    It 'recovers wholly absent ordinary lookup relationships on an existing table' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object type -eq 'Lookup')
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
+            })
+            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId='existing-table'
+                    LogicalName=$table.logicalName
+                    OwnershipType=$table.ownership
+                    SolutionUniqueName=$table.solution
+                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
+                    Description=ConvertTo-LocalizedLabel $table.metadata.description
+                    Attributes=@()
+                    ManyToOneRelationships=@()
+                }) }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.LookupAttributeMetadata') {
+                return [pscustomobject]@{ value=@() }
+            }
+            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
+                return [pscustomobject]@{ ObjectTypeCode=10427 }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $creates = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        })
+        $creates.Count | Should -Be 2
+        @($creates.Body.Lookup.LogicalName) |
+            Should -Be @('crmshow_accountid', 'crmshow_contactid')
+        @($creates.Body.SchemaName) |
+            Should -Be @(
+                'crmshow_Account_AccountContactRoles',
+                'crmshow_Contact_AccountContactRoles'
+            )
     }
 
     It 'binds a missing choice column on an existing table by metadata ID' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -574,6 +574,11 @@ Describe 'Insurance Foundation reconciliation' {
                                 ReferencedEntity=[string]$_.referencedTables[0]
                                 ReferencingEntity=$table.logicalName
                                 ReferencingAttribute=$_.lookupColumn
+                                CascadeConfiguration=[pscustomobject]@{
+                                    Assign='NoCascade'; Delete='Restrict'
+                                    Merge='NoCascade'; Reparent='NoCascade'
+                                    Share='NoCascade'; Unshare='NoCascade'
+                                }
                             }
                         })
                 }) }
@@ -864,6 +869,11 @@ Describe 'Insurance Foundation reconciliation' {
                             ReferencedEntity = [string]$_.referencedTables[0]
                             ReferencingEntity = $table.logicalName
                             ReferencingAttribute = $_.lookupColumn
+                            CascadeConfiguration = [pscustomobject]@{
+                                Assign='NoCascade'; Delete='Restrict'
+                                Merge='NoCascade'; Reparent='NoCascade'
+                                Share='NoCascade'; Unshare='NoCascade'
+                            }
                         }
                     })
                     Attributes = @($table.columns | ForEach-Object {
@@ -1014,6 +1024,82 @@ Describe 'Insurance Foundation reconciliation' {
                 'crmshow_Account_AccountContactRoles',
                 'crmshow_Contact_AccountContactRoles'
             )
+    }
+
+    It 'rejects destructive cascade behavior on an existing ordinary relationship' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object type -eq 'Lookup')
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId='existing-table'
+                    LogicalName=$table.logicalName
+                    OwnershipType=$table.ownership
+                    SolutionUniqueName=$table.solution
+                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
+                    Description=ConvertTo-LocalizedLabel $table.metadata.description
+                    Attributes=@($table.columns | ForEach-Object {
+                        [pscustomobject]@{
+                            MetadataId="attribute-$($_.logicalName)"
+                            LogicalName=$_.logicalName
+                            SchemaName=$_.schemaName
+                            AttributeType='Lookup'
+                            DisplayName=ConvertTo-LocalizedLabel $_.metadata.label
+                            Description=ConvertTo-LocalizedLabel $_.metadata.description
+                        }
+                    })
+                    ManyToOneRelationships=@($table.relationships | ForEach-Object {
+                        [pscustomobject]@{
+                            SchemaName=$_.schemaName
+                            ReferencedEntity=[string]$_.referencedTables[0]
+                            ReferencingEntity=$table.logicalName
+                            ReferencingAttribute=$_.lookupColumn
+                            CascadeConfiguration=[pscustomobject]@{
+                                Assign='NoCascade'; Delete='Cascade'
+                                Merge='NoCascade'; Reparent='NoCascade'
+                                Share='NoCascade'; Unshare='NoCascade'
+                            }
+                        }
+                    })
+                }) }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.LookupAttributeMetadata') {
+                $logicalName = [regex]::Match(
+                    $Path, "LogicalName eq '([^']+)'"
+                ).Groups[1].Value
+                $column = $table.columns |
+                    Where-Object logicalName -eq $logicalName
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId="attribute-$($column.logicalName)"
+                    LogicalName=$column.logicalName
+                    SchemaName=$column.schemaName
+                    AttributeType='Lookup'
+                    Targets=@($column.lookup.targets)
+                    DisplayName=ConvertTo-LocalizedLabel $column.metadata.label
+                    Description=ConvertTo-LocalizedLabel $column.metadata.description
+                }) }
+            }
+            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
+                return [pscustomobject]@{ ObjectTypeCode=10427 }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value=@() }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        { Invoke-TableReconciliation $table } |
+            Should -Throw '*cascade conflict*Delete*'
     }
 
     It 'binds a missing choice column on an existing table by metadata ID' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1102,6 +1102,78 @@ Describe 'Insurance Foundation reconciliation' {
             Should -Throw '*cascade conflict*Delete*'
     }
 
+    It 'rejects incomplete ordinary relationship endpoint metadata' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object type -eq 'Lookup')
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId='existing-table'
+                    LogicalName=$table.logicalName
+                    OwnershipType=$table.ownership
+                    SolutionUniqueName=$table.solution
+                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
+                    Description=ConvertTo-LocalizedLabel $table.metadata.description
+                    Attributes=@($table.columns | ForEach-Object {
+                        [pscustomobject]@{
+                            MetadataId="attribute-$($_.logicalName)"
+                            LogicalName=$_.logicalName
+                            SchemaName=$_.schemaName
+                            AttributeType='Lookup'
+                        }
+                    })
+                    ManyToOneRelationships=@($table.relationships | ForEach-Object {
+                        [pscustomobject]@{
+                            SchemaName=$_.schemaName
+                            ReferencedEntity=$null
+                            ReferencingEntity=$table.logicalName
+                            ReferencingAttribute=$_.lookupColumn
+                            CascadeConfiguration=[pscustomobject]@{
+                                Assign='NoCascade'; Delete='Restrict'
+                                Merge='NoCascade'; Reparent='NoCascade'
+                                Share='NoCascade'; Unshare='NoCascade'
+                            }
+                        }
+                    })
+                }) }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.LookupAttributeMetadata') {
+                $logicalName = [regex]::Match(
+                    $Path, "LogicalName eq '([^']+)'"
+                ).Groups[1].Value
+                $column = $table.columns |
+                    Where-Object logicalName -eq $logicalName
+                return [pscustomobject]@{ value=@([pscustomobject]@{
+                    MetadataId="attribute-$($column.logicalName)"
+                    LogicalName=$column.logicalName
+                    SchemaName=$column.schemaName
+                    AttributeType='Lookup'
+                    Targets=@($column.lookup.targets)
+                }) }
+            }
+            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
+                return [pscustomobject]@{ ObjectTypeCode=10427 }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value=@() }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        { Invoke-TableReconciliation $table } |
+            Should -Throw '*target conflict*'
+    }
+
     It 'binds a missing choice column on an existing table by metadata ID' {
         $table = $script:contract.tables[0] |
             ConvertTo-Json -Depth 100 | ConvertFrom-Json


### PR DESCRIPTION
## Outcome

Fixes the remaining DEV authoring failure after [run 31278948823](https://github.com/urruegg/CRMShowcase/actions/runs/31278948823). Live Model Builder evidence showed the interrupted `crmshow_accountcontactrole` table contained no ordinary lookup columns.

## Root cause

Dataverse ordinary lookups must be authored as `OneToManyRelationshipMetadata` with nested `LookupAttributeMetadata`. The initial table payload placed lookup attributes separately and supplied only relationship references, so Dataverse created neither relationship nor lookup.

## Change

- Deep-insert ordinary lookup metadata for newly created tables.
- Recover existing tables only when both relationship and lookup are wholly absent.
- Reject partial, incomplete, endpoint-conflicting, or destructive-cascade metadata.
- Use restrictive `Delete=Restrict` and no-cascade behavior.

## Traceability

- Stories: US-702 through US-706
- Issue: Relates to #8
- ADR: [ADR-0021](docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md)

## Evidence

- Model Builder inspection of DEV metadata.
- Microsoft Learn Web API relationship creation contract.
- Targeted authoring suite: 48/48 pass.
- Full suite: 128/128 pass before final two regression additions; targeted suite remains green.
- Final code review: no significant issues.