### PR TITLE
fix(dataverse): ignore stored saved-query ID

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1113,7 +1113,9 @@ function Get-XmlStructuralSignature {
             return '#text:' + $Node.Value
         }
         if ($Node.NodeType -ne [System.Xml.XmlNodeType]::Element) { return '' }
-        $attributes = @($Node.Attributes | Sort-Object Name | ForEach-Object {
+        $attributes = @($Node.Attributes |
+            Where-Object Name -ne 'savedqueryid' |
+            Sort-Object Name | ForEach-Object {
             "$($_.Name)=$($_.Value)"
         }) -join ';'
         $children = @($Node.ChildNodes | ForEach-Object {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1413,6 +1413,21 @@ Describe 'Insurance Foundation reconciliation' {
         } | Should -Throw '*Actual signature:*name=stale*Wanted signature:*'
     }
 
+    It 'accepts the server-assigned saved-query ID in stored FetchXML' {
+        $table = $script:contract.tables[0]
+        $request = New-ViewRequest $table $table.views[0] 10427
+        $storedFetchXml = $request.Body.fetchxml.Replace(
+            '<fetch ',
+            '<fetch savedqueryid="fd79983c-bf93-f111-8075-000d3a30c0f4" '
+        )
+
+        {
+            Assert-XmlCompatible (
+                [pscustomobject]@{ fetchxml = $storedFetchXml }
+            ) $request fetchxml 'component'
+        } | Should -Not -Throw
+    }
+
     It 'updates an empty existing choice rather than treating it as unchanged' {
         $choice = $script:contract.choices[0]
         Mock Invoke-DataverseRequest {


### PR DESCRIPTION
## Summary
- ignore Dataverse's server-assigned savedqueryid when comparing stored FetchXML
- continue comparing every contract-owned XML node and attribute
- retain actual/wanted signatures for actionable conflict diagnostics

## Evidence
Run 31300701300 showed the stored and desired FetchXML differed only by the injected savedqueryid attribute.

## Traceability
- Story: US-707
- ADR: ADR-0021
- Issue: #8

## Tests
- 88 targeted authoring and language tests pass locally