### PR TITLE
fix(dataverse): query supported saved-query metadata

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -758,9 +758,13 @@ function Assert-SolutionOwnership {
         $Existing.SolutionUniqueName -and $Existing.SolutionUniqueName -ne $Expected) {
         throw "Structural ownership conflict for '$Component': expected '$Expected', found '$($Existing.SolutionUniqueName)'."
     }
-    if ($Existing.MetadataId -and
+    $componentId = if ($Existing.MetadataId) {
+        ([string]$Existing.MetadataId).Trim('{}')
+    } elseif ($Existing.savedqueryid) {
+        ([string]$Existing.savedqueryid).Trim('{}')
+    }
+    if ($componentId -and
         $Existing.PSObject.Properties.Name -notcontains 'SolutionUniqueName') {
-        $componentId = ([string]$Existing.MetadataId).Trim('{}')
         $membership = Invoke-DataverseRequest -Method GET -Path (
             "/solutioncomponents?`$select=solutioncomponentid&" +
             "`$filter=objectid eq $componentId&" +
@@ -1140,7 +1144,7 @@ function Invoke-TableChildren {
         Write-Output "$($Table.logicalName)/$($rule.name): Deferred: OR-001/#9"
         $ruleLabel = ([string]$rule.metadata.label.'1033').Replace("'", "''")
         Invoke-ChildRequestIfMissing `
-            -QueryPath "/savedqueries?`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml,_solutionid_value&`$filter=name eq '$ruleLabel' and returnedtypecode eq '$($Table.logicalName)'" `
+            -QueryPath "/savedqueries?`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml&`$filter=name eq '$ruleLabel' and returnedtypecode eq '$($Table.logicalName)'" `
             -Request ($ruleRequest = New-InvalidDateViewRequest $Table $rule $ObjectTypeCode) `
             -Component "$($Table.logicalName)/$($rule.name)report" `
             -AssertCompatible {
@@ -1155,7 +1159,7 @@ function Invoke-TableChildren {
     foreach ($view in $Table.views) {
         $viewLabel = ([string]$view.metadata.label.'1033').Replace("'", "''")
         Invoke-ChildRequestIfMissing `
-            -QueryPath "/savedqueries?`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml,_solutionid_value&`$filter=name eq '$viewLabel' and returnedtypecode eq '$($Table.logicalName)'" `
+            -QueryPath "/savedqueries?`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml&`$filter=name eq '$viewLabel' and returnedtypecode eq '$($Table.logicalName)'" `
             -Request ($viewRequest = New-ViewRequest $Table $view $ObjectTypeCode) `
             -Component "$($Table.logicalName)/$($view.name)" `
             -AssertCompatible {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -471,6 +471,37 @@ Describe 'Insurance Foundation reconciliation' {
         )
     }
 
+    It 'queries saved queries only through supported Web API properties' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope All -Confirm:$false
+
+        $savedQueryReads = @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and $_.Path -match '^/savedqueries\?'
+        })
+        $savedQueryReads.Count | Should -BeGreaterThan 0
+        @($savedQueryReads.Path | Where-Object { $_ -match '_solutionid_value' }) |
+            Should -BeNullOrEmpty
+    }
+
+    It 'verifies saved-query ownership through solution component membership' {
+        Mock Invoke-DataverseRequest {
+            return [pscustomobject]@{
+                value = @([pscustomobject]@{
+                    solutionid = [pscustomobject]@{ uniquename = 'crmshow_DataModel' }
+                })
+            }
+        }
+
+        Assert-SolutionOwnership `
+            ([pscustomobject]@{ savedqueryid = '11111111-1111-1111-1111-111111111111' }) `
+            'crmshow_DataModel' 'existing view'
+
+        Should -Invoke Invoke-DataverseRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and
+            $Path -match 'solutioncomponents' -and
+            $Path -match 'objectid eq 11111111-1111-1111-1111-111111111111'
+        }
+    }
+
     It 'continues after all five choices already exist and creates schema components' {
         $script:choicesExist = $true
 
@@ -704,6 +735,15 @@ Describe 'Insurance Foundation reconciliation' {
                 $script:calls.Add([pscustomobject]@{
                     Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
                 })
+                if ($Method -eq 'GET' -and $Path -match '^/solutioncomponents\?') {
+                    return [pscustomobject]@{
+                        value = @([pscustomobject]@{
+                            solutionid = [pscustomobject]@{
+                                uniquename = $request.Solution
+                            }
+                        })
+                    }
+                }
                 if ($Method -eq 'GET') {
                     return [pscustomobject]@{ value=@($existing) }
                 }


### PR DESCRIPTION
## Summary
- remove unsupported `_solutionid_value` from `savedquery` Web API queries
- verify existing view ownership through `solutioncomponents` using `savedqueryid`
- preserve fail-closed ownership and XML compatibility checks

## Evidence
- 131 Pester tests passed across solution and infrastructure suites
- reproduces run 31296308996 error `0x80060888`

## Traceability
- Refs #8
- US-707
- ADR-0017
- ADR-0020