### PR TITLE
fix(dataverse): verify role solution membership

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -773,6 +773,8 @@ function Assert-SolutionOwnership {
         ([string]$Existing.MetadataId).Trim('{}')
     } elseif ($Existing.savedqueryid) {
         ([string]$Existing.savedqueryid).Trim('{}')
+    } elseif ($Existing.roleid) {
+        ([string]$Existing.roleid).Trim('{}')
     }
     if ($componentId -and
         $Existing.PSObject.Properties.Name -notcontains 'SolutionUniqueName') {
@@ -1551,7 +1553,7 @@ function Invoke-RoleReconciliation {
         }
     }
     $escapedName = $Role.name.Replace("'", "''")
-    $existing = Get-One "/roles?`$select=roleid,name,description,_businessunitid_value,_solutionid_value&`$filter=name eq '$escapedName' and _parentrootroleid_value eq null"
+    $existing = Get-One "/roles?`$select=roleid,name,description,_businessunitid_value&`$filter=name eq '$escapedName' and _parentrootroleid_value eq null"
     if ($null -eq $existing) {
         $businessUnit = Get-One "/businessunits?`$select=businessunitid&`$filter=parentbusinessunitid eq null"
         if ($null -eq $businessUnit -or -not $businessUnit.businessunitid) {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -505,6 +505,17 @@ Describe 'Insurance Foundation reconciliation' {
             Should -BeNullOrEmpty
     }
 
+    It 'queries roles only through supported Web API properties' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope All -Confirm:$false
+
+        $roleReads = @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and $_.Path -match '^/roles\?'
+        })
+        $roleReads.Count | Should -BeGreaterThan 0
+        @($roleReads.Path | Where-Object { $_ -match '_solutionid_value' }) |
+            Should -BeNullOrEmpty
+    }
+
     It 'verifies saved-query ownership through solution component membership' {
         Mock Invoke-DataverseRequest {
             return [pscustomobject]@{
@@ -517,6 +528,27 @@ Describe 'Insurance Foundation reconciliation' {
         Assert-SolutionOwnership `
             ([pscustomobject]@{ savedqueryid = '11111111-1111-1111-1111-111111111111' }) `
             'crmshow_DataModel' 'existing view'
+    }
+
+    It 'verifies role ownership through solution component membership' {
+        $script:ownershipPath = $null
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path)
+            $script:ownershipPath = $Path
+            return [pscustomobject]@{
+                value = @([pscustomobject]@{
+                    solutionid = [pscustomobject]@{ uniquename = 'crmshow_DataModel' }
+                })
+            }
+        }
+
+        Assert-SolutionOwnership `
+            ([pscustomobject]@{ roleid = '11111111-1111-1111-1111-111111111111' }) `
+            'crmshow_DataModel' 'existing role'
+
+        $script:ownershipPath | Should -Match (
+            'objectid eq 11111111-1111-1111-1111-111111111111'
+        )
 
         Should -Invoke Invoke-DataverseRequest -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'GET' -and
@@ -1645,6 +1677,11 @@ Describe 'Insurance Foundation reconciliation' {
                     description=[string]$role.metadata.description.'1033'
                 }) }
             }
+            if ($Method -eq 'GET' -and $Path -like '/solutioncomponents?*') {
+                return [pscustomobject]@{ value = @([pscustomobject]@{
+                    solutionid = [pscustomobject]@{ uniquename = $role.solution }
+                }) }
+            }
             if ($Method -eq 'GET' -and
                 $Path -match "^/EntityDefinitions\(LogicalName='([^']+)'\)") {
                 $logicalName = $Matches[1]
@@ -1714,6 +1751,11 @@ Describe 'Insurance Foundation reconciliation' {
                 return [pscustomobject]@{ value = @([pscustomobject]@{
                     roleid=$roleId; name=$role.name
                     description=[string]$role.metadata.description.'1033'
+                }) }
+            }
+            if ($Method -eq 'GET' -and $Path -like '/solutioncomponents?*') {
+                return [pscustomobject]@{ value = @([pscustomobject]@{
+                    solutionid = [pscustomobject]@{ uniquename = $role.solution }
                 }) }
             }
             if ($Method -eq 'GET' -and


### PR DESCRIPTION
## Summary
- remove unsupported _solutionid_value from role reads
- verify existing security-role ownership through solutioncomponents by roleid
- preserve fail-closed ownership checks and multilingual role reconciliation

## Evidence
Run 31302344260 completed all table metadata and failed with Dataverse error 0x80060888 on role._solutionid_value.

## Traceability
- Story: US-708
- ADR: ADR-0021
- Issue: #8

## Tests
- 93 targeted authoring and language tests pass locally