### PR TITLE
fix(dataverse): compare key attributes as a set

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1167,8 +1167,10 @@ function Invoke-TableChildren {
             -Component "$($Table.logicalName)/$($key.name)" `
             -AssertCompatible {
                 param($actual)
-                if ((@($actual.KeyAttributes) -join ',') -ne ($expectedKeyColumns -join ',')) {
-                    throw "Structural key conflict for '$($Table.logicalName)/$($key.name)'. Actual: $(@($actual.KeyAttributes) -join ','). Expected: $($expectedKeyColumns -join ',')."
+                $actualKeyColumns = @($actual.KeyAttributes)
+                if ((@($actualKeyColumns | Sort-Object) -join ',') -ne
+                    (@($expectedKeyColumns | Sort-Object) -join ',')) {
+                    throw "Structural key conflict for '$($Table.logicalName)/$($key.name)'. Actual: $($actualKeyColumns -join ','). Expected: $($expectedKeyColumns -join ',')."
                 }
             }
     }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1344,6 +1344,24 @@ Describe 'Insurance Foundation reconciliation' {
         } | Should -Throw '*key conflict*Actual: crmshow_sourceid*Expected:*'
     }
 
+    It 'accepts alternate-key attributes returned in platform order' {
+        $table = $script:contract.tables[1] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+        Mock Invoke-DataverseRequest {
+            return [pscustomobject]@{ value = @([pscustomobject]@{
+                SchemaName = $table.alternateKeys[0].schemaName
+                KeyAttributes = @('crmshow_externalid', 'crmshow_externalsystem')
+            }) }
+        }
+
+        {
+            Invoke-TableChildren $table 10427
+        } | Should -Not -Throw
+    }
+
     It 'throws on type and global-choice binding conflicts' {
         {
             Test-AttributeCompatibility ([pscustomobject]@{ AttributeType = 'String' }) `


### PR DESCRIPTION
## Summary
- treat Dataverse alternate-key attribute ordering as non-semantic
- continue rejecting missing, extra, or substituted key attributes
- retain actual/expected conflict diagnostics

## Evidence
Run 31301896698 returned the exact Policy Projection key attributes in reverse order.

## Traceability
- Story: US-707
- ADR: ADR-0021
- Issue: #8

## Tests
- 91 targeted authoring and language tests pass locally