### PR TITLE
fix(platform): provision Dataverse languages correctly

### DIFF
--- a/infra/scripts/Set-DataverseLanguages.ps1
+++ b/infra/scripts/Set-DataverseLanguages.ps1
@@ -3,9 +3,9 @@
     Reconcile the supported Dataverse languages for an environment.
 
 .DESCRIPTION
-    Reads LanguageLocale records and activates requested inactive languages.
-    Authentication is delegated to az rest, which acquires a runtime token for
-    the Dataverse environment. Languages are never deactivated.
+    Reads the provisioned-language list and provisions requested missing
+    languages through documented Dataverse Web API operations. Authentication
+    is delegated to az rest. Languages are never deprovisioned.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -36,24 +36,19 @@ function Get-NormalizedLocaleIds {
     return @($LocaleId | Sort-Object -Unique)
 }
 
-function Get-LanguageTransition {
+function Get-ProvisionedLocaleIds {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [int]$LocaleId,
-
-        [Parameter(Mandatory)]
-        [int]$StateCode
+        [string]$BaseUrl
     )
 
-    if ($StateCode -eq 0) {
-        return 'Unchanged'
+    $url = "$($BaseUrl.TrimEnd('/'))/api/data/v9.2/RetrieveProvisionedLanguages()"
+    $response = Invoke-DataverseRest -Method GET -Url $url
+    if ($null -eq $response.RetrieveProvisionedLanguages) {
+        throw 'RetrieveProvisionedLanguages returned no language collection.'
     }
-    if ($StateCode -eq 1) {
-        return 'Activate'
-    }
-
-    throw "Unexpected statecode '$StateCode' for locale '$LocaleId'."
+    return @($response.RetrieveProvisionedLanguages | ForEach-Object { [int]$_ })
 }
 
 function Wait-DataverseLanguage {
@@ -74,9 +69,7 @@ function Wait-DataverseLanguage {
 
     $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
     while ($true) {
-        $url = "$($BaseUrl.TrimEnd('/'))/api/data/v9.2/languagelocale?`$select=localeid,statecode&`$filter=localeid eq $LocaleId"
-        $response = Invoke-DataverseRest -Method GET -Url $url
-        if ($response.value.Count -eq 1 -and [int]$response.value[0].statecode -eq 0) {
+        if ($LocaleId -in @(Get-ProvisionedLocaleIds -BaseUrl $BaseUrl)) {
             return
         }
 
@@ -94,7 +87,7 @@ function Invoke-DataverseRest {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('GET', 'PATCH')]
+        [ValidateSet('GET', 'POST')]
         [string]$Method,
 
         [Parameter(Mandatory)]
@@ -151,43 +144,29 @@ function Invoke-DataverseLanguageReconciliation {
     )
 
     $baseUrl = $BaseUrl.TrimEnd('/')
-    $languages = foreach ($lcid in $RequiredLocaleId) {
-        $queryUrl = "$baseUrl/api/data/v9.2/languagelocale?`$select=languagelocaleid,localeid,statecode,statuscode&`$filter=localeid eq $lcid"
-        $response = Invoke-DataverseRest -Method GET -Url $queryUrl
-        if ($response.value.Count -ne 1) {
-            throw "Locale '$lcid' is unavailable in '$baseUrl'; expected exactly one LanguageLocale record."
-        }
-
-        $language = $response.value[0]
-        $transition = Get-LanguageTransition -LocaleId $lcid -StateCode ([int]$language.statecode)
-        [pscustomobject]@{
-            LocaleId         = $lcid
-            LanguageLocaleId = $language.languagelocaleid
-            Transition       = $transition
-            ShouldVerify     = $true
-        }
-    }
-
-    foreach ($language in $languages | Where-Object Transition -eq 'Activate') {
-        $target = "$baseUrl locale $($language.LocaleId)"
+    $provisioned = @(Get-ProvisionedLocaleIds -BaseUrl $baseUrl)
+    $missing = @($RequiredLocaleId | Where-Object { $_ -notin $provisioned })
+    $submitted = @()
+    foreach ($lcid in $missing) {
+        $target = "$baseUrl locale $lcid"
         if ($PSCmdlet.ShouldProcess($target, 'Activate Dataverse language')) {
-            $patchUrl = "$baseUrl/api/data/v9.2/languagelocale($($language.LanguageLocaleId))"
-            Invoke-DataverseRest -Method PATCH -Url $patchUrl -Body @{
-                statecode  = 0
-                statuscode = 1
-            } | Out-Null
-        }
-        else {
-            $language.ShouldVerify = $false
+            Invoke-DataverseRest -Method POST `
+                -Url "$baseUrl/api/data/v9.2/ProvisionLanguage" `
+                -Body @{ Language = [int]$lcid } | Out-Null
+            $submitted += $lcid
         }
     }
 
-    foreach ($language in $languages | Where-Object ShouldVerify) {
-        Wait-DataverseLanguage -BaseUrl $baseUrl -LocaleId $language.LocaleId
+    foreach ($lcid in $submitted) {
+        Wait-DataverseLanguage -BaseUrl $baseUrl -LocaleId $lcid
+    }
+
+    foreach ($lcid in $RequiredLocaleId) {
         Write-Output ([pscustomobject]@{
                 Environment = $baseUrl
-                LocaleId    = $language.LocaleId
-                State       = 'Active'
+                LocaleId    = $lcid
+                State       = if ($lcid -in $provisioned -or
+                    $lcid -in $submitted) { 'Active' } else { 'Planned' }
             })
     }
 }

--- a/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
+++ b/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
@@ -16,21 +16,6 @@ Describe 'Get-NormalizedLocaleIds' {
     }
 }
 
-Describe 'Get-LanguageTransition' {
-    It 'returns Unchanged for an active language' {
-        Get-LanguageTransition -LocaleId 1033 -StateCode 0 | Should -Be 'Unchanged'
-    }
-
-    It 'returns Activate for an inactive language' {
-        Get-LanguageTransition -LocaleId 1031 -StateCode 1 | Should -Be 'Activate'
-    }
-
-    It 'rejects an unexpected state code' {
-        { Get-LanguageTransition -LocaleId 1036 -StateCode 2 } |
-            Should -Throw -ExpectedMessage "*Unexpected statecode '2' for locale '1036'*"
-    }
-}
-
 Describe 'Wait-DataverseLanguage' {
     BeforeEach {
         $script:readCount = 0
@@ -38,32 +23,30 @@ Describe 'Wait-DataverseLanguage' {
     }
 
     It 'polls until the language is active' {
-        Mock Invoke-DataverseRest {
+        Mock Get-ProvisionedLocaleIds {
             $script:readCount++
             if ($script:readCount -eq 1) {
-                return @{ value = @(@{ localeid = 1031; statecode = 1 }) }
+                return @(1033)
             }
-            return @{ value = @(@{ localeid = 1031; statecode = 0 }) }
+            return @(1031, 1033)
         }
 
         Wait-DataverseLanguage -BaseUrl 'https://crmshowdev.crm.dynamics.com' `
             -LocaleId 1031 -TimeoutSeconds 5 -PollSeconds 1
 
-        Should -Invoke Invoke-DataverseRest -Times 2 -Exactly
+        Should -Invoke Get-ProvisionedLocaleIds -Times 2 -Exactly
         Should -Invoke Start-Sleep -Times 1 -Exactly -ParameterFilter { $Seconds -eq 1 }
     }
 
     It 'throws after its bounded timeout without real sleeping' {
-        Mock Invoke-DataverseRest {
-            return @{ value = @(@{ localeid = 1040; statecode = 1 }) }
-        }
+        Mock Get-ProvisionedLocaleIds { return @(1033) }
 
         {
             Wait-DataverseLanguage -BaseUrl 'https://orgd0d886ca.crm.dynamics.com' `
                 -LocaleId 1040 -TimeoutSeconds 0 -PollSeconds 1
         } | Should -Throw -ExpectedMessage "*Locale '1040' did not become active within 0 seconds*"
 
-        Should -Invoke Invoke-DataverseRest -Times 1 -Exactly
+        Should -Invoke Get-ProvisionedLocaleIds -Times 1 -Exactly
         Should -Invoke Start-Sleep -Times 0 -Exactly
     }
 }
@@ -72,31 +55,19 @@ Describe 'Invoke-DataverseLanguageReconciliation' {
     BeforeEach {
         $script:events = [System.Collections.Generic.List[string]]::new()
 
+        Mock Get-ProvisionedLocaleIds {
+            [void]$script:events.Add('GET:PROVISIONED')
+            return @(1033)
+        }
         Mock Invoke-DataverseRest {
-            if ($Method -eq 'PATCH') {
-                [void]$script:events.Add("PATCH:$Url")
-                return
-            }
-
-            $lcid = [int]([regex]::Match($Url, 'localeid eq (\d+)').Groups[1].Value)
-            [void]$script:events.Add("GET:$lcid")
-            return @{
-                value = @(
-                    @{
-                        languagelocaleid = "language-$lcid"
-                        localeid         = $lcid
-                        statecode        = 1
-                        statuscode       = 2
-                    }
-                )
-            }
+            [void]$script:events.Add("POST:$($Body.Language)")
         }
         Mock Wait-DataverseLanguage {
             [void]$script:events.Add("WAIT:$LocaleId")
         }
     }
 
-    It 'submits every inactive activation before starting the first wait' {
+    It 'provisions every missing language before starting the first wait' {
         $evidence = @(
             Invoke-DataverseLanguageReconciliation `
                 -BaseUrl 'https://crmshowdev.crm.dynamics.com' `
@@ -104,14 +75,43 @@ Describe 'Invoke-DataverseLanguageReconciliation' {
         )
 
         $script:events | Should -Be @(
-            'GET:1031'
-            'GET:1036'
-            'PATCH:https://crmshowdev.crm.dynamics.com/api/data/v9.2/languagelocale(language-1031)'
-            'PATCH:https://crmshowdev.crm.dynamics.com/api/data/v9.2/languagelocale(language-1036)'
+            'GET:PROVISIONED'
+            'POST:1031'
+            'POST:1036'
             'WAIT:1031'
             'WAIT:1036'
         )
         $evidence.LocaleId | Should -Be @(1031, 1036)
         $evidence.State | Should -Be @('Active', 'Active')
+    }
+
+    It 'does not reprovision languages returned by RetrieveProvisionedLanguages' {
+        Mock Get-ProvisionedLocaleIds { return @(1031, 1033, 1036, 1040) }
+        Mock Invoke-DataverseRest
+        Mock Wait-DataverseLanguage
+
+        Invoke-DataverseLanguageReconciliation `
+            -BaseUrl 'https://crmshowdev.crm.dynamics.com' `
+            -RequiredLocaleId @(1031, 1033, 1036, 1040) | Out-Null
+
+        Should -Invoke Invoke-DataverseRest -Times 0 -Exactly
+        Should -Invoke Wait-DataverseLanguage -Times 0 -Exactly
+    }
+
+    It 'does not provision or wait during WhatIf and preserves requested output order' {
+        Mock Get-ProvisionedLocaleIds { return @(1033) }
+        Mock Invoke-DataverseRest
+        Mock Wait-DataverseLanguage
+
+        $evidence = @(
+            Invoke-DataverseLanguageReconciliation `
+                -BaseUrl 'https://crmshowdev.crm.dynamics.com' `
+                -RequiredLocaleId @(1031, 1033) -WhatIf
+        )
+
+        Should -Invoke Invoke-DataverseRest -Times 0 -Exactly
+        Should -Invoke Wait-DataverseLanguage -Times 0 -Exactly
+        $evidence.LocaleId | Should -Be @(1031, 1033)
+        $evidence.State | Should -Be @('Planned', 'Active')
     }
 }


### PR DESCRIPTION
## Outcome

Fixes the language-readiness root cause exposed by [DEV run 31280515688](https://github.com/urruegg/CRMShowcase/actions/runs/31280515688), where relationship metadata rejected German LCID 1031.

## Root cause

The `LanguageLocale` table is a locale catalogue; its `statecode` did not prove a language was provisioned in the organization. The prior control therefore falsely reported EN/DE/FR/IT as active.

## Change

- Read actual state through documented `RetrieveProvisionedLanguages()`.
- Provision missing LCIDs through documented `ProvisionLanguage`.
- Poll the provisioned-language function with a bounded timeout.
- Preserve missing-only idempotency, `-WhatIf` behavior, and requested output ordering.

## Traceability

- Story: US-701
- Issue: Relates to #8
- ADR: [ADR-0021](docs/adr/ADR-0021-multilingual-semantic-dataverse-metadata.md)

## Evidence

- Targeted language tests: 7/7 pass.
- Combined infra and solution suite: 128/128 pass.
- Final review: no significant issues.