### PR TITLE
fix(dataverse): inherit table child ownership

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -490,6 +490,7 @@ function New-ViewRequest {
     param($Table, $View, [Parameter(Mandatory)] [int]$ObjectTypeCode)
     return [pscustomobject]@{
         Method = 'POST'; Path = '/savedqueries'; Solution = $Table.solution
+        InheritsSolutionOwnership = $true
         EntityLogicalName = 'savedquery'; IdProperty = 'savedqueryid'
         LocalizedFields = @{
             name = $View.metadata.label
@@ -518,6 +519,7 @@ function New-FormRequest {
     }) -join ''
     return [pscustomobject]@{
         Method = 'POST'; Path = '/systemforms'; Solution = $Table.solution
+        InheritsSolutionOwnership = $true
         EntityLogicalName = 'systemform'; IdProperty = 'formid'
         LocalizedFields = @{
             name = $Form.metadata.label

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -756,6 +756,7 @@ Describe 'Insurance Foundation reconciliation' {
             (New-FormRequest $table $table.forms[0])
         )
         foreach ($request in $requests) {
+            $request.InheritsSolutionOwnership | Should -BeTrue
             $script:calls.Clear()
             $id = if ($request.EntityLogicalName -eq 'savedquery') {
                 'existing-view'
@@ -776,15 +777,6 @@ Describe 'Insurance Foundation reconciliation' {
                 $script:calls.Add([pscustomobject]@{
                     Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
                 })
-                if ($Method -eq 'GET' -and $Path -match '^/solutioncomponents\?') {
-                    return [pscustomobject]@{
-                        value = @([pscustomobject]@{
-                            solutionid = [pscustomobject]@{
-                                uniquename = $request.Solution
-                            }
-                        })
-                    }
-                }
                 if ($Method -eq 'GET') {
                     return [pscustomobject]@{ value=@($existing) }
                 }
@@ -809,6 +801,9 @@ Describe 'Insurance Foundation reconciliation' {
                 @($repair.Body.Labels.LanguageCode) |
                     Should -Be @(1033, 1031, 1036, 1040)
             }
+            @($script:calls | Where-Object {
+                $_.Method -eq 'GET' -and $_.Path -match '^/solutioncomponents\?'
+            }) | Should -BeNullOrEmpty
         }
     }
 


### PR DESCRIPTION
## Summary
- treat saved queries and forms as subcomponents of an ownership-verified table
- preserve XML compatibility and multilingual label convergence
- retain direct ownership validation for independent components

## Evidence
- 132 Pester tests passed
- reproduces run 31300142521 saved-query ownership conflict

## Traceability
- Refs #8
- US-707
- ADR-0017
- ADR-0020