### PR TITLE
fix(dataverse): expose key attribute conflicts

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1168,7 +1168,7 @@ function Invoke-TableChildren {
             -AssertCompatible {
                 param($actual)
                 if ((@($actual.KeyAttributes) -join ',') -ne ($expectedKeyColumns -join ',')) {
-                    throw "Structural key conflict for '$($Table.logicalName)/$($key.name)'."
+                    throw "Structural key conflict for '$($Table.logicalName)/$($key.name)'. Actual: $(@($actual.KeyAttributes) -join ','). Expected: $($expectedKeyColumns -join ',')."
                 }
             }
     }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1341,7 +1341,7 @@ Describe 'Insurance Foundation reconciliation' {
         }
         {
             Invoke-TableChildren $script:contract.tables[0] 10427
-        } | Should -Throw '*key conflict*'
+        } | Should -Throw '*key conflict*Actual: crmshow_sourceid*Expected:*'
     }
 
     It 'throws on type and global-choice binding conflicts' {


### PR DESCRIPTION
## Summary
- include actual and expected alternate-key attributes in fail-closed diagnostics
- preserve strict key validation until the live metadata shape is known

## Evidence
Run 31301597384 reached Policy Projection after safe lookup recovery and reported an opaque key conflict.

## Traceability
- Story: US-707
- ADR: ADR-0021
- Issue: #8

## Tests
- 90 targeted authoring and language tests pass locally