### PR TITLE
fix(dataverse): honor merge-enabled lookup cascades

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -280,7 +280,11 @@ function New-OrdinaryRelationshipMetadata {
         CascadeConfiguration = @{
             Assign = 'NoCascade'
             Delete = 'Restrict'
-            Merge = 'NoCascade'
+            Merge = if ($target -in @('account', 'contact')) {
+                'Cascade'
+            } else {
+                'NoCascade'
+            }
             Reparent = 'NoCascade'
             Share = 'NoCascade'
             Unshare = 'NoCascade'
@@ -1380,7 +1384,12 @@ function Invoke-TableReconciliation {
                     throw "Structural relationship target conflict for '$($wanted.SchemaName)'."
                 }
                 $expectedCascade = @{
-                    Assign='NoCascade'; Delete='Restrict'; Merge='NoCascade'
+                    Assign='NoCascade'; Delete='Restrict'
+                    Merge=$(if ($wanted.ReferencedEntity -in @('account', 'contact')) {
+                        'Cascade'
+                    } else {
+                        'NoCascade'
+                    })
                     Reparent='NoCascade'; Share='NoCascade'; Unshare='NoCascade'
                 }
                 foreach ($action in @($expectedCascade.Keys | Sort-Object)) {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -122,6 +122,12 @@ Describe 'Insurance Foundation request builders' {
             Should -Be @('crmshow_accountid', 'crmshow_contactid')
         @($request.Body.OneToManyRelationships.Lookup.Targets) |
             Should -BeNullOrEmpty
+        @($request.Body.OneToManyRelationships.CascadeConfiguration.Merge) |
+            Should -Be @('Cascade', 'Cascade')
+
+        $customTarget = New-OrdinaryRelationshipMetadata `
+            $script:contract.tables[2] $script:contract.tables[2].relationships[0]
+        $customTarget.CascadeConfiguration.Merge | Should -Be 'NoCascade'
     }
 
     It 'marks only crmshow_name as primary name on every custom table create' {
@@ -911,7 +917,7 @@ Describe 'Insurance Foundation reconciliation' {
                             ReferencingAttribute = $_.lookupColumn
                             CascadeConfiguration = [pscustomobject]@{
                                 Assign='NoCascade'; Delete='Restrict'
-                                Merge='NoCascade'; Reparent='NoCascade'
+                                Merge='Cascade'; Reparent='NoCascade'
                                 Share='NoCascade'; Unshare='NoCascade'
                             }
                         }
@@ -1103,7 +1109,7 @@ Describe 'Insurance Foundation reconciliation' {
                             ReferencingAttribute=$_.lookupColumn
                             CascadeConfiguration=[pscustomobject]@{
                                 Assign='NoCascade'; Delete='Cascade'
-                                Merge='NoCascade'; Reparent='NoCascade'
+                                Merge='Cascade'; Reparent='NoCascade'
                                 Share='NoCascade'; Unshare='NoCascade'
                             }
                         }


### PR DESCRIPTION
## Summary
- model Dataverse merge behavior explicitly for ordinary lookups
- use `Merge = Cascade` for Account and Contact targets
- retain `Merge = NoCascade` for custom-table targets and restrictive delete/share/reparent behavior

## Evidence
- 131 Pester tests passed
- reproduces run 31298073671 relationship normalization

## Traceability
- Refs #8
- US-707
- ADR-0006
- ADR-0020