### PR TITLE
fix(dataverse): emit valid view layout XML

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -483,7 +483,7 @@ function ConvertTo-LayoutXml {
     $cells = @($View.columns | ForEach-Object {
         "<cell name=`"$_`" width=`"150`" />"
     }) -join ''
-    return "<grid name=`"resultset`" object=`"$ObjectTypeCode`" jump=`"crmshow_name`" select=`"1`" preview=`"0`"><row name=`"$($Table.logicalName)`" id=`"$($Table.logicalName)id`">$cells</row></grid>"
+    return "<grid name=`"resultset`" object=`"$ObjectTypeCode`" jump=`"crmshow_name`" select=`"1`" preview=`"0`" icon=`"1`"><row name=`"$($Table.logicalName)`" id=`"$($Table.logicalName)id`">$cells</row></grid>"
 }
 
 function New-ViewRequest {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -253,7 +253,9 @@ Describe 'Insurance Foundation request builders' {
     It 'uses the resolved custom object type code in layout XML' {
         $request = New-ViewRequest $script:contract.tables[0] `
             $script:contract.tables[0].views[0] 10427
+
         $request.Body.layoutxml | Should -Match 'object="10427"'
+        $request.Body.layoutxml | Should -Match '<grid[^>]+icon="1"'
         $request.Body.layoutxml | Should -Not -Match 'object="1"'
     }
 }


### PR DESCRIPTION
## Summary
- add the required `icon=1` attribute to generated saved-query grid layout XML
- lock the exact layout requirement in the request-builder regression suite

## Evidence
- 132 Pester tests passed
- reproduces run 31299502905 error `0x80040216`

## Traceability
- Refs #8
- US-707
- ADR-0017