### PR TITLE
fix(dataverse): wait for component membership

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -757,6 +757,37 @@ function Get-MergeLabelHeaders {
     return $headers
 }
 
+function Wait-SolutionComponentMembership {
+    param(
+        [Parameter(Mandatory)] [string]$ComponentId,
+        [Parameter(Mandatory)] [string]$Expected,
+        [ValidateRange(0, [int]::MaxValue)] [int]$TimeoutSeconds = 600,
+        [ValidateRange(1, [int]::MaxValue)] [int]$PollSeconds = 10
+    )
+
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ($true) {
+        $membership = Invoke-DataverseRequest -Method GET -Path (
+            "/solutioncomponents?`$select=solutioncomponentid&" +
+            "`$filter=objectid eq $ComponentId&" +
+            "`$expand=solutionid(`$select=uniquename)"
+        )
+        $solutionNames = @($membership.value | ForEach-Object {
+            if ($_.solutionid) { $_.solutionid.uniquename }
+        })
+        if ($Expected -in $solutionNames) { return }
+
+        $remainingSeconds = ($deadline - [DateTimeOffset]::UtcNow).TotalSeconds
+        if ($remainingSeconds -le 0) {
+            throw "Solution component '$ComponentId' was not added to '$Expected' within $TimeoutSeconds seconds."
+        }
+        Start-Sleep -Seconds ([Math]::Min(
+            $PollSeconds,
+            [Math]::Ceiling($remainingSeconds)
+        ))
+    }
+}
+
 function Assert-SolutionOwnership {
     param(
         $Existing,
@@ -794,17 +825,8 @@ function Assert-SolutionOwnership {
                 AddRequiredComponents = $false
                 DoNotIncludeSubcomponents = $true
             } -Headers (Get-DataverseHeaders $Expected) | Out-Null
-            $membership = Invoke-DataverseRequest -Method GET -Path (
-                "/solutioncomponents?`$select=solutioncomponentid&" +
-                "`$filter=objectid eq $componentId&" +
-                "`$expand=solutionid(`$select=uniquename)"
-            )
-            $solutionNames = @($membership.value | ForEach-Object {
-                if ($_.solutionid) { $_.solutionid.uniquename }
-            })
-            if ($Expected -notin $solutionNames) {
-                throw "Structural ownership conflict for '$Component': repair did not add the component to '$Expected'."
-            }
+            Wait-SolutionComponentMembership -ComponentId $componentId `
+                -Expected $Expected
         }
     }
     if ($Existing._solutionid_value) {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -510,21 +510,11 @@ Describe 'Insurance Foundation reconciliation' {
 
     It 'repairs missing alternate-key solution membership without recreating the key' {
         $script:membershipReads = 0
+        Mock Wait-SolutionComponentMembership
         Mock Invoke-DataverseRequest {
             param($Method, $Path, $Body)
             if ($Method -eq 'GET') {
-                $script:membershipReads++
-                return [pscustomobject]@{
-                    value = if ($script:membershipReads -eq 1) {
-                        @()
-                    } else {
-                        @([pscustomobject]@{
-                            solutionid = [pscustomobject]@{
-                                uniquename = 'crmshow_DataModel'
-                            }
-                        })
-                    }
-                }
+                return [pscustomobject]@{ value = @() }
             }
             return [pscustomobject]@{}
         }
@@ -540,6 +530,39 @@ Describe 'Insurance Foundation reconciliation' {
             $Body.SolutionUniqueName -eq 'crmshow_DataModel' -and
             $Body.AddRequiredComponents -eq $false -and
             $Body.DoNotIncludeSubcomponents -eq $true
+        }
+        Should -Invoke Wait-SolutionComponentMembership -Times 1 -Exactly `
+            -ParameterFilter {
+                $ComponentId -eq '22222222-2222-2222-2222-222222222222' -and
+                $Expected -eq 'crmshow_DataModel'
+            }
+    }
+
+    It 'polls solution membership until an internal component import completes' {
+        $script:membershipReads = 0
+        Mock Start-Sleep
+        Mock Invoke-DataverseRequest {
+            $script:membershipReads++
+            return [pscustomobject]@{
+                value = if ($script:membershipReads -lt 3) {
+                    @()
+                } else {
+                    @([pscustomobject]@{
+                        solutionid = [pscustomobject]@{
+                            uniquename = 'crmshow_DataModel'
+                        }
+                    })
+                }
+            }
+        }
+
+        Wait-SolutionComponentMembership `
+            -ComponentId '33333333-3333-3333-3333-333333333333' `
+            -Expected 'crmshow_DataModel' -TimeoutSeconds 5 -PollSeconds 1
+
+        Should -Invoke Invoke-DataverseRequest -Times 3 -Exactly
+        Should -Invoke Start-Sleep -Times 2 -Exactly -ParameterFilter {
+            $Seconds -eq 1
         }
     }
 


### PR DESCRIPTION
## Summary
- wait for Dataverse solution-component membership after `AddSolutionComponent`
- use bounded condition polling rather than publishing during the internal import
- fail explicitly if membership does not converge within ten minutes

## Evidence
- 133 Pester tests passed
- reproduces run 31298608156 error `0x80071151`

## Traceability
- Refs #8
- US-707
- ADR-0017
- ADR-0020