### PR TITLE
fix(platform): provision Dataverse languages asynchronously

### DIFF
--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -42,7 +42,8 @@ jobs:
           $root = $env:GITHUB_WORKSPACE
           $targeted = Invoke-Pester -Path @(
             (Join-Path $root 'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'),
-            (Join-Path $root 'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1')
+            (Join-Path $root 'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'),
+            (Join-Path $root 'infra/scripts/tests/Set-DataverseLanguages.Tests.ps1')
           ) -PassThru -Output Detailed
           if ($targeted.Result -ne 'Passed') { throw 'Targeted authoring tests failed.' }
           $full = Invoke-Pester -Path (Join-Path $root 'scripts/solution/tests') `

--- a/infra/scripts/Set-DataverseLanguages.ps1
+++ b/infra/scripts/Set-DataverseLanguages.ps1
@@ -151,7 +151,7 @@ function Invoke-DataverseLanguageReconciliation {
         $target = "$baseUrl locale $lcid"
         if ($PSCmdlet.ShouldProcess($target, 'Activate Dataverse language')) {
             Invoke-DataverseRest -Method POST `
-                -Url "$baseUrl/api/data/v9.2/ProvisionLanguage" `
+                -Url "$baseUrl/api/data/v9.2/ProvisionLanguageAsync" `
                 -Body @{ Language = [int]$lcid } | Out-Null
             $submitted += $lcid
         }

--- a/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
+++ b/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
@@ -60,7 +60,8 @@ Describe 'Invoke-DataverseLanguageReconciliation' {
             return @(1033)
         }
         Mock Invoke-DataverseRest {
-            [void]$script:events.Add("POST:$($Body.Language)")
+            [void]$script:events.Add("POST:${Url}:$($Body.Language)")
+            return @{ AsyncOperationId = '11111111-1111-1111-1111-111111111111' }
         }
         Mock Wait-DataverseLanguage {
             [void]$script:events.Add("WAIT:$LocaleId")
@@ -76,8 +77,8 @@ Describe 'Invoke-DataverseLanguageReconciliation' {
 
         $script:events | Should -Be @(
             'GET:PROVISIONED'
-            'POST:1031'
-            'POST:1036'
+            'POST:https://crmshowdev.crm.dynamics.com/api/data/v9.2/ProvisionLanguageAsync:1031'
+            'POST:https://crmshowdev.crm.dynamics.com/api/data/v9.2/ProvisionLanguageAsync:1036'
             'WAIT:1031'
             'WAIT:1036'
         )

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1640,4 +1640,13 @@ function pac { throw 'pac was called' }
         $tests | Should -BeLessThan $auth
         $tests | Should -BeLessThan $languages
     }
+
+    It 'runs the Dataverse language tests before mutating the environment' {
+        $workflow = Get-Content (Join-Path $script:repoRoot `
+            '.github/workflows/solution-author-dev.yml') -Raw
+
+        $expected = [regex]::Escape(
+            "(Join-Path `$root 'infra/scripts/tests/Set-DataverseLanguages.Tests.ps1')")
+        $workflow | Should -Match $expected
+    }
 }


### PR DESCRIPTION
## Summary
- replace synchronous `ProvisionLanguage` with documented `ProvisionLanguageAsync`
- retain condition-based polling through `RetrieveProvisionedLanguages`
- execute the language regression in the DEV authoring pre-mutation gate

## Evidence
- 129 Pester tests passed across `scripts/solution/tests` and `infra/scripts/tests`
- reproduces run 31281131444, which was cancelled after six hours inside synchronous language provisioning

## Traceability
- Refs #8
- US-701
- ADR-0017
- ADR-0021