### PR TITLE
fix(dataverse): recover alternate key membership

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -387,6 +387,7 @@ function Get-AlternateKeyRequest {
         Method = 'POST'
         Path = "/EntityDefinitions(LogicalName='$TableLogicalName')/Keys"
         Solution = 'crmshow_DataModel'
+        SolutionComponentType = 14
         Body = @{
             SchemaName = $SchemaName
             DisplayName = if ($Metadata) {
@@ -757,7 +758,12 @@ function Get-MergeLabelHeaders {
 }
 
 function Assert-SolutionOwnership {
-    param($Existing, [string]$Expected, [string]$Component)
+    param(
+        $Existing,
+        [string]$Expected,
+        [string]$Component,
+        [Nullable[int]]$RepairComponentType
+    )
     if ($Existing.PSObject.Properties.Name -contains 'SolutionUniqueName' -and
         $Existing.SolutionUniqueName -and $Existing.SolutionUniqueName -ne $Expected) {
         throw "Structural ownership conflict for '$Component': expected '$Expected', found '$($Existing.SolutionUniqueName)'."
@@ -778,7 +784,27 @@ function Assert-SolutionOwnership {
             if ($_.solutionid) { $_.solutionid.uniquename }
         })
         if ($Expected -notin $solutionNames) {
-            throw "Structural ownership conflict for '$Component': component is not in '$Expected'."
+            if ($null -eq $RepairComponentType) {
+                throw "Structural ownership conflict for '$Component': component is not in '$Expected'."
+            }
+            Invoke-DataverseRequest -Method POST -Path '/AddSolutionComponent' -Body @{
+                ComponentId = $componentId
+                ComponentType = [int]$RepairComponentType
+                SolutionUniqueName = $Expected
+                AddRequiredComponents = $false
+                DoNotIncludeSubcomponents = $true
+            } -Headers (Get-DataverseHeaders $Expected) | Out-Null
+            $membership = Invoke-DataverseRequest -Method GET -Path (
+                "/solutioncomponents?`$select=solutioncomponentid&" +
+                "`$filter=objectid eq $componentId&" +
+                "`$expand=solutionid(`$select=uniquename)"
+            )
+            $solutionNames = @($membership.value | ForEach-Object {
+                if ($_.solutionid) { $_.solutionid.uniquename }
+            })
+            if ($Expected -notin $solutionNames) {
+                throw "Structural ownership conflict for '$Component': repair did not add the component to '$Expected'."
+            }
         }
     }
     if ($Existing._solutionid_value) {
@@ -1077,7 +1103,8 @@ function Invoke-ChildRequestIfMissing {
         Set-RecordLocalizedFields -Request $Request -CreatedRecord $created
         Write-Output "$Component`: Created"
     } else {
-        Assert-SolutionOwnership $existing $Request.Solution $Component
+        Assert-SolutionOwnership $existing $Request.Solution $Component `
+            -RepairComponentType $Request.SolutionComponentType
         if ($AssertCompatible) { & $AssertCompatible $existing }
         if ($Request.LocalizedFields) {
             # savedquery/systemform localization cannot be expanded reliably

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -508,6 +508,41 @@ Describe 'Insurance Foundation reconciliation' {
         }
     }
 
+    It 'repairs missing alternate-key solution membership without recreating the key' {
+        $script:membershipReads = 0
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body)
+            if ($Method -eq 'GET') {
+                $script:membershipReads++
+                return [pscustomobject]@{
+                    value = if ($script:membershipReads -eq 1) {
+                        @()
+                    } else {
+                        @([pscustomobject]@{
+                            solutionid = [pscustomobject]@{
+                                uniquename = 'crmshow_DataModel'
+                            }
+                        })
+                    }
+                }
+            }
+            return [pscustomobject]@{}
+        }
+
+        Assert-SolutionOwnership `
+            ([pscustomobject]@{ MetadataId = '22222222-2222-2222-2222-222222222222' }) `
+            'crmshow_DataModel' 'existing key' -RepairComponentType 14
+
+        Should -Invoke Invoke-DataverseRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Path -eq '/AddSolutionComponent' -and
+            $Body.ComponentId -eq '22222222-2222-2222-2222-222222222222' -and
+            $Body.ComponentType -eq 14 -and
+            $Body.SolutionUniqueName -eq 'crmshow_DataModel' -and
+            $Body.AddRequiredComponents -eq $false -and
+            $Body.DoNotIncludeSubcomponents -eq $true
+        }
+    }
+
     It 'continues after all five choices already exist and creates schema components' {
         $script:choicesExist = $true
 


### PR DESCRIPTION
## Summary
- mark alternate keys as Dataverse solution component type 14
- repair missing membership for an existing structurally compatible key through `AddSolutionComponent`
- re-query membership and fail closed if repair does not persist

## Evidence
- 132 Pester tests passed
- reproduces run 31298272697 ownership failure

## Traceability
- Refs #8
- US-707
- ADR-0017
- ADR-0020