### PR TITLE
fix(dataverse): inherit alternate key ownership

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -387,7 +387,7 @@ function Get-AlternateKeyRequest {
         Method = 'POST'
         Path = "/EntityDefinitions(LogicalName='$TableLogicalName')/Keys"
         Solution = 'crmshow_DataModel'
-        SolutionComponentType = 14
+        InheritsSolutionOwnership = $true
         Body = @{
             SchemaName = $SchemaName
             DisplayName = if ($Metadata) {
@@ -757,43 +757,11 @@ function Get-MergeLabelHeaders {
     return $headers
 }
 
-function Wait-SolutionComponentMembership {
-    param(
-        [Parameter(Mandatory)] [string]$ComponentId,
-        [Parameter(Mandatory)] [string]$Expected,
-        [ValidateRange(0, [int]::MaxValue)] [int]$TimeoutSeconds = 600,
-        [ValidateRange(1, [int]::MaxValue)] [int]$PollSeconds = 10
-    )
-
-    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
-    while ($true) {
-        $membership = Invoke-DataverseRequest -Method GET -Path (
-            "/solutioncomponents?`$select=solutioncomponentid&" +
-            "`$filter=objectid eq $ComponentId&" +
-            "`$expand=solutionid(`$select=uniquename)"
-        )
-        $solutionNames = @($membership.value | ForEach-Object {
-            if ($_.solutionid) { $_.solutionid.uniquename }
-        })
-        if ($Expected -in $solutionNames) { return }
-
-        $remainingSeconds = ($deadline - [DateTimeOffset]::UtcNow).TotalSeconds
-        if ($remainingSeconds -le 0) {
-            throw "Solution component '$ComponentId' was not added to '$Expected' within $TimeoutSeconds seconds."
-        }
-        Start-Sleep -Seconds ([Math]::Min(
-            $PollSeconds,
-            [Math]::Ceiling($remainingSeconds)
-        ))
-    }
-}
-
 function Assert-SolutionOwnership {
     param(
         $Existing,
         [string]$Expected,
-        [string]$Component,
-        [Nullable[int]]$RepairComponentType
+        [string]$Component
     )
     if ($Existing.PSObject.Properties.Name -contains 'SolutionUniqueName' -and
         $Existing.SolutionUniqueName -and $Existing.SolutionUniqueName -ne $Expected) {
@@ -815,18 +783,7 @@ function Assert-SolutionOwnership {
             if ($_.solutionid) { $_.solutionid.uniquename }
         })
         if ($Expected -notin $solutionNames) {
-            if ($null -eq $RepairComponentType) {
-                throw "Structural ownership conflict for '$Component': component is not in '$Expected'."
-            }
-            Invoke-DataverseRequest -Method POST -Path '/AddSolutionComponent' -Body @{
-                ComponentId = $componentId
-                ComponentType = [int]$RepairComponentType
-                SolutionUniqueName = $Expected
-                AddRequiredComponents = $false
-                DoNotIncludeSubcomponents = $true
-            } -Headers (Get-DataverseHeaders $Expected) | Out-Null
-            Wait-SolutionComponentMembership -ComponentId $componentId `
-                -Expected $Expected
+            throw "Structural ownership conflict for '$Component': component is not in '$Expected'."
         }
     }
     if ($Existing._solutionid_value) {
@@ -1125,8 +1082,9 @@ function Invoke-ChildRequestIfMissing {
         Set-RecordLocalizedFields -Request $Request -CreatedRecord $created
         Write-Output "$Component`: Created"
     } else {
-        Assert-SolutionOwnership $existing $Request.Solution $Component `
-            -RepairComponentType $Request.SolutionComponentType
+        if (-not $Request.InheritsSolutionOwnership) {
+            Assert-SolutionOwnership $existing $Request.Solution $Component
+        }
         if ($AssertCompatible) { & $AssertCompatible $existing }
         if ($Request.LocalizedFields) {
             # savedquery/systemform localization cannot be expanded reliably

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -508,61 +508,32 @@ Describe 'Insurance Foundation reconciliation' {
         }
     }
 
-    It 'repairs missing alternate-key solution membership without recreating the key' {
-        $script:membershipReads = 0
-        Mock Wait-SolutionComponentMembership
+    It 'inherits alternate-key ownership from the already-verified parent table' {
+        $keyRequest = Get-AlternateKeyRequest `
+            -TableLogicalName 'crmshow_accountcontactrole' `
+            -Columns @('crmshow_accountid') `
+            -SchemaName 'crmshow_testkey'
+        $keyRequest.InheritsSolutionOwnership | Should -BeTrue
+
         Mock Invoke-DataverseRequest {
-            param($Method, $Path, $Body)
-            if ($Method -eq 'GET') {
-                return [pscustomobject]@{ value = @() }
-            }
-            return [pscustomobject]@{}
-        }
-
-        Assert-SolutionOwnership `
-            ([pscustomobject]@{ MetadataId = '22222222-2222-2222-2222-222222222222' }) `
-            'crmshow_DataModel' 'existing key' -RepairComponentType 14
-
-        Should -Invoke Invoke-DataverseRequest -Times 1 -Exactly -ParameterFilter {
-            $Method -eq 'POST' -and $Path -eq '/AddSolutionComponent' -and
-            $Body.ComponentId -eq '22222222-2222-2222-2222-222222222222' -and
-            $Body.ComponentType -eq 14 -and
-            $Body.SolutionUniqueName -eq 'crmshow_DataModel' -and
-            $Body.AddRequiredComponents -eq $false -and
-            $Body.DoNotIncludeSubcomponents -eq $true
-        }
-        Should -Invoke Wait-SolutionComponentMembership -Times 1 -Exactly `
-            -ParameterFilter {
-                $ComponentId -eq '22222222-2222-2222-2222-222222222222' -and
-                $Expected -eq 'crmshow_DataModel'
-            }
-    }
-
-    It 'polls solution membership until an internal component import completes' {
-        $script:membershipReads = 0
-        Mock Start-Sleep
-        Mock Invoke-DataverseRequest {
-            $script:membershipReads++
             return [pscustomobject]@{
-                value = if ($script:membershipReads -lt 3) {
-                    @()
-                } else {
-                    @([pscustomobject]@{
-                        solutionid = [pscustomobject]@{
-                            uniquename = 'crmshow_DataModel'
-                        }
-                    })
-                }
+                value = @([pscustomobject]@{
+                    MetadataId = '22222222-2222-2222-2222-222222222222'
+                    SchemaName = 'crmshow_testkey'
+                    KeyAttributes = @('crmshow_accountid')
+                })
             }
         }
 
-        Wait-SolutionComponentMembership `
-            -ComponentId '33333333-3333-3333-3333-333333333333' `
-            -Expected 'crmshow_DataModel' -TimeoutSeconds 5 -PollSeconds 1
+        Invoke-ChildRequestIfMissing -QueryPath '/key-query' `
+            -Request $keyRequest -Component 'existing key' `
+            -AssertCompatible {
+                param($actual)
+                @($actual.KeyAttributes) | Should -Be @('crmshow_accountid')
+            }
 
-        Should -Invoke Invoke-DataverseRequest -Times 3 -Exactly
-        Should -Invoke Start-Sleep -Times 2 -Exactly -ParameterFilter {
-            $Seconds -eq 1
+        Should -Invoke Invoke-DataverseRequest -Times 0 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Path -match '^/solutioncomponents\?'
         }
     }
 


### PR DESCRIPTION
## Summary
- treat entity keys as subcomponents of an already ownership-verified table
- remove invalid standalone `AddSolutionComponent` repair and polling
- retain direct ownership validation for independently owned metadata

## Evidence
- 132 Pester tests passed
- run 31298836801 disproved standalone key membership after a ten-minute bounded wait

## Traceability
- Refs #8
- US-707
- ADR-0017
- ADR-0020