### PR TITLE
fix(dataverse): use supported system-form metadata

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1189,7 +1189,7 @@ function Invoke-TableChildren {
     foreach ($form in $Table.forms) {
         $formLabel = ([string]$form.metadata.label.'1033').Replace("'", "''")
         Invoke-ChildRequestIfMissing `
-            -QueryPath "/systemforms?`$select=formid,name,description,objecttypecode,type,formxml,_solutionid_value&`$filter=name eq '$formLabel' and objecttypecode eq '$($Table.logicalName)' and type eq 2" `
+            -QueryPath "/systemforms?`$select=formid,name,description,objecttypecode,type,formxml&`$filter=name eq '$formLabel' and objecttypecode eq '$($Table.logicalName)' and type eq 2" `
             -Request ($formRequest = New-FormRequest $Table $form) `
             -Component "$($Table.logicalName)/$($form.name)" `
             -AssertCompatible {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -494,6 +494,17 @@ Describe 'Insurance Foundation reconciliation' {
             Should -BeNullOrEmpty
     }
 
+    It 'queries system forms only through supported Web API properties' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope All -Confirm:$false
+
+        $systemFormReads = @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and $_.Path -match '^/systemforms\?'
+        })
+        $systemFormReads.Count | Should -BeGreaterThan 0
+        @($systemFormReads.Path | Where-Object { $_ -match '_solutionid_value' }) |
+            Should -BeNullOrEmpty
+    }
+
     It 'verifies saved-query ownership through solution component membership' {
         Mock Invoke-DataverseRequest {
             return [pscustomobject]@{


### PR DESCRIPTION
## Summary
- remove unsupported _solutionid_value from systemform Web API reads
- preserve inherited table ownership for forms
- add regression coverage for the live Dataverse shape

## Evidence
Run 31300904092 failed with Dataverse error 0x80060888 because systemform does not expose _solutionid_value.

## Traceability
- Story: US-707
- ADR: ADR-0021
- Issue: #8

## Tests
- 89 targeted authoring and language tests pass locally