### PR TITLE
fix(dataverse): generate valid overlap FetchXML

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -463,16 +463,16 @@ function ConvertTo-FetchXml {
         }
         $primaryId = "$($Table.logicalName)id"
         $sameGroup = @($groupColumns[1..($groupColumns.Count - 1)] | ForEach-Object {
-            "<condition attribute=`"$_`" operator=`"eq`" valueof=`"a.$_`" />"
+            "<condition attribute=`"$_`" operator=`"eq`" valueof=`"b.$_`" />"
         }) -join ''
-        "<link-entity name=`"$($Table.logicalName)`" from=`"$($groupColumns[0])`" to=`"$($groupColumns[0])`" alias=`"b`">" +
+        "<link-entity name=`"$($Table.logicalName)`" from=`"$($groupColumns[0])`" to=`"$($groupColumns[0])`" alias=`"b`" />" +
         "<filter type=`"and`">$sameGroup" +
-        "<condition attribute=`"$primaryId`" operator=`"gt`" valueof=`"a.$primaryId`" />" +
+        "<condition attribute=`"$primaryId`" operator=`"lt`" valueof=`"b.$primaryId`" />" +
         "<filter type=`"or`"><condition attribute=`"crmshow_validto`" operator=`"null`" />" +
-        "<condition attribute=`"crmshow_validto`" operator=`"ge`" valueof=`"a.crmshow_validfrom`" /></filter>" +
-        "<filter type=`"or`"><condition entityname=`"a`" attribute=`"crmshow_validto`" operator=`"null`" />" +
-        "<condition attribute=`"crmshow_validfrom`" operator=`"le`" valueof=`"a.crmshow_validto`" /></filter>" +
-        '</filter></link-entity>'
+        "<condition attribute=`"crmshow_validto`" operator=`"ge`" valueof=`"b.crmshow_validfrom`" /></filter>" +
+        "<filter type=`"or`"><condition entityname=`"b`" attribute=`"crmshow_validto`" operator=`"null`" />" +
+        "<condition attribute=`"crmshow_validfrom`" operator=`"le`" valueof=`"b.crmshow_validto`" /></filter>" +
+        '</filter>'
     } else { '' }
     $distinct = if ($View.purpose -eq 'OverlapReporting') { ' distinct="true"' } else { '' }
     return "<fetch version=`"1.0`"$distinct><entity name=`"$($Table.logicalName)`" alias=`"a`">$attributes$filter</entity></fetch>"

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -245,8 +245,12 @@ Describe 'Insurance Foundation request builders' {
             $fetch | Should -Match 'distinct="true"'
             $fetch | Should -Match "<link-entity name=`"$($table.logicalName)`""
             ([regex]::Matches($fetch, 'operator="null"')).Count | Should -Be 2
-            $fetch | Should -Match 'valueof="a\.crmshow_validfrom"'
-            $fetch | Should -Match 'valueof="a\.crmshow_validto"'
+            $fetch | Should -Match 'valueof="b\.crmshow_validfrom"'
+            $fetch | Should -Match 'valueof="b\.crmshow_validto"'
+            $fetch | Should -Not -Match 'valueof="a\.'
+            [xml]$document = $fetch
+            $document.fetch.entity.'link-entity'.filter |
+                Should -BeNullOrEmpty
         }
     }
 


### PR DESCRIPTION
## Summary
- move overlap comparisons to the base FetchXML entity
- reference linked self-join alias `b` through supported cross-table `valueof` syntax
- retain distinct, open-ended interval overlap semantics

## Evidence
- 132 Pester tests passed
- reproduces run 31299843885 error `0x80040303`

## Traceability
- Refs #8
- US-707
- ADR-0017