### PR TITLE
fix(dataverse): compare normalized form XML

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1101,7 +1101,11 @@ function Invoke-ChildRequestIfMissing {
 }
 
 function Get-XmlStructuralSignature {
-    param([Parameter(Mandatory)] [string]$Xml, [Parameter(Mandatory)] [string]$Component)
+    param(
+        [Parameter(Mandatory)] [string]$Xml,
+        [Parameter(Mandatory)] [string]$Component,
+        [string]$Property
+    )
     try {
         [xml]$document = $Xml
     } catch {
@@ -1113,15 +1117,28 @@ function Get-XmlStructuralSignature {
             return '#text:' + $Node.Value
         }
         if ($Node.NodeType -ne [System.Xml.XmlNodeType]::Element) { return '' }
+        if ($Property -eq 'formxml') {
+            if ($Node.LocalName -eq 'labels' -and $Node.ParentNode.LocalName -eq 'cell') {
+                return ''
+            }
+            if ($Node.LocalName -eq 'label' -and
+                $Node.GetAttribute('languagecode') -ne '1033') {
+                return ''
+            }
+        }
+        $ignoredAttributes = @('savedqueryid')
+        if ($Property -eq 'formxml' -and $Node.LocalName -in @('tab', 'section')) {
+            $ignoredAttributes += 'id'
+        }
         $attributes = @($Node.Attributes |
-            Where-Object Name -ne 'savedqueryid' |
-            Sort-Object Name | ForEach-Object {
-            "$($_.Name)=$($_.Value)"
+            Where-Object LocalName -notin $ignoredAttributes |
+            Sort-Object LocalName | ForEach-Object {
+            "$($_.LocalName)=$($_.Value)"
         }) -join ';'
         $children = @($Node.ChildNodes | ForEach-Object {
             Get-NodeSignature $_
         } | Where-Object { $_ }) -join ''
-        return "<$($Node.Name)|$attributes>$children</$($Node.Name)>"
+        return "<$($Node.LocalName)|$attributes>$children</$($Node.LocalName)>"
     }
     return Get-NodeSignature $document.DocumentElement
 }
@@ -1132,8 +1149,8 @@ function Assert-XmlCompatible {
         [string]::IsNullOrWhiteSpace([string]$Existing.$Property)) {
         throw "Structural XML conflict for '$Component': '$Property' was not retrieved."
     }
-    $actual = Get-XmlStructuralSignature ([string]$Existing.$Property) $Component
-    $wanted = Get-XmlStructuralSignature ([string]$Request.Body.$Property) $Component
+    $actual = Get-XmlStructuralSignature ([string]$Existing.$Property) $Component $Property
+    $wanted = Get-XmlStructuralSignature ([string]$Request.Body.$Property) $Component $Property
     if ($actual -ne $wanted) {
         throw "Structural XML conflict for '$Component': existing $Property is stale. Actual signature: $actual Wanted signature: $wanted"
     }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1439,6 +1439,25 @@ Describe 'Insurance Foundation reconciliation' {
         } | Should -Not -Throw
     }
 
+    It 'accepts platform-normalized form IDs and localized field labels' {
+        $request = [pscustomobject]@{
+            Body = @{
+                formxml = @'
+<form><tabs><tab name="general"><labels><label description="English" languagecode="1033" /><label description="Deutsch" languagecode="1031" /></labels><columns><column><sections><section name="general"><labels><label description="English" languagecode="1033" /><label description="Deutsch" languagecode="1031" /></labels><rows><row><cell><control id="crmshow_name" datafieldname="crmshow_name" /></cell></row></rows></section></sections></column></columns></tab></tabs></form>
+'@
+            }
+        }
+        $existing = [pscustomobject]@{
+            formxml = @'
+<form><tabs><tab name="general" id="{11111111-1111-1111-1111-111111111111}"><labels><label description="English" languagecode="1033" /></labels><columns><column><sections><section name="general" id="{22222222-2222-2222-2222-222222222222}"><labels><label description="English" languagecode="1033" /></labels><rows><row><cell><labels><label description="Name" languagecode="1033" /></labels><control id="crmshow_name" datafieldname="crmshow_name" /></cell></row></rows></section></sections></column></columns></tab></tabs></form>
+'@
+        }
+
+        {
+            Assert-XmlCompatible $existing $request formxml 'component'
+        } | Should -Not -Throw
+    }
+
     It 'updates an empty existing choice rather than treating it as unchanged' {
         $choice = $script:contract.choices[0]
         Mock Invoke-DataverseRequest {


### PR DESCRIPTION
## Summary
- compare form XML semantically after removing only platform-owned normalization
- ignore generated tab/section IDs, current-language projection, and generated cell labels
- continue validating tabs, sections, rows, controls, field bindings, and primary labels

## Evidence
Run 31301363060 showed Dataverse rewrites form XML on persistence while preserving the authored control structure.

## Traceability
- Story: US-707
- ADR: ADR-0021
- Issue: #8

## Tests
- 90 targeted authoring and language tests pass locally