### PR TITLE
fix(dataverse): expose stale XML signatures

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1133,7 +1133,7 @@ function Assert-XmlCompatible {
     $actual = Get-XmlStructuralSignature ([string]$Existing.$Property) $Component
     $wanted = Get-XmlStructuralSignature ([string]$Request.Body.$Property) $Component
     if ($actual -ne $wanted) {
-        throw "Structural XML conflict for '$Component': existing $Property is stale."
+        throw "Structural XML conflict for '$Component': existing $Property is stale. Actual signature: $actual Wanted signature: $wanted"
     }
 }
 

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1403,6 +1403,16 @@ Describe 'Insurance Foundation reconciliation' {
         }
     }
 
+    It 'includes comparable XML signatures when existing metadata is stale' {
+        $table = $script:contract.tables[0]
+        $request = New-ViewRequest $table $table.views[0] 10427
+        $existing = [pscustomobject]@{ fetchxml = '<fetch><entity name="stale" /></fetch>' }
+
+        {
+            Assert-XmlCompatible $existing $request fetchxml 'component'
+        } | Should -Throw '*Actual signature:*name=stale*Wanted signature:*'
+    }
+
     It 'updates an empty existing choice rather than treating it as unchanged' {
         $choice = $script:contract.choices[0]
         Mock Invoke-DataverseRequest {


### PR DESCRIPTION
## Summary
- include actual and desired structural XML signatures when Dataverse metadata is stale
- retain fail-closed reconciliation behavior
- add regression coverage for actionable diagnostics

## Traceability
- Story: US-707
- ADR: ADR-0021
- Issue: #8

## Tests
- 87 targeted authoring and language tests pass locally