### PR TITLE
feat(dataverse): add demo-feasible DEV authoring gates

### DIFF
--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -17,17 +17,19 @@ jobs:
       POWER_PLATFORM_ENV_URL: ${{ vars.POWER_PLATFORM_ENV_URL }}
     steps:
       - name: Check out reviewed commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Sign in with workload identity
-        uses: azure/login@v2
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       - name: Install Power Platform CLI
-        uses: microsoft/powerplatform-actions/actions-install@v1
+        uses: microsoft/powerplatform-actions/actions-install@59c0b2abadc26618ca914c689ab9dc399da4d6bb # v1.9.2
 
       - name: Install Pester 6.0.1
         shell: pwsh
@@ -43,6 +45,10 @@ jobs:
           $targeted = Invoke-Pester -Path @(
             (Join-Path $root 'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'),
+            (Join-Path $root 'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'),
+            (Join-Path $root 'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'),
+            (Join-Path $root 'scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1'),
+            (Join-Path $root 'scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1'),
             (Join-Path $root 'infra/scripts/tests/Set-DataverseLanguages.Tests.ps1')
           ) -PassThru -Output Detailed
           if ($targeted.Result -ne 'Passed') { throw 'Targeted authoring tests failed.' }
@@ -63,67 +69,79 @@ jobs:
             --environment $env:POWER_PLATFORM_ENV_URL
           if ($LASTEXITCODE -ne 0) { throw 'PAC federated authentication failed.' }
 
+      - name: Run authoring preflight
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+          $preflightScript = Join-Path $root 'scripts/solution/Test-InsuranceAuthoringPreflight.ps1'
+          $contractPath = Join-Path $root 'solution/schema/insurance-foundation.json'
+          & $pwsh `
+            -NoLogo `
+            -NoProfile `
+            -NonInteractive `
+            -File $preflightScript `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -ContractPath $contractPath
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -eq 2) {
+            throw 'Authoring preflight reported a non-ready state. Review the JSON above and follow docs/runbooks/insurance-foundation-security-role-bootstrap.md before rerunning once the prerequisite or tenant capability gap is resolved.'
+          }
+          if ($exitCode -ne 0) { throw 'Authoring preflight failed.' }
+
       - name: Reconcile Dataverse languages
         shell: pwsh
         run: |
           $root = $env:GITHUB_WORKSPACE
           & (Join-Path $root 'infra/scripts/Set-DataverseLanguages.ps1') `
             -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
-            -LocaleId 1033,1031,1036,1040
+            -LocaleId 1033,1031,1036,1040 `
+            -Confirm:$false
           if ($LASTEXITCODE -ne 0) { throw 'Language reconciliation failed.' }
 
-      - name: Reconcile insurance metadata
+      - name: Reconcile demo-safe metadata
         shell: pwsh
         run: |
           $root = $env:GITHUB_WORKSPACE
           & (Join-Path $root 'scripts/solution/Publish-InsuranceFoundation.ps1') `
             -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
             -ContractPath (Join-Path $root 'solution/schema/insurance-foundation.json') `
-            -Scope All `
+            -Scope Demo `
             -Confirm:$false
-          if ($LASTEXITCODE -ne 0) { throw 'Insurance metadata reconciliation failed.' }
+          if ($LASTEXITCODE -ne 0) { throw 'Demo-safe metadata reconciliation failed.' }
+
+      - name: Validate complete demo convergence
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+          $convergenceScript = Join-Path $root 'scripts/solution/Test-InsuranceFoundationConvergence.ps1'
+          $contractPath = Join-Path $root 'solution/schema/insurance-foundation.json'
+          & $pwsh `
+            -NoLogo `
+            -NoProfile `
+            -NonInteractive `
+            -File $convergenceScript `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -ContractPath $contractPath
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) { throw 'Demo convergence validation failed.' }
 
       - name: Export managed and unmanaged solutions
         shell: pwsh
         run: |
+          $root = $env:GITHUB_WORKSPACE
           $artifact = Join-Path $env:RUNNER_TEMP 'insurance-foundation-authoring'
-          New-Item -ItemType Directory -Path $artifact -Force | Out-Null
-          $exports = @(
-            @{ Name = 'crmshow_Foundation'; Managed = 'false'; File = 'crmshow_Foundation.zip' },
-            @{ Name = 'crmshow_Foundation'; Managed = 'true'; File = 'crmshow_Foundation_managed.zip' },
-            @{ Name = 'crmshow_DataModel'; Managed = 'false'; File = 'crmshow_DataModel.zip' },
-            @{ Name = 'crmshow_DataModel'; Managed = 'true'; File = 'crmshow_DataModel_managed.zip' }
-          )
-          foreach ($export in $exports) {
-            pac solution export `
-              --environment $env:POWER_PLATFORM_ENV_URL `
-              --name $export.Name `
-              --path (Join-Path $artifact $export.File) `
-              --managed $export.Managed `
-              --overwrite
-            if ($LASTEXITCODE -ne 0) { throw "Export failed for $($export.File)." }
-          }
-
-      - name: Verify exact authored package set
-        shell: pwsh
-        run: |
-          $artifact = Join-Path $env:RUNNER_TEMP 'insurance-foundation-authoring'
-          $expected = @(
-            'crmshow_DataModel.zip',
-            'crmshow_DataModel_managed.zip',
-            'crmshow_Foundation.zip',
-            'crmshow_Foundation_managed.zip'
-          )
-          $actual = @(Get-ChildItem -LiteralPath $artifact -File |
-            Sort-Object Name | ForEach-Object Name)
-          if (($actual -join '|') -ne ($expected -join '|')) {
-            throw "Unexpected authored package set: $($actual -join ', ')."
-          }
+          & (Join-Path $root 'scripts/solution/Export-InsuranceFoundationPackages.ps1') `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -OutputDirectory $artifact `
+            -Confirm:$false
+          if ($LASTEXITCODE -ne 0) { throw 'Solution package export failed.' }
 
       - name: Upload authored solution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: insurance-foundation-authoring
-          path: ${{ runner.temp }}/insurance-foundation-authoring/*.zip
+          path: ${{ runner.temp }}/insurance-foundation-authoring
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -45,6 +45,7 @@ jobs:
           $targeted = Invoke-Pester -Path @(
             (Join-Path $root 'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'),
+            (Join-Path $root 'scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1'),
@@ -73,10 +74,11 @@ jobs:
         shell: pwsh
         run: |
           $root = $env:GITHUB_WORKSPACE
+          . (Join-Path $root 'scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1')
           $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
           $preflightScript = Join-Path $root 'scripts/solution/Test-InsuranceAuthoringPreflight.ps1'
           $contractPath = Join-Path $root 'solution/schema/insurance-foundation.json'
-          & $pwsh `
+          $preflightJsonLines = & $pwsh `
             -NoLogo `
             -NoProfile `
             -NonInteractive `
@@ -84,10 +86,17 @@ jobs:
             -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
             -ContractPath $contractPath
           $exitCode = $LASTEXITCODE
-          if ($exitCode -eq 2) {
-            throw 'Authoring preflight reported a non-ready state. Review the JSON above and follow docs/runbooks/insurance-foundation-security-role-bootstrap.md before rerunning once the prerequisite or tenant capability gap is resolved.'
+          $preflightJson = (@($preflightJsonLines | ForEach-Object {
+                $_.ToString()
+              }) -join [Environment]::NewLine).Trim()
+          if (-not [string]::IsNullOrWhiteSpace($preflightJson)) {
+            Write-Host $preflightJson
           }
-          if ($exitCode -ne 0) { throw 'Authoring preflight failed.' }
+          if ($exitCode -ne 0) {
+            throw (Get-InsuranceAuthoringPreflightFailureMessage `
+              -ExitCode $exitCode `
+              -JsonText $preflightJson)
+          }
 
       - name: Reconcile Dataverse languages
         shell: pwsh

--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -45,6 +45,7 @@ jobs:
           $targeted = Invoke-Pester -Path @(
             (Join-Path $root 'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'),
+            (Join-Path $root 'scripts/solution/tests/ConvertTo-SafeCliDiagnosticLine.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'),
             (Join-Path $root 'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'),

--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -5,37 +5,22 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
-  author:
+  validate:
     runs-on: ubuntu-latest
-    environment: dev
-    env:
-      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
-      POWER_PLATFORM_ENV_URL: ${{ vars.POWER_PLATFORM_ENV_URL }}
+    permissions:
+      contents: read
     steps:
       - name: Check out reviewed commit
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
-      - name: Sign in with workload identity
-        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - name: Install Power Platform CLI
-        uses: microsoft/powerplatform-actions/actions-install@59c0b2abadc26618ca914c689ab9dc399da4d6bb # v1.9.2
-
       - name: Install Pester 6.0.1
         shell: pwsh
         run: |
-          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -RequiredVersion 6.0.1 -Scope CurrentUser -Force -SkipPublisherCheck
+          Install-Module Pester -RequiredVersion 6.0.1 -Repository PSGallery -Scope CurrentUser -Force
 
       - name: Run offline authoring contract tests
         shell: pwsh
@@ -57,6 +42,33 @@ jobs:
           $full = Invoke-Pester -Path (Join-Path $root 'scripts/solution/tests') `
             -PassThru -Output Detailed
           if ($full.Result -ne 'Passed') { throw 'Full solution test suite failed.' }
+
+  author:
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      POWER_PLATFORM_ENV_URL: ${{ vars.POWER_PLATFORM_ENV_URL }}
+    steps:
+      - name: Check out reviewed commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Sign in with workload identity
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Install Power Platform CLI
+        uses: microsoft/powerplatform-actions/actions-install@59c0b2abadc26618ca914c689ab9dc399da4d6bb # v1.9.2
 
       - name: Authenticate Power Platform CLI
         shell: pwsh

--- a/.github/workflows/solution-author-dev.yml
+++ b/.github/workflows/solution-author-dev.yml
@@ -89,8 +89,10 @@ jobs:
           $preflightJson = (@($preflightJsonLines | ForEach-Object {
                 $_.ToString()
               }) -join [Environment]::NewLine).Trim()
-          if (-not [string]::IsNullOrWhiteSpace($preflightJson)) {
-            Write-Host $preflightJson
+          $preflightDiagnostics = Get-InsuranceAuthoringPreflightDiagnosticSummary `
+            -JsonText $preflightJson
+          if (-not [string]::IsNullOrWhiteSpace($preflightDiagnostics)) {
+            Write-Host $preflightDiagnostics
           }
           if ($exitCode -ne 0) {
             throw (Get-InsuranceAuthoringPreflightFailureMessage `

--- a/.github/workflows/solution-ci.yml
+++ b/.github/workflows/solution-ci.yml
@@ -1,11 +1,7 @@
 name: Solution CI
 
 on:
-  pull_request:
-    paths:
-      - 'solution/**'
-      - 'scripts/solution/**'
-      - '.github/workflows/solution-*.yml'
+  pull_request: {}
   # Also fire on branch pushes so this workflow starts validating as soon as it
   # lands on a feature branch — the `pull_request` trigger only picks up the
   # workflow file version that lives on the PR's base branch (main), so a
@@ -28,7 +24,6 @@ permissions:
 jobs:
   gate1:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip-solution-ci')"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -97,13 +97,13 @@ and the
 | ID | Story | Status |
 | --- | --- | --- |
 | US-701 | Reconcile EN/DE/FR/IT environment languages as IaC desired state | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
-| US-702 | Deliver shared insurance choices and security roles | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+| US-702 | Deliver shared insurance choices; create security roles through the approved DEV administrator prerequisite and verify them in CI | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8), [#40](https://github.com/urruegg/CRMShowcase/issues/40) |
 | US-703 | Extend Account and Contact | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-704 | Deliver effective-dated AccountContactRole | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-705 | Deliver Account-owned PolicyProjection | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-706 | Deliver effective-dated PolicyPartyRole | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-707 | Validate schema and multilingual semantic metadata | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
-| US-708 | Deploy unmanaged to DEV and managed to TEST | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+| US-708 | Author and export unmanaged/managed packages from DEV; managed TEST promotion is a separate solution-versioning sprint | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-709 | Load synthetic fixtures and publish smoke evidence | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-710 | Enforce effective-date integrity across every Dataverse write path | Deferred — [#9](https://github.com/urruegg/CRMShowcase/issues/9) · [OR-001](./requirements/OR-001-effective-date-integrity.md) |
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -104,7 +104,7 @@ and the
 | US-706 | Deliver effective-dated PolicyPartyRole | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-707 | Validate schema and multilingual semantic metadata | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-708 | Author and export unmanaged/managed packages from DEV; managed TEST promotion is a separate solution-versioning sprint | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
-| US-709 | Load synthetic fixtures and publish smoke evidence | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+| US-709 | Load synthetic fixtures and publish persona security smoke evidence after managed TEST promotion | Deferred - separate follow-up after the solution-versioning sprint - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-710 | Enforce effective-date integrity across every Dataverse write path | Deferred — [#9](https://github.com/urruegg/CRMShowcase/issues/9) · [OR-001](./requirements/OR-001-effective-date-integrity.md) |
 
 ## Epic 8 — Engineering capability packs

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -104,7 +104,7 @@ and the
 | US-706 | Deliver effective-dated PolicyPartyRole | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-707 | Validate schema and multilingual semantic metadata | Planned — [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-708 | Author and export unmanaged/managed packages from DEV; managed TEST promotion is a separate solution-versioning sprint | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
-| US-709 | Load synthetic fixtures and publish persona security smoke evidence after managed TEST promotion | Deferred - separate follow-up after the solution-versioning sprint - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+| US-709 | Load synthetic fixtures and publish persona security smoke evidence after managed TEST promotion | Deferred - included in the separate solution-versioning and managed TEST-promotion sprint - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 | US-710 | Enforce effective-date integrity across every Dataverse write path | Deferred — [#9](https://github.com/urruegg/CRMShowcase/issues/9) · [OR-001](./requirements/OR-001-effective-date-integrity.md) |
 
 ## Epic 8 — Engineering capability packs

--- a/docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md
+++ b/docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md
@@ -46,16 +46,38 @@ that surface the identifiers to CI as **non-secret variables**.
 
 ### GitHub Environments
 
-| Environment | Purpose | Variables set |
-| --- | --- | --- |
-| `dev`  | CI targeting `crmshowdev`  | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `POWER_PLATFORM_ENV_ID`, `POWER_PLATFORM_ENV_URL` |
-| `test` | CI targeting `crmshowtest` | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `POWER_PLATFORM_ENV_ID`, `POWER_PLATFORM_ENV_URL` |
+| Environment | Purpose | Variables set | Current live reviewer posture |
+| --- | --- | --- | --- |
+| `dev`  | CI targeting `crmshowdev`  | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `POWER_PLATFORM_ENV_ID`, `POWER_PLATFORM_ENV_URL` | No required reviewers yet. |
+| `test` | CI targeting `crmshowtest` | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `POWER_PLATFORM_ENV_ID`, `POWER_PLATFORM_ENV_URL` | Required reviewer is the repo owner `urruegg` (GitHub user ID `46865858`). |
 
-- `prevent_self_review = true` — a maintainer opening a PR cannot approve their
-  own deployment to that environment.
 - `can_admins_bypass = false` — even repo admins go through the environment gate.
-- No `required_reviewers` yet — repo has one collaborator. Add reviewers once
-  a second maintainer joins.
+- `prevent_self_review = false` on `test` is a deliberate **demo constraint**.
+  This personal repo currently has one dependable maintainer, so disallowing
+  self-review would deadlock the TEST gate. Customer target state is stricter:
+  use independent required reviewers and remove the owner-as-reviewer exception.
+
+### Reviewed-ref controls: live evidence vs desired IaC
+
+**Current live evidence on the demo repo**
+
+- `test` already has the owner reviewer gate above.
+- `test` already has a `main` deployment branch policy.
+- `dev` currently has zero required reviewers and no live deployment branch
+  policy yet.
+
+**Desired IaC state declared in this repo**
+
+- Both `dev` and `test` GitHub Environments deploy only from `main`.
+- `main` branch protection requires pull-request flow plus the `gate1` status
+  check.
+- `required_approving_review_count = 0` is the current demo-repo setting so the
+  single owner does not deadlock reviewed-ref authoring.
+
+That branch-protection rule is **desired IaC**, not live evidence, until the
+Terraform controller / maintainer session imports and applies it. For customer
+repos, the target state is at least one independent approving reviewer on
+`main`, plus independent required reviewers on `test`.
 
 ### CI workflow
 
@@ -99,7 +121,7 @@ that surface the identifiers to CI as **non-secret variables**.
 **Follow-ups**
 - **ADR-0005** — Power Platform env-user assignment for the CI SPs.
 - **ADR-0006** — Remote state backend choice.
-- Add `required_reviewers` on the `test` environment once a second maintainer
-  joins.
-- Add branch protection on `main` requiring at least one review + the `validate`
-  workflow to pass, once the org / collaborators exist.
+- Replace the demo owner-reviewer exception on `test` with independent required
+  reviewers once a second maintainer or customer approver exists.
+- Raise `required_approving_review_count` above zero for customer repos, then
+  apply/import the matching live branch-protection rule and capture evidence.

--- a/docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md
+++ b/docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md
@@ -57,27 +57,27 @@ that surface the identifiers to CI as **non-secret variables**.
   self-review would deadlock the TEST gate. Customer target state is stricter:
   use independent required reviewers and remove the owner-as-reviewer exception.
 
-### Reviewed-ref controls: live evidence vs desired IaC
+### Reviewed-ref controls: live evidence captured 2026-08-10
 
-**Current live evidence on the demo repo**
+Evidence captured on 2026-08-10 from the live demo repo shows the reviewed-ref
+controls are now active:
 
-- `test` already has the owner reviewer gate above.
-- `test` already has a `main` deployment branch policy.
-- `dev` currently has zero required reviewers and no live deployment branch
-  policy yet.
+- `dev` deploys only from `main` via live deployment policy ID `56913774`.
+- `test` deploys only from `main` via live deployment policy ID `56680080`.
+- `test` keeps required reviewer `urruegg` (GitHub user ID `46865858`);
+  `prevent_self_review = false` remains the deliberate single-maintainer demo
+  exception.
+- `main` branch protection is live and enforces pull-request flow, the `gate1`
+  status check, conversation resolution, `required_linear_history = true`,
+  `dismiss_stale_reviews = true`, `allows_force_pushes = false`,
+  `allows_deletions = false`, and `required_approving_review_count = 0`.
+- Deployment policy IDs are environment-scoped live identifiers. If either
+  GitHub Environment is recreated, re-check the current policy ID before
+  re-importing Terraform state.
 
-**Desired IaC state declared in this repo**
-
-- Both `dev` and `test` GitHub Environments deploy only from `main`.
-- `main` branch protection requires pull-request flow plus the `gate1` status
-  check.
-- `required_approving_review_count = 0` is the current demo-repo setting so the
-  single owner does not deadlock reviewed-ref authoring.
-
-That branch-protection rule is **desired IaC**, not live evidence, until the
-Terraform controller / maintainer session imports and applies it. For customer
-repos, the target state is at least one independent approving reviewer on
-`main`, plus independent required reviewers on `test`.
+Customer target state remains stricter: use independent required reviewers on
+`test` and raise `required_approving_review_count` on `main` to at least one
+independent approver once the repo is no longer single-maintainer.
 
 ### CI workflow
 
@@ -123,5 +123,5 @@ repos, the target state is at least one independent approving reviewer on
 - **ADR-0006** — Remote state backend choice.
 - Replace the demo owner-reviewer exception on `test` with independent required
   reviewers once a second maintainer or customer approver exists.
-- Raise `required_approving_review_count` above zero for customer repos, then
-  apply/import the matching live branch-protection rule and capture evidence.
+- Raise `required_approving_review_count` above zero for customer repos while
+  preserving imported live evidence for the demo repo.

--- a/docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
+++ b/docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
@@ -20,9 +20,10 @@
 
 The DEV OIDC application user has System Customizer and can author the reviewed
 schema, but Dataverse rejects security-role creation because it lacks
-prvCreateRole. Run 31302762752 proved that choices, extensions, tables,
-relationships, keys, views, forms, and multilingual metadata are feasible
-before that boundary.
+prvCreateRole.
+[Run 31302762752](https://github.com/urruegg/CRMShowcase/actions/runs/31302762752/job/93218095999)
+proved that choices, extensions, tables, relationships, keys, views, forms,
+and multilingual metadata are feasible before that boundary.
 
 ## Options
 

--- a/docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
+++ b/docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
@@ -53,6 +53,13 @@ capabilities support a separately approved and auditable privileged identity.
 
 - **Known:** System Customizer lacks prvCreateRole in this tenant.
 - **Known:** normal CI can reconcile the reviewed schema metadata.
+- **Known:** demo DEV authoring can be constrained to reviewed refs by allowing
+  the privileged `dev` workflow to deploy only from `main`, while `main`
+  itself is protected by pull-request flow plus the required `gate1` status
+  check.
+- **Constraint:** this personal demo repo has no dependable independent
+  reviewer pool, so the reviewed-ref control requires pull requests but sets
+  the approving-review count to zero to avoid owner deadlock.
 - **Inferred:** imported source-controlled solutions can become the steady-state
   path after the first successful export.
 - **Evidence still required:** administrator-created roles export correctly and
@@ -69,7 +76,11 @@ promotion requires a different permission model.
 - **At the next release:** import reviewed solution packages; do not reconstruct
   released metadata with live authoring.
 - **Operationally:** first environment setup has an administrator prerequisite.
+- **Operationally:** privileged DEV authoring runs only from reviewed `main`
+  refs, and `main` merges stay gated by `gate1` with force-push and deletion
+  protection enabled for admins as well.
 - **For customer teams:** bootstrap and deployment identities have separate
-  accountability.
+  accountability, and once an independent reviewer pool exists they should
+  require at least one approving review before `main` can advance.
 - **Reversibility:** automated bootstrap can replace the runbook without
   changing the schema contract.

--- a/docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
+++ b/docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
@@ -1,0 +1,74 @@
+# ADR-0023 - Demo-feasible Dataverse bootstrap and steady-state identities
+
+| Field | Value |
+| --- | --- |
+| **Status** | Proposed hypothesis |
+| **Date** | 2026-08-09 |
+| **Decision mode** | Working hypothesis |
+| **Confidence** | High for the demo boundary; medium for automated target bootstrap |
+| **Deciders** | Enterprise Architect, SecDevOps, repo owner |
+| **Topic area** | A8 - lifecycle, deployment, and rollback |
+| **Use case** | Sprint 3 Insurance Foundation |
+| **Licence** | Configuration / own build; environment entitlements require validation |
+| **Upgrade impact** | Medium - separates bootstrap from normal deployment |
+| **CAF methodology** | Ready, Adopt, Govern, Secure, Manage |
+| **WAF pillar(s)** | Security and Operational Excellence; Reliability improved by preflight |
+| **Zero Trust** | Verify explicitly, use least privilege, assume breach |
+| **Responsible AI** | Not AI-relevant |
+
+## Context
+
+The DEV OIDC application user has System Customizer and can author the reviewed
+schema, but Dataverse rejects security-role creation because it lacks
+prvCreateRole. Run 31302762752 proved that choices, extensions, tables,
+relationships, keys, views, forms, and multilingual metadata are feasible
+before that boundary.
+
+## Options
+
+### Option A - Permanently elevate normal CI
+
+Rejected. A one-time bootstrap capability must not become a permanent
+steady-state privilege.
+
+### Option B - Remove custom roles
+
+Rejected as the normal path. It produces an incomplete Foundation solution.
+
+### Option C - Manual demo prerequisite plus separate target bootstrap
+
+Preferred. An authorized administrator creates the reviewed roles once. Normal
+CI verifies them and performs only demo-safe schema reconciliation and export.
+A dedicated automated bootstrap identity remains a target-state hypothesis.
+
+## Working hypothesis
+
+Use the existing System Customizer application user for steady-state DEV
+authoring. Exclude role mutation from normal CI. Treat role existence as a
+read-only preflight prerequisite. Revisit automated bootstrap only when tenant
+capabilities support a separately approved and auditable privileged identity.
+
+## Evidence and assumptions
+
+- **Known:** System Customizer lacks prvCreateRole in this tenant.
+- **Known:** normal CI can reconcile the reviewed schema metadata.
+- **Inferred:** imported source-controlled solutions can become the steady-state
+  path after the first successful export.
+- **Evidence still required:** administrator-created roles export correctly and
+  a second CI run succeeds without role mutation.
+
+## Validation and review triggers
+
+Reopen when the Power Platform provider supports application-user role
+assignment, a supported bootstrap API becomes available, or managed TEST
+promotion requires a different permission model.
+
+## Consequences
+
+- **At the next release:** import reviewed solution packages; do not reconstruct
+  released metadata with live authoring.
+- **Operationally:** first environment setup has an administrator prerequisite.
+- **For customer teams:** bootstrap and deployment identities have separate
+  accountability.
+- **Reversibility:** automated bootstrap can replace the runbook without
+  changing the schema contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ Copy [ADR-TEMPLATE.md](./ADR-TEMPLATE.md) and edit — do not invent a new shape
 
 `ADR-####-kebab-case-title.md`, four-digit sequence, no gaps.
 
-`0023` is allocated; use the next available sequence number for any new ADR.
+`0023` is the latest allocated sequence; use `0024` for the next ADR.
 
 ## Index
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,10 +10,11 @@ Two loose series live side by side:
 - **Governance / build ADRs (0001–0005)** record real decisions made while bringing
   the showcase up: Copilot governance, OIDC federation, Terraform, CI plane, CI app
   users.
-- **Domain and delivery ADRs (0006–0022)** record the CRM Frontier Firm design position on the
+- **Domain and delivery ADRs (0006–0023)** record the CRM Frontier Firm design position on the
   illustrated insurance vertical: party model, portfolio placement, thin CRM over
   the engines, consent, event cascade, jurisdiction eligibility, GA territory,
-  agents-advisory, voice, outbound, ALM, analytics split.
+  agents-advisory, voice, outbound, ALM, analytics split, and demo-feasible
+  Dataverse bootstrap boundaries.
 
 ## Shape
 
@@ -22,6 +23,8 @@ Copy [ADR-TEMPLATE.md](./ADR-TEMPLATE.md) and edit — do not invent a new shape
 ## Naming
 
 `ADR-####-kebab-case-title.md`, four-digit sequence, no gaps.
+
+`0023` is allocated; use the next available sequence number for any new ADR.
 
 ## Index
 
@@ -49,8 +52,9 @@ Copy [ADR-TEMPLATE.md](./ADR-TEMPLATE.md) and edit — do not invent a new shape
 | [0020](./ADR-0020-domain-ownership-within-six-solution-architecture.md) | Domain ownership within the six-solution architecture | A1 · A2 · A4 · A8 | Proposed hypothesis |
 | [0021](./ADR-0021-multilingual-semantic-dataverse-metadata.md) | Multilingual semantic Dataverse metadata | A2 · A4 · A6 · A8 | Accepted |
 | [0022](./ADR-0022-curated-external-copilot-capability-packs.md) | Curated external Copilot capability packs | A4 · A6 · A8 | Accepted |
+| [0023](./ADR-0023-demo-feasible-dataverse-bootstrap.md) | Demo-feasible Dataverse bootstrap and steady-state identities | A8 | Proposed hypothesis |
 
-ADRs 0011, 0012, 0013, 0017, 0018, 0019, and 0020 remain proposed until
+ADRs 0011, 0012, 0013, 0017, 0018, 0019, 0020, and 0023 remain proposed until
 confirmed with customer architecture in the next review.
 
 ## Hypothesis-driven decisions

--- a/docs/runbooks/insurance-foundation-security-role-bootstrap.md
+++ b/docs/runbooks/insurance-foundation-security-role-bootstrap.md
@@ -1,0 +1,98 @@
+# Insurance Foundation security-role bootstrap
+
+| Field | Value |
+| --- | --- |
+| **Status** | Approved administrator runbook |
+| **Date** | 2026-08-09 |
+| **Maturity** | Demo-only DEV bootstrap prerequisite; not automated; TEST delivery is not part of this runbook |
+| **Licence** | 🧩 configuration / own build; authorized Power Platform administrator entitlements are required |
+| **Related** | [ADR-0023](../adr/ADR-0023-demo-feasible-dataverse-bootstrap.md) · [Demo-Feasible Dataverse Authoring and Bootstrap](../superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md) · [Sprint 3 Insurance Foundation](../superpowers/specs/2026-08-08-insurance-foundation-design.md) |
+
+## Purpose
+
+Create the two reviewed DEV roles once without granting GitHub CI permanent
+security-role administration. Normal CI remains the reviewed `System
+Customizer` application user.
+
+## Preconditions
+
+- Authorized Power Platform administrator.
+- DEV only: `https://crmshowdev.crm.dynamics.com`.
+- Reviewed contract: `solution/schema/insurance-foundation.json`.
+- Approved delivery tracking: issue [#40](https://github.com/urruegg/CRMShowcase/issues/40).
+- No credentials or access tokens are copied into GitHub, the repository, or
+  workflow inputs.
+
+## Permitted changes
+
+This bootstrap may change only:
+
+- `CRM Showcase Insurance Reader`;
+- `CRM Showcase Insurance Data Steward`;
+- localized English (`1033`), German (`1031`), French (`1036`), and Italian
+  (`1040`) role labels and descriptions;
+- only the privileges declared by the reviewed contract.
+
+If the local confirmation text or resulting verifier output implies any other
+change, stop and escalate under administrator review.
+
+## Procedure
+
+1. Sign in interactively as the authorized administrator in a local shell:
+
+   ```powershell
+   az login --tenant b829e4ef-1a9f-45ba-80e5-48408aa421a9 --allow-no-subscriptions
+   ```
+
+2. Run the reviewed publisher locally with the explicit privileged scope:
+
+   ```powershell
+   .\scripts\solution\Publish-InsuranceFoundation.ps1 `
+     -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' `
+     -ContractPath '.\solution\schema\insurance-foundation.json' `
+     -Scope SecurityRoles `
+     -Confirm
+   ```
+
+3. Review every `ShouldProcess` confirmation before accepting it. The run is
+   bounded to the permitted changes listed above.
+
+4. Run the read-only verifier:
+
+   ```powershell
+   .\scripts\solution\Test-InsuranceSecurityRoles.ps1 `
+     -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' `
+     -ContractPath '.\solution\schema\insurance-foundation.json'
+   ```
+
+5. Confirm the verifier reports:
+   - overall `State` = `Ready`;
+   - one `Ready` result for each reviewed role;
+   - `MutationOccurred` = `false`.
+
+6. Attach the verifier JSON output and any local confirmation evidence to
+   issue #40, then trigger **Author insurance foundation in DEV**.
+
+## Failure and rollback
+
+- Stop immediately if verification reports unexpected privileges, wrong
+  solution ownership, duplicate root roles, unsupported depth, or any other
+  `ContractConflict`.
+- Do **not** delete either role.
+- Do **not** elevate normal GitHub CI beyond the approved `System Customizer`
+  role.
+- Correct the role metadata or privilege assignment locally under
+  administrator review, rerun the read-only verifier, and add the updated
+  evidence to issue #40.
+
+## Evidence and sign-out
+
+- Keep the local terminal transcript, screenshots, or pasted verifier JSON as
+  administrator evidence for issue #40.
+- After the verified DEV bootstrap is complete, sign out locally:
+
+  ```powershell
+  az logout
+  ```
+
+This runbook does not automate the bootstrap and does not claim TEST delivery.

--- a/docs/runbooks/insurance-foundation-security-role-bootstrap.md
+++ b/docs/runbooks/insurance-foundation-security-role-bootstrap.md
@@ -19,6 +19,10 @@ Customizer` application user.
 - Authorized Power Platform administrator.
 - DEV only: `https://crmshowdev.crm.dynamics.com`.
 - Reviewed contract: `solution/schema/insurance-foundation.json`.
+- If you run the publisher from Windows PowerShell 5.1 instead of PowerShell 7,
+  local `python` and the `jsonschema` package are already present, and both
+  `python --version` and `python -c "import jsonschema"` succeed. PowerShell 7
+  uses `Test-Json` and does not require this fallback.
 - Approved delivery tracking: issue [#40](https://github.com/urruegg/CRMShowcase/issues/40).
 - No credentials or access tokens are copied into GitHub, the repository, or
   workflow inputs.
@@ -44,7 +48,20 @@ any other change, stop and escalate under administrator review.
    az login --tenant b829e4ef-1a9f-45ba-80e5-48408aa421a9 --allow-no-subscriptions
    ```
 
-2. Run the reviewed publisher locally with the explicit privileged scope:
+2. If you are running Windows PowerShell 5.1, verify the local JSON Schema
+   fallback prerequisite first. If either command fails, stop and correct the
+   local prerequisite before continuing. Do not install packages automatically
+   as part of this run.
+
+   ```powershell
+   python --version
+   python -c "import jsonschema"
+   ```
+
+   If you are running PowerShell 7, skip this step because `Test-Json` handles
+   the schema validation path.
+
+3. Run the reviewed publisher locally with the explicit privileged scope:
 
    ```powershell
    .\scripts\solution\Publish-InsuranceFoundation.ps1 `
@@ -54,10 +71,10 @@ any other change, stop and escalate under administrator review.
      -Confirm
    ```
 
-3. Review every `ShouldProcess` confirmation before accepting it. The run is
+4. Review every `ShouldProcess` confirmation before accepting it. The run is
    bounded to the permitted changes listed above.
 
-4. Run the GET-only, read-only verifier:
+5. Run the GET-only, read-only verifier:
 
    ```powershell
    .\scripts\solution\Test-InsuranceSecurityRoles.ps1 `
@@ -65,7 +82,7 @@ any other change, stop and escalate under administrator review.
      -ContractPath '.\solution\schema\insurance-foundation.json'
    ```
 
-5. Confirm the verifier reports:
+6. Confirm the verifier reports:
    - overall `State` = `Ready`;
    - one `Ready` result for each reviewed role;
    - `MutationOccurred` = `false`.
@@ -75,14 +92,14 @@ any other change, stop and escalate under administrator review.
    - exact declared privileges and Dataverse depth;
    - no mutation during verification.
 
-6. For localized English (`1033`), German (`1031`), French (`1036`), and
+7. For localized English (`1033`), German (`1031`), French (`1036`), and
    Italian (`1040`) role labels/descriptions, capture the reviewed
-   `ShouldProcess`/publisher output from step 2 and inspect the role
+   `ShouldProcess`/publisher output from step 3 and inspect the role
    translations in Power Platform before attaching evidence. This is a manual
    evidence item because the current GET-only verifier does not retrieve
    localized role labels/descriptions.
 
-7. Attach the verifier JSON output and the manual localization evidence to
+8. Attach the verifier JSON output and the manual localization evidence to
    issue #40, then trigger **Author insurance foundation in DEV**.
 
 ## Failure and rollback

--- a/docs/runbooks/insurance-foundation-security-role-bootstrap.md
+++ b/docs/runbooks/insurance-foundation-security-role-bootstrap.md
@@ -33,8 +33,8 @@ This bootstrap may change only:
   (`1040`) role labels and descriptions;
 - only the privileges declared by the reviewed contract.
 
-If the local confirmation text or resulting verifier output implies any other
-change, stop and escalate under administrator review.
+If the local confirmation text or resulting structural verifier output implies
+any other change, stop and escalate under administrator review.
 
 ## Procedure
 
@@ -57,7 +57,7 @@ change, stop and escalate under administrator review.
 3. Review every `ShouldProcess` confirmation before accepting it. The run is
    bounded to the permitted changes listed above.
 
-4. Run the read-only verifier:
+4. Run the GET-only, read-only verifier:
 
    ```powershell
    .\scripts\solution\Test-InsuranceSecurityRoles.ps1 `
@@ -69,26 +69,44 @@ change, stop and escalate under administrator review.
    - overall `State` = `Ready`;
    - one `Ready` result for each reviewed role;
    - `MutationOccurred` = `false`.
+   Use the verifier only as evidence of:
+   - exact case-sensitive root role identity/name;
+   - solution membership;
+   - exact declared privileges and Dataverse depth;
+   - no mutation during verification.
 
-6. Attach the verifier JSON output and any local confirmation evidence to
+6. For localized English (`1033`), German (`1031`), French (`1036`), and
+   Italian (`1040`) role labels/descriptions, capture the reviewed
+   `ShouldProcess`/publisher output from step 2 and inspect the role
+   translations in Power Platform before attaching evidence. This is a manual
+   evidence item because the current GET-only verifier does not retrieve
+   localized role labels/descriptions.
+
+7. Attach the verifier JSON output and the manual localization evidence to
    issue #40, then trigger **Author insurance foundation in DEV**.
 
 ## Failure and rollback
 
-- Stop immediately if verification reports unexpected privileges, wrong
-  solution ownership, duplicate root roles, unsupported depth, or any other
-  `ContractConflict`.
+- Stop immediately if verification reports an exact-name mismatch, unexpected
+  privileges, wrong solution ownership, duplicate root roles, unsupported
+  depth, or any other `ContractConflict`.
+- Stop immediately if the manual Power Platform review shows incorrect
+  EN/DE/FR/IT role labels or descriptions.
 - Do **not** delete either role.
 - Do **not** elevate normal GitHub CI beyond the approved `System Customizer`
   role.
-- Correct the role metadata or privilege assignment locally under
-  administrator review, rerun the read-only verifier, and add the updated
-  evidence to issue #40.
+- Correct the role identity, solution membership, privilege assignment, or
+  localized translation locally under administrator review, rerun the
+  read-only verifier for structural evidence, repeat the manual localization
+  review, and add the updated evidence to issue #40.
 
 ## Evidence and sign-out
 
-- Keep the local terminal transcript, screenshots, or pasted verifier JSON as
-  administrator evidence for issue #40.
+- Keep the local terminal transcript, reviewed `ShouldProcess`/publisher
+  output, Power Platform translation review screenshots/notes, and pasted
+  verifier JSON as administrator evidence for issue #40.
+- Localized label/description evidence remains manual because the current
+  GET-only verifier does not retrieve localized role labels/descriptions.
 - After the verified DEV bootstrap is complete, sign out locally:
 
   ```powershell

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Deliver one deterministic DEV authoring workflow that stays within the existing `System Customizer` permissions, stops before mutation when the manual security-role prerequisite is missing, converges Dataverse metadata without operator reruns, and exports exactly four reviewed solution packages.
+**Goal:** Deliver one deterministic DEV authoring workflow that stays within the existing `System Customizer` permissions, stops before mutation when the manual security-role prerequisite is missing, converges Dataverse metadata without operator reruns, and exports exactly four reviewed solution packages. `0023` is the latest allocated sequence; use `0024` for the next ADR.
 
 **Architecture:** Split the current monolithic authoring path into read-only preflight, demo-safe schema reconciliation, read-only role/convergence verification, and exact package export. Keep security-role mutation available only as an explicit administrator-run bootstrap scope; document automated privileged bootstrap as an ADR hypothesis rather than implementing unavailable tenant capability.
 
@@ -139,6 +139,7 @@ promotion requires a different permission model.
 
 In `docs/adr/README.md`, update the domain-and-delivery numbering range and
 ADR index so ADR-0023 is discoverable and the next allocation remains clear:
+`0023` is the latest allocated sequence; use `0024` for the next ADR.
 
 ```markdown
 - **Domain and delivery ADRs (0006–0023)** record the CRM Frontier Firm design position on the

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -1,0 +1,1607 @@
+# Demo-Feasible Dataverse Authoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver one deterministic DEV authoring workflow that stays within the existing `System Customizer` permissions, stops before mutation when the manual security-role prerequisite is missing, converges Dataverse metadata without operator reruns, and exports exactly four reviewed solution packages.
+
+**Architecture:** Split the current monolithic authoring path into read-only preflight, demo-safe schema reconciliation, read-only role/convergence verification, and exact package export. Keep security-role mutation available only as an explicit administrator-run bootstrap scope; document automated privileged bootstrap as an ADR hypothesis rather than implementing unavailable tenant capability.
+
+**Tech Stack:** PowerShell 5.1-compatible scripts, Pester 6.0.1, Dataverse Web API v9.2, PAC CLI, GitHub Actions OIDC, Power Platform solutions, Markdown ADRs/runbooks.
+
+---
+
+## Delivery boundary
+
+This plan implements the **demo scope** from
+`docs/superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md`.
+It does not implement managed TEST promotion, automated privileged bootstrap,
+fixtures, or persona security smoke tests.
+
+The administrator role prerequisite is intentionally a gate:
+
+- if the two custom roles do not exist, preflight returns
+  `ManualPrerequisite` and no Dataverse mutation occurs;
+- after an authorized administrator creates the roles, the normal DEV workflow
+  verifies them but never creates or changes them;
+- the current `System Customizer` assignment remains the steady-state CI role.
+
+## File map
+
+| Path | Responsibility |
+| --- | --- |
+| `docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md` | Records demo boundary and target bootstrap hypothesis |
+| `docs/BACKLOG.md` | Updates US-702/US-708 scope and issue links |
+| `scripts/solution/Test-InsuranceAuthoringPreflight.ps1` | Read-only environment, role, solution, and phase feasibility checks |
+| `scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1` | Preflight result and no-mutation tests |
+| `scripts/solution/Publish-InsuranceFoundation.ps1` | Adds explicit `Demo` and `SecurityRoles` scopes and bounded metadata waits |
+| `scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1` | Scope isolation, polling, timeout, and workflow-order tests |
+| `scripts/solution/Test-InsuranceSecurityRoles.ps1` | Read-only role ownership and privilege comparison |
+| `scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1` | Role verifier tests |
+| `scripts/solution/Test-InsuranceFoundationConvergence.ps1` | Read-only full demo contract check before export |
+| `scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1` | Convergence summary and conflict tests |
+| `scripts/solution/Export-InsuranceFoundationPackages.ps1` | PAC export plus exact package-set verification |
+| `scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1` | Export command and package-set tests |
+| `.github/workflows/solution-author-dev.yml` | Preflight-first, demo-safe authoring, validation, and export |
+| `docs/runbooks/insurance-foundation-security-role-bootstrap.md` | Administrator prerequisite and verification procedure |
+| `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md` | Marks TEST promotion and automated role bootstrap as deferred |
+
+### Task 1: Record the demo boundary and bootstrap hypothesis
+
+**Files:**
+- Create: `docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md`
+- Modify: `docs/BACKLOG.md`
+- Modify: `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md`
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md`:
+
+```markdown
+# ADR-0022 - Demo-feasible Dataverse bootstrap and steady-state identities
+
+| Field | Value |
+| --- | --- |
+| **Status** | Proposed hypothesis |
+| **Date** | 2026-08-09 |
+| **Decision mode** | Working hypothesis |
+| **Confidence** | High for the demo boundary; medium for automated target bootstrap |
+| **Deciders** | Enterprise Architect, SecDevOps, repo owner |
+| **Topic area** | A8 - lifecycle, deployment, and rollback |
+| **Use case** | Sprint 3 Insurance Foundation |
+| **Licence** | Configuration / own build; environment entitlements require validation |
+| **Upgrade impact** | Medium - separates bootstrap from normal deployment |
+| **CAF methodology** | Ready, Adopt, Govern, Secure, Manage |
+| **WAF pillar(s)** | Security and Operational Excellence; Reliability improved by preflight |
+| **Zero Trust** | Verify explicitly, use least privilege, assume breach |
+| **Responsible AI** | Not AI-relevant |
+
+## Context
+
+The DEV OIDC application user has System Customizer and can author the reviewed
+schema, but Dataverse rejects security-role creation because it lacks
+prvCreateRole. Run 31302762752 proved that choices, extensions, tables,
+relationships, keys, views, forms, and multilingual metadata are feasible
+before that boundary.
+
+## Options
+
+### Option A - Permanently elevate normal CI
+
+Rejected. A one-time bootstrap capability must not become a permanent
+steady-state privilege.
+
+### Option B - Remove custom roles
+
+Rejected as the normal path. It produces an incomplete Foundation solution.
+
+### Option C - Manual demo prerequisite plus separate target bootstrap
+
+Preferred. An authorized administrator creates the reviewed roles once. Normal
+CI verifies them and performs only demo-safe schema reconciliation and export.
+A dedicated automated bootstrap identity remains a target-state hypothesis.
+
+## Working hypothesis
+
+Use the existing System Customizer application user for steady-state DEV
+authoring. Exclude role mutation from normal CI. Treat role existence as a
+read-only preflight prerequisite. Revisit automated bootstrap only when tenant
+capabilities support a separately approved and auditable privileged identity.
+
+## Evidence and assumptions
+
+- **Known:** System Customizer lacks prvCreateRole in this tenant.
+- **Known:** normal CI can reconcile the reviewed schema metadata.
+- **Inferred:** imported source-controlled solutions can become the steady-state
+  path after the first successful export.
+- **Evidence still required:** administrator-created roles export correctly and
+  a second CI run succeeds without role mutation.
+
+## Validation and review triggers
+
+Reopen when the Power Platform provider supports application-user role
+assignment, a supported bootstrap API becomes available, or managed TEST
+promotion requires a different permission model.
+
+## Consequences
+
+- **At the next release:** import reviewed solution packages; do not reconstruct
+  released metadata with live authoring.
+- **Operationally:** first environment setup has an administrator prerequisite.
+- **For customer teams:** bootstrap and deployment identities have separate
+  accountability.
+- **Reversibility:** automated bootstrap can replace the runbook without
+  changing the schema contract.
+```
+
+- [ ] **Step 2: Update Sprint 3 backlog wording**
+
+In `docs/BACKLOG.md`, change the affected Epic 7 rows to:
+
+```markdown
+| US-702 | Deliver shared insurance choices; create security roles through the approved DEV administrator prerequisite and verify them in CI | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8), [#40](https://github.com/urruegg/CRMShowcase/issues/40) |
+| US-708 | Author and export unmanaged/managed packages from DEV; managed TEST promotion is a separate solution-versioning sprint | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+```
+
+- [ ] **Step 3: Align the original Sprint 3 specification**
+
+Add this note after the Outcome section in
+`docs/superpowers/specs/2026-08-08-insurance-foundation-design.md`:
+
+```markdown
+> **Demo feasibility amendment (2026-08-09).** The current tenant permits the
+> environment-scoped CI application user to author schema metadata but not
+> security roles. The approved demo scope and administrator prerequisite are
+> defined in
+> [Demo-Feasible Dataverse Authoring and Bootstrap](./2026-08-09-demo-feasible-dataverse-authoring-design.md)
+> and ADR-0022. Managed TEST promotion remains a separate sprint.
+```
+
+- [ ] **Step 4: Validate documentation**
+
+Run:
+
+```powershell
+git diff --check
+rg "TBD|TODO|placeholder" docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md
+```
+
+Expected: `git diff --check` exits 0 and `rg` returns no matches.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md docs/BACKLOG.md docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
+git commit -m "docs(sprint-3): scope demo-feasible Dataverse bootstrap (US-702)"
+```
+
+### Task 2: Add a read-only authoring preflight
+
+**Files:**
+- Create: `scripts/solution/Test-InsuranceAuthoringPreflight.ps1`
+- Create: `scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1`
+
+- [ ] **Step 1: Write failing result-classification tests**
+
+Create `scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    $script:preflightPath = Join-Path $PSScriptRoot '../Test-InsuranceAuthoringPreflight.ps1'
+    . $script:preflightPath
+}
+
+Describe 'Get-InsuranceAuthoringPhaseState' {
+    It 'requires manual bootstrap when either reviewed role is absent' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $true -SchemaFeasible $true `
+            -RolesReady $false |
+            Should -Be 'ManualPrerequisite'
+    }
+
+    It 'is ready when structural prerequisites are satisfied' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $true -SchemaFeasible $true `
+            -RolesReady $true |
+            Should -Be 'Ready'
+    }
+
+    It 'reports unsupported tenant capability before role state' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $true -SchemaFeasible $false `
+            -RolesReady $false |
+            Should -Be 'UnsupportedInTenant'
+    }
+
+    It 'plans language reconciliation without blocking schema authoring' {
+        Get-LanguagePreflightAction `
+            -Required @('1033','1031','1036','1040') `
+            -Provisioned @('1033') |
+            Should -Be 'Reconcile'
+    }
+
+    It 'accepts the proven System Customizer demo capability' {
+        Test-DemoSchemaAuthoringCapability `
+            -AssignedRoleNames @('System Customizer') |
+            Should -BeTrue
+    }
+
+    It 'rejects an unproven steady-state role' {
+        Test-DemoSchemaAuthoringCapability `
+            -AssignedRoleNames @('Basic User') |
+            Should -BeFalse
+    }
+}
+
+Describe 'Invoke-InsuranceAuthoringPreflight' {
+    BeforeEach {
+        Mock Invoke-PreflightDataverseRequest {
+            throw 'Unexpected endpoint'
+        }
+    }
+
+    It 'performs GET requests only' {
+        Mock Invoke-PreflightDataverseRequest {
+            param($Method, $Path)
+            if ($Path -like '/RetrieveProvisionedLanguages*') {
+                return [pscustomobject]@{
+                    RetrieveProvisionedLanguages = @(1033, 1031, 1036, 1040)
+                }
+            }
+            if ($Path -like '/solutions?*') {
+                return [pscustomobject]@{ value = @(
+                    [pscustomobject]@{ uniquename='crmshow_Foundation' },
+                    [pscustomobject]@{ uniquename='crmshow_DataModel' }
+                ) }
+            }
+            if ($Path -like '/roles?*') {
+                return [pscustomobject]@{ value = @(
+                    [pscustomobject]@{ roleid='reader'; name='CRM Showcase Insurance Reader' },
+                    [pscustomobject]@{ roleid='steward'; name='CRM Showcase Insurance Data Steward' }
+                ) }
+            }
+            if ($Path -like '/WhoAmI*') {
+                return [pscustomobject]@{ UserId='ci-user' }
+            }
+            if ($Path -like '/systemusers(*') {
+                return [pscustomobject]@{ value = @(
+                    [pscustomobject]@{ name='System Customizer' }
+                ) }
+            }
+            throw "Unexpected endpoint: $Path"
+        }
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract ([pscustomobject]@{
+                solutions=@('crmshow_Foundation','crmshow_DataModel')
+                languages=@('1033','1031','1036','1040')
+                roles=@(
+                    [pscustomobject]@{ name='CRM Showcase Insurance Reader' },
+                    [pscustomobject]@{ name='CRM Showcase Insurance Data Steward' }
+                )
+            })
+
+        $result.State | Should -Be 'Ready'
+        Assert-MockCalled Invoke-PreflightDataverseRequest -ParameterFilter {
+            $Method -ne 'GET'
+        } -Times 0
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+Import-Module Pester -RequiredVersion 6.0.1
+Invoke-Pester .\scripts\solution\tests\Test-InsuranceAuthoringPreflight.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because the script and functions do not exist.
+
+- [ ] **Step 3: Implement preflight classification and read-only transport**
+
+Create `scripts/solution/Test-InsuranceAuthoringPreflight.ps1` with:
+
+```powershell
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string]$EnvironmentUrl,
+    [Parameter(Mandatory)] [string]$ContractPath
+)
+
+$ErrorActionPreference = 'Stop'
+$script:PreflightBaseUrl = $EnvironmentUrl.TrimEnd('/') + '/api/data/v9.2'
+
+function Invoke-PreflightDataverseRequest {
+    param(
+        [ValidateSet('GET')] [string]$Method = 'GET',
+        [Parameter(Mandatory)] [string]$Path
+    )
+    $url = $script:PreflightBaseUrl + $Path
+    $output = & az rest --method get --url $url `
+        --resource ($EnvironmentUrl.TrimEnd('/') + '/') `
+        --only-show-errors 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Preflight transport failure (GET $Path): $($output -join [Environment]::NewLine)"
+    }
+    if ([string]::IsNullOrWhiteSpace(($output -join ''))) {
+        return [pscustomobject]@{}
+    }
+    return ($output -join [Environment]::NewLine) | ConvertFrom-Json
+}
+
+function Get-InsuranceAuthoringPhaseState {
+    param(
+        [bool]$SolutionsReady,
+        [bool]$SchemaFeasible,
+        [bool]$RolesReady
+    )
+    if (-not $SchemaFeasible) { return 'UnsupportedInTenant' }
+    if (-not $SolutionsReady) { return 'Precondition' }
+    if (-not $RolesReady) { return 'ManualPrerequisite' }
+    return 'Ready'
+}
+
+function Get-LanguagePreflightAction {
+    param(
+        [string[]]$Required,
+        [string[]]$Provisioned
+    )
+    if (@($Required | Where-Object { $_ -notin $Provisioned }).Count -gt 0) {
+        return 'Reconcile'
+    }
+    return 'None'
+}
+
+function Test-DemoSchemaAuthoringCapability {
+    param([string[]]$AssignedRoleNames)
+    return @($AssignedRoleNames | Where-Object {
+        $_ -in @('System Customizer', 'System Administrator')
+    }).Count -gt 0
+}
+
+function Invoke-InsuranceAuthoringPreflight {
+    param(
+        [Parameter(Mandatory)] [string]$EnvironmentUrl,
+        [Parameter(Mandatory)] $Contract
+    )
+    $identity = Invoke-PreflightDataverseRequest -Path '/WhoAmI'
+    $assignedRoles = Invoke-PreflightDataverseRequest -Path (
+        "/systemusers($($identity.UserId))/systemuserroles_association?" +
+        "`$select=name"
+    )
+    $languages = Invoke-PreflightDataverseRequest `
+        -Path '/RetrieveProvisionedLanguages()'
+    $solutions = Invoke-PreflightDataverseRequest -Path (
+        "/solutions?`$select=uniquename&`$filter=" +
+        "uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'"
+    )
+    $roles = Invoke-PreflightDataverseRequest -Path (
+        "/roles?`$select=roleid,name&`$filter=" +
+        "_parentrootroleid_value eq null and (" +
+        "name eq 'CRM Showcase Insurance Reader' or " +
+        "name eq 'CRM Showcase Insurance Data Steward')"
+    )
+
+    $provisioned = @($languages.RetrieveProvisionedLanguages |
+        ForEach-Object { [string]$_ })
+    $solutionNames = @($solutions.value.uniquename)
+    $roleNames = @($roles.value.name)
+    $solutionsReady = @($Contract.solutions | Where-Object {
+        $_ -notin $solutionNames
+    }).Count -eq 0
+    $languagesReady = @($Contract.languages | Where-Object {
+        $_ -notin $provisioned
+    }).Count -eq 0
+    $rolesReady = @($Contract.roles.name | Where-Object {
+        $_ -notin $roleNames
+    }).Count -eq 0
+    $schemaFeasible = Test-DemoSchemaAuthoringCapability `
+        -AssignedRoleNames @($assignedRoles.value.name)
+
+    [pscustomobject]@{
+        State = Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $solutionsReady `
+            -SchemaFeasible $schemaFeasible `
+            -RolesReady $rolesReady
+        UserId = $identity.UserId
+        SolutionsReady = $solutionsReady
+        LanguagesReady = $languagesReady
+        LanguageAction = Get-LanguagePreflightAction `
+            -Required @($Contract.languages) `
+            -Provisioned $provisioned
+        RolesReady = $rolesReady
+        AssignedRoleNames = @($assignedRoles.value.name)
+        MissingRoles = @($Contract.roles.name | Where-Object {
+            $_ -notin $roleNames
+        })
+        MutationOccurred = $false
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    $contract = Get-Content -LiteralPath $ContractPath -Raw |
+        ConvertFrom-Json
+    $result = Invoke-InsuranceAuthoringPreflight `
+        -EnvironmentUrl $EnvironmentUrl -Contract $contract
+    $result | ConvertTo-Json -Depth 10
+    if ($result.State -ne 'Ready') { exit 2 }
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Test-InsuranceAuthoringPreflight.Tests.ps1 -Output Detailed
+```
+
+Expected: all preflight tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/solution/Test-InsuranceAuthoringPreflight.ps1 scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+git commit -m "feat(dataverse): add read-only authoring preflight (US-708)"
+```
+
+### Task 3: Isolate demo-safe and privileged authoring scopes
+
+**Files:**
+- Modify: `scripts/solution/Publish-InsuranceFoundation.ps1`
+- Modify: `scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1`
+
+- [ ] **Step 1: Write failing scope-isolation tests**
+
+Add to `scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1`:
+
+```powershell
+It 'does not schedule role mutation in Demo scope' {
+    Invoke-InsuranceFoundationReconciliation `
+        -Contract $script:contract -Scope Demo -Confirm:$false | Out-Null
+
+    @($script:calls | Where-Object {
+        $_.Method -ne 'GET' -and
+        ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+    }) | Should -BeNullOrEmpty
+}
+
+It 'schedules only role mutation in SecurityRoles scope' {
+    Invoke-InsuranceFoundationReconciliation `
+        -Contract $script:contract -Scope SecurityRoles -Confirm:$false | Out-Null
+
+    @($script:calls | Where-Object {
+        $_.Method -ne 'GET' -and $_.Path -eq '/EntityDefinitions'
+    }) | Should -BeNullOrEmpty
+    @($script:calls | Where-Object {
+        $_.Method -ne 'GET' -and $_.Path -eq '/GlobalOptionSetDefinitions'
+    }) | Should -BeNullOrEmpty
+    @($script:calls | Where-Object {
+        $_.Method -ne 'GET' -and
+        ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+    }).Count | Should -BeGreaterThan 0
+}
+
+It 'keeps All as the explicit privileged legacy scope' {
+    $text = Get-Content -LiteralPath $script:publisherPath -Raw
+    $text | Should -Match "ValidateSet\\('Foundation', 'DataModel', 'Demo', 'SecurityRoles', 'All'\\)"
+}
+```
+
+- [ ] **Step 2: Run targeted test and verify RED**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Publish-InsuranceFoundation.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because `Demo` and `SecurityRoles` are not accepted.
+
+- [ ] **Step 3: Implement explicit scopes**
+
+Change both `Scope` validation declarations to:
+
+```powershell
+[ValidateSet('Foundation', 'DataModel', 'Demo', 'SecurityRoles', 'All')]
+[string]$Scope = 'Demo'
+```
+
+Replace the phase selection in `Invoke-InsuranceFoundationReconciliation` with:
+
+```powershell
+$includeChoices = $Scope -in @('Foundation', 'Demo', 'All')
+$includeDataModel = $Scope -in @('DataModel', 'Demo', 'All')
+$includeRoles = $Scope -in @('SecurityRoles', 'All')
+
+if ($includeChoices) {
+    foreach ($choice in $Contract.choices) {
+        if ($PSCmdlet.ShouldProcess(
+                $choice.logicalName,
+                'Reconcile global choice'
+            )) {
+            Invoke-ChoiceReconciliation $choice
+        }
+    }
+}
+if ($includeDataModel) {
+    foreach ($extension in $Contract.nativeExtensions) {
+        if ($PSCmdlet.ShouldProcess(
+                "$($extension.table)/$($extension.logicalName)",
+                'Reconcile native extension'
+            )) {
+            Invoke-NativeExtensionReconciliation $extension
+        }
+    }
+    foreach ($table in $Contract.tables) {
+        if ($PSCmdlet.ShouldProcess(
+                $table.logicalName,
+                'Reconcile custom table'
+            )) {
+            Invoke-TableReconciliation $table
+        }
+    }
+}
+if ($includeRoles) {
+    foreach ($role in $Contract.roles) {
+        if ($PSCmdlet.ShouldProcess(
+                $role.name,
+                'Reconcile security role'
+            )) {
+            Invoke-RoleReconciliation $role $Contract
+        }
+    }
+}
+```
+
+Choose the publish header with:
+
+```powershell
+$publishSolution = if ($Scope -eq 'SecurityRoles' -or
+    ($includeChoices -and -not $includeDataModel)) {
+    'crmshow_Foundation'
+} else {
+    'crmshow_DataModel'
+}
+```
+
+- [ ] **Step 4: Run targeted and full solution tests**
+
+Run:
+
+```powershell
+$targeted = Invoke-Pester .\scripts\solution\tests\Publish-InsuranceFoundation.Tests.ps1 -PassThru -Output Detailed
+if ($targeted.Result -ne 'Passed') { throw 'Publisher tests failed.' }
+$full = Invoke-Pester .\scripts\solution\tests -PassThru -Output Normal
+if ($full.Result -ne 'Passed') { throw 'Solution tests failed.' }
+```
+
+Expected: all tests pass and no Demo-scope role mutation is recorded.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/solution/Publish-InsuranceFoundation.ps1 scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+git commit -m "refactor(dataverse): isolate privileged role authoring (US-702)"
+```
+
+### Task 4: Replace workflow reruns with bounded metadata convergence
+
+**Files:**
+- Modify: `scripts/solution/Publish-InsuranceFoundation.ps1`
+- Modify: `scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1`
+
+- [ ] **Step 1: Write failing wait tests**
+
+Add:
+
+```powershell
+Describe 'Wait-DataverseCondition' {
+    It 'returns the first non-null condition result' {
+        $script:attempt = 0
+        Mock Start-Sleep {}
+        $result = Wait-DataverseCondition `
+            -Component 'table/lookup' -TimeoutSeconds 10 `
+            -PollIntervalSeconds 1 -Condition {
+                $script:attempt++
+                if ($script:attempt -eq 3) {
+                    return [pscustomobject]@{ LogicalName='crmshow_accountid' }
+                }
+                return $null
+            }
+
+        $result.LogicalName | Should -Be 'crmshow_accountid'
+        $script:attempt | Should -Be 3
+    }
+
+    It 'throws a classified timeout with the component name' {
+        Mock Start-Sleep {}
+        Mock Get-Date {
+            if (-not $script:clock) {
+                $script:clock = [datetime]'2026-08-09T00:00:00Z'
+            } else {
+                $script:clock = $script:clock.AddSeconds(6)
+            }
+            return $script:clock
+        }
+
+        {
+            Wait-DataverseCondition `
+                -Component 'crmshow_policyprojection/crmshow_accountid' `
+                -TimeoutSeconds 5 -PollIntervalSeconds 1 `
+                -Condition { $null }
+        } | Should -Throw '*EventualConsistencyTimeout*crmshow_policyprojection/crmshow_accountid*'
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Publish-InsuranceFoundation.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because `Wait-DataverseCondition` is absent.
+
+- [ ] **Step 3: Implement the bounded condition wait**
+
+Add before `Invoke-TableReconciliation`:
+
+```powershell
+function Wait-DataverseCondition {
+    param(
+        [Parameter(Mandatory)] [string]$Component,
+        [Parameter(Mandatory)] [scriptblock]$Condition,
+        [int]$TimeoutSeconds = 180,
+        [int]$PollIntervalSeconds = 5
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $result = & $Condition
+        if ($null -ne $result) { return $result }
+        if ((Get-Date) -ge $deadline) {
+            throw "EventualConsistencyTimeout for '$Component' after $TimeoutSeconds seconds."
+        }
+        Start-Sleep -Seconds $PollIntervalSeconds
+    } while ($true)
+}
+
+function Get-TableMetadataSnapshot {
+    param([Parameter(Mandatory)] [string]$LogicalName)
+    return Get-One (
+        "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName," +
+        "OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&" +
+        "`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName," +
+        "AttributeType,DisplayName,Description)," +
+        "ManyToOneRelationships(`$select=SchemaName,ReferencedEntity," +
+        "ReferencingEntity,ReferencingAttribute,CascadeConfiguration)&" +
+        "`$filter=LogicalName eq '$LogicalName'"
+    )
+}
+```
+
+After a new table is published, wait for it:
+
+```powershell
+$existing = Wait-DataverseCondition `
+    -Component $Table.logicalName `
+    -Condition { Get-TableMetadataSnapshot $Table.logicalName }
+```
+
+Refactor `Invoke-TableReconciliation` so table creation and table validation
+join one common path:
+
+```powershell
+$existing = Get-TableMetadataSnapshot $Table.logicalName
+if ($null -eq $existing) {
+    $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
+    Invoke-PlannedRequest (
+        Get-TableCreateRequest $Table $choiceMetadataIds
+    ) | Out-Null
+    Publish-TableMetadata $Table
+    $existing = Wait-DataverseCondition `
+        -Component $Table.logicalName `
+        -Condition { Get-TableMetadataSnapshot $Table.logicalName }
+}
+
+# From this point onward, use the same relationship, column, localization,
+# publish, and child reconciliation for both new and pre-existing tables.
+Assert-SolutionOwnership $existing $Table.solution $Table.logicalName
+```
+
+Do not leave relationship recovery and column reconciliation inside an `else`
+branch. The common path is what prevents the first workflow run from reaching
+views before deep-inserted lookups are visible.
+
+After each relationship create, wait until both lookup and relationship are
+visible before continuing:
+
+```powershell
+$existing = Wait-DataverseCondition `
+    -Component "$($Table.logicalName)/$($relationship.lookupColumn)" `
+    -Condition {
+        $snapshot = Get-TableMetadataSnapshot $Table.logicalName
+        $lookup = @($snapshot.Attributes | Where-Object {
+            $_.LogicalName -eq $relationship.lookupColumn
+        })
+        $relation = @($snapshot.ManyToOneRelationships | Where-Object {
+            $_.SchemaName -eq $relationship.schemaName
+        })
+        if ($lookup.Count -eq 1 -and $relation.Count -eq 1) {
+            return $snapshot
+        }
+        return $null
+    }
+```
+
+Reuse the refreshed `$existing` snapshot for column and child reconciliation.
+Do not submit views, forms, or keys against the pre-create snapshot.
+
+- [ ] **Step 4: Add a regression proving dependent children wait**
+
+Add a test that mocks the first table snapshot without the lookup and the
+second with it, invokes `Invoke-TableReconciliation`, and asserts the
+`/savedqueries` POST occurs after the second metadata GET:
+
+```powershell
+$lookupVisibleRead = @($script:calls | Where-Object {
+    $_.Method -eq 'GET' -and $_.Path -like '/EntityDefinitions?*'
+}).Count
+$firstViewCreate = @($script:calls | Where-Object {
+    $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+})[0]
+$firstViewCreate | Should -Not -BeNullOrEmpty
+$lookupVisibleRead | Should -BeGreaterThan 1
+```
+
+- [ ] **Step 5: Run regression suites**
+
+Run:
+
+```powershell
+$result = Invoke-Pester -Path @(
+  '.\scripts\solution\tests\InsuranceFoundationContract.Tests.ps1',
+  '.\scripts\solution\tests\Publish-InsuranceFoundation.Tests.ps1'
+) -PassThru -Output Detailed
+if ($result.Result -ne 'Passed') { throw 'Metadata convergence tests failed.' }
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add scripts/solution/Publish-InsuranceFoundation.ps1 scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+git commit -m "fix(dataverse): await metadata convergence in one run (US-708)"
+```
+
+### Task 5: Add read-only security-role verification and administrator runbook
+
+**Files:**
+- Create: `scripts/solution/Test-InsuranceSecurityRoles.ps1`
+- Create: `scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1`
+- Create: `docs/runbooks/insurance-foundation-security-role-bootstrap.md`
+
+- [ ] **Step 1: Write failing role verifier tests**
+
+Create `scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../Test-InsuranceSecurityRoles.ps1')
+}
+
+Describe 'Compare-InsuranceRolePrivileges' {
+    It 'reports Ready when exact privileges and depth match' {
+        Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                Name='prvReadAccount'; Depth='Global'
+            }) `
+            -Actual @([pscustomobject]@{
+                Name='prvReadAccount'; Depth='Global'
+            }) |
+            Select-Object -ExpandProperty State |
+            Should -Be 'Ready'
+    }
+
+    It 'fails closed for an unexpected privilege' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                Name='prvReadAccount'; Depth='Global'
+            }) `
+            -Actual @(
+                [pscustomobject]@{ Name='prvReadAccount'; Depth='Global' },
+                [pscustomobject]@{ Name='prvDeleteAccount'; Depth='Global' }
+            )
+        $result.State | Should -Be 'ContractConflict'
+        $result.Unexpected | Should -Contain 'prvDeleteAccount'
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Test-InsuranceSecurityRoles.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because the verifier does not exist.
+
+- [ ] **Step 3: Implement the comparison and online verifier**
+
+Create `scripts/solution/Test-InsuranceSecurityRoles.ps1` with:
+
+```powershell
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string]$EnvironmentUrl,
+    [Parameter(Mandatory)] [string]$ContractPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Compare-InsuranceRolePrivileges {
+    param(
+        [Parameter(Mandatory)] [string]$RoleName,
+        [object[]]$Expected = @(),
+        [object[]]$Actual = @()
+    )
+    $expectedNames = @($Expected.Name)
+    $actualNames = @($Actual.Name)
+    $missing = @($expectedNames | Where-Object { $_ -notin $actualNames })
+    $unexpected = @($actualNames | Where-Object { $_ -notin $expectedNames })
+    $wrongDepth = @(
+        foreach ($expectedPrivilege in $Expected) {
+            $actualPrivilege = $Actual |
+                Where-Object Name -eq $expectedPrivilege.Name |
+                Select-Object -First 1
+            if ($null -ne $actualPrivilege -and
+                $actualPrivilege.Depth -ne $expectedPrivilege.Depth) {
+                $expectedPrivilege.Name
+            }
+        }
+    )
+    [pscustomobject]@{
+        Role = $RoleName
+        State = if ($missing.Count -eq 0 -and
+            $unexpected.Count -eq 0 -and
+            $wrongDepth.Count -eq 0) { 'Ready' } else { 'ContractConflict' }
+        Missing = $missing
+        Unexpected = $unexpected
+        WrongDepth = $wrongDepth
+    }
+}
+```
+
+Reuse the exact schema-name and privilege-resolution logic from
+`Invoke-RoleReconciliation`, but issue GET requests only:
+
+1. query each root role by name;
+2. verify solution membership through `solutioncomponents`;
+3. resolve expected privilege names through
+   `EntityDefinitions(...)?$select=SchemaName,Privileges`;
+4. read assigned privileges through `RetrieveRolePrivilegesRole`;
+5. call `Compare-InsuranceRolePrivileges`;
+6. emit one JSON result per role and exit 2 unless every state is `Ready`.
+
+Do not call `SetLocLabels`, `AddPrivilegesRole`, `ReplacePrivilegesRole`, or
+`POST /roles`.
+
+- [ ] **Step 4: Write the administrator runbook**
+
+Create `docs/runbooks/insurance-foundation-security-role-bootstrap.md` with:
+
+```markdown
+# Insurance Foundation security-role bootstrap
+
+## Purpose
+
+Create the two reviewed DEV roles once without granting GitHub CI permanent
+security-role administration.
+
+## Preconditions
+
+- Authorized Power Platform administrator.
+- DEV environment only: `https://crmshowdev.crm.dynamics.com`.
+- Reviewed contract:
+  `solution/schema/insurance-foundation.json`.
+- No credentials or access tokens are copied into GitHub.
+
+## Procedure
+
+1. Sign in interactively with the authorized administrator.
+2. Run the authoring script locally with the explicit privileged scope:
+
+   ```powershell
+   az login --tenant b829e4ef-1a9f-45ba-80e5-48408aa421a9 --allow-no-subscriptions
+   .\scripts\solution\Publish-InsuranceFoundation.ps1 `
+     -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' `
+     -ContractPath '.\solution\schema\insurance-foundation.json' `
+     -Scope SecurityRoles `
+     -Confirm
+   ```
+
+3. Review each `ShouldProcess` confirmation. The run may change only:
+   - `CRM Showcase Insurance Reader`;
+   - `CRM Showcase Insurance Data Steward`;
+   - their localized labels/descriptions;
+   - privileges declared by the reviewed contract.
+4. Run read-only verification:
+
+   ```powershell
+   .\scripts\solution\Test-InsuranceSecurityRoles.ps1 `
+     -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' `
+     -ContractPath '.\solution\schema\insurance-foundation.json'
+   ```
+5. Attach the verifier output to issue #40.
+6. Trigger `Author insurance foundation in DEV`.
+
+## Rollback
+
+If verification reports an unexpected privilege, stop. Do not delete the role.
+Correct the reviewed contract or role assignment under administrator review,
+rerun verification, and record the evidence.
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Test-InsuranceSecurityRoles.Tests.ps1 -Output Detailed
+git diff --check
+```
+
+Expected: tests pass and documentation has no whitespace errors.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add scripts/solution/Test-InsuranceSecurityRoles.ps1 scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1 docs/runbooks/insurance-foundation-security-role-bootstrap.md
+git commit -m "feat(dataverse): verify manually bootstrapped roles (US-702)"
+```
+
+### Task 6: Add a read-only full convergence gate
+
+**Files:**
+- Create: `scripts/solution/Test-InsuranceFoundationConvergence.ps1`
+- Create: `scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1`
+
+- [ ] **Step 1: Write failing summary tests**
+
+Create `scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../Test-InsuranceFoundationConvergence.ps1')
+}
+
+Describe 'New-ConvergenceSummary' {
+    It 'is Ready only when every component is Ready' {
+        New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='choices'; State='Ready' },
+            [pscustomobject]@{ Component='tables'; State='Ready' },
+            [pscustomobject]@{ Component='roles'; State='Ready' }
+        ) | Select-Object -ExpandProperty State |
+            Should -Be 'Ready'
+    }
+
+    It 'preserves the first blocking classification' {
+        $summary = New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='choices'; State='Ready' },
+            [pscustomobject]@{
+                Component='roles'; State='ManualPrerequisite'
+            }
+        )
+        $summary.State | Should -Be 'ManualPrerequisite'
+        $summary.BlockingComponents | Should -Contain 'roles'
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Test-InsuranceFoundationConvergence.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because the convergence script does not exist.
+
+- [ ] **Step 3: Implement the convergence summary**
+
+Create the script with:
+
+```powershell
+function New-ConvergenceSummary {
+    param([Parameter(Mandatory)] [object[]]$Results)
+    $blocking = @($Results | Where-Object State -ne 'Ready')
+    [pscustomobject]@{
+        State = if ($blocking.Count -eq 0) {
+            'Ready'
+        } else {
+            [string]$blocking[0].State
+        }
+        BlockingComponents = @($blocking.Component)
+        Results = @($Results)
+        MutationOccurred = $false
+    }
+}
+```
+
+The online entry point must dot-source
+`Publish-InsuranceFoundation.ps1` to reuse its pure contract and semantic
+comparison functions, then perform GET-only checks for:
+
+- required languages;
+- both solutions;
+- all choices and options;
+- Account/Contact extensions;
+- all tables, columns, relationships, cascades, keys, views, and forms;
+- both security roles through `Test-InsuranceSecurityRoles.ps1`.
+
+Dot-source safely with:
+
+```powershell
+. (Join-Path $PSScriptRoot 'Publish-InsuranceFoundation.ps1') `
+    -EnvironmentUrl $EnvironmentUrl `
+    -ContractPath $ContractPath
+```
+
+The publisher entry point is already guarded by
+`$MyInvocation.InvocationName -ne '.'`; dot-sourcing must not mutate. The
+convergence script must not call `Invoke-PlannedRequest`,
+`Invoke-ChoiceReconciliation`, `Invoke-TableReconciliation`, or
+`Invoke-RoleReconciliation`.
+
+The entry point emits JSON and exits:
+
+- `0` for `Ready`;
+- `2` for `ManualPrerequisite` or `Precondition`;
+- `3` for `ContractConflict`;
+- `1` for transport failure.
+
+- [ ] **Step 4: Add a no-mutation test**
+
+Mock the verifier transport, invoke the online function, and assert:
+
+```powershell
+Assert-MockCalled Invoke-ConvergenceDataverseRequest `
+    -ParameterFilter { $Method -ne 'GET' } -Times 0
+```
+
+- [ ] **Step 5: Run all solution tests**
+
+Run:
+
+```powershell
+$result = Invoke-Pester .\scripts\solution\tests -PassThru -Output Normal
+if ($result.Result -ne 'Passed') { throw 'Solution tests failed.' }
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add scripts/solution/Test-InsuranceFoundationConvergence.ps1 scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+git commit -m "feat(dataverse): add read-only convergence gate (US-707)"
+```
+
+### Task 7: Extract exact package export into a tested script
+
+**Files:**
+- Create: `scripts/solution/Export-InsuranceFoundationPackages.ps1`
+- Create: `scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1`
+- Modify: `.github/workflows/solution-author-dev.yml`
+
+- [ ] **Step 1: Write failing export tests**
+
+Create `scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../Export-InsuranceFoundationPackages.ps1')
+}
+
+Describe 'Get-InsuranceFoundationExports' {
+    It 'returns the exact four reviewed packages' {
+        @((Get-InsuranceFoundationExports).File | Sort-Object) |
+            Should -Be @(
+                'crmshow_DataModel.zip',
+                'crmshow_DataModel_managed.zip',
+                'crmshow_Foundation.zip',
+                'crmshow_Foundation_managed.zip'
+            )
+    }
+}
+
+Describe 'Assert-InsuranceFoundationPackageSet' {
+    It 'rejects a missing package' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                'crmshow_Foundation.zip'
+            )
+        } | Should -Throw '*Unexpected authored package set*'
+    }
+
+    It 'rejects an additional package' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                (Get-InsuranceFoundationExports).File + 'unexpected.zip'
+            )
+        } | Should -Throw '*Unexpected authored package set*'
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Export-InsuranceFoundationPackages.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because the export script does not exist.
+
+- [ ] **Step 3: Implement export and exact verification**
+
+Create `scripts/solution/Export-InsuranceFoundationPackages.ps1`:
+
+```powershell
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)] [string]$EnvironmentUrl,
+    [Parameter(Mandatory)] [string]$OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-InsuranceFoundationExports {
+    @(
+        [pscustomobject]@{
+            Name='crmshow_Foundation'; Managed=$false
+            File='crmshow_Foundation.zip'
+        },
+        [pscustomobject]@{
+            Name='crmshow_Foundation'; Managed=$true
+            File='crmshow_Foundation_managed.zip'
+        },
+        [pscustomobject]@{
+            Name='crmshow_DataModel'; Managed=$false
+            File='crmshow_DataModel.zip'
+        },
+        [pscustomobject]@{
+            Name='crmshow_DataModel'; Managed=$true
+            File='crmshow_DataModel_managed.zip'
+        }
+    )
+}
+
+function Assert-InsuranceFoundationPackageSet {
+    param([Parameter(Mandatory)] [string[]]$FileNames)
+    $expected = @((Get-InsuranceFoundationExports).File | Sort-Object)
+    $actual = @($FileNames | Sort-Object)
+    if (($actual -join '|') -ne ($expected -join '|')) {
+        throw "Unexpected authored package set: $($actual -join ', ')."
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    New-Item -ItemType Directory -Path $OutputDirectory -Force |
+        Out-Null
+    foreach ($export in Get-InsuranceFoundationExports) {
+        $path = Join-Path $OutputDirectory $export.File
+        if ($PSCmdlet.ShouldProcess($path, "Export $($export.Name)")) {
+            & pac solution export `
+                --environment $EnvironmentUrl `
+                --name $export.Name `
+                --path $path `
+                --managed $export.Managed.ToString().ToLowerInvariant() `
+                --overwrite
+            if ($LASTEXITCODE -ne 0) {
+                throw "Export failure for '$($export.File)'."
+            }
+        }
+    }
+    Assert-InsuranceFoundationPackageSet -FileNames @(
+        Get-ChildItem -LiteralPath $OutputDirectory -File |
+            ForEach-Object Name
+    )
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Export-InsuranceFoundationPackages.Tests.ps1 -Output Detailed
+```
+
+Expected: all export tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/solution/Export-InsuranceFoundationPackages.ps1 scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+git commit -m "refactor(dataverse): test exact solution export set (US-708)"
+```
+
+### Task 8: Rebuild the DEV workflow around preflight and explicit gates
+
+**Files:**
+- Modify: `.github/workflows/solution-author-dev.yml`
+- Modify: `scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1`
+
+- [ ] **Step 1: Write failing workflow-order and privilege-boundary tests**
+
+Add to `Describe 'Publisher entry point safety'`:
+
+```powershell
+It 'runs read-only preflight before every Dataverse mutation' {
+    $workflow = Get-Content (Join-Path $script:repoRoot `
+        '.github/workflows/solution-author-dev.yml') -Raw
+    $preflight = $workflow.IndexOf('- name: Run authoring preflight')
+    $languages = $workflow.IndexOf('- name: Reconcile Dataverse languages')
+    $metadata = $workflow.IndexOf('- name: Reconcile demo-safe metadata')
+    $preflight | Should -BeGreaterOrEqual 0
+    $preflight | Should -BeLessThan $languages
+    $preflight | Should -BeLessThan $metadata
+}
+
+It 'uses Demo scope and never requests role authoring' {
+    $workflow = Get-Content (Join-Path $script:repoRoot `
+        '.github/workflows/solution-author-dev.yml') -Raw
+    $workflow | Should -Match '-Scope Demo'
+    $workflow | Should -Not -Match '-Scope (?:All|SecurityRoles)'
+}
+
+It 'validates convergence before exporting packages' {
+    $workflow = Get-Content (Join-Path $script:repoRoot `
+        '.github/workflows/solution-author-dev.yml') -Raw
+    $validation = $workflow.IndexOf(
+        '- name: Validate complete demo convergence'
+    )
+    $export = $workflow.IndexOf(
+        '- name: Export managed and unmanaged solutions'
+    )
+    $validation | Should -BeGreaterOrEqual 0
+    $validation | Should -BeLessThan $export
+}
+```
+
+- [ ] **Step 2: Run publisher tests and verify RED**
+
+Run:
+
+```powershell
+Invoke-Pester .\scripts\solution\tests\Publish-InsuranceFoundation.Tests.ps1 -Output Detailed
+```
+
+Expected: workflow assertions fail.
+
+- [ ] **Step 3: Update the workflow**
+
+Keep top-level permissions:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+Set checkout to avoid persisting credentials:
+
+```yaml
+- name: Check out reviewed commit
+  uses: actions/checkout@v4
+  with:
+    persist-credentials: false
+```
+
+After PAC authentication and before language reconciliation, add:
+
+```yaml
+- name: Run authoring preflight
+  shell: pwsh
+  run: |
+    $root = $env:GITHUB_WORKSPACE
+    & (Join-Path $root 'scripts/solution/Test-InsuranceAuthoringPreflight.ps1') `
+      -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+      -ContractPath (Join-Path $root 'solution/schema/insurance-foundation.json')
+    if ($LASTEXITCODE -eq 2) {
+      throw 'Manual prerequisite: create and verify the reviewed DEV security roles using docs/runbooks/insurance-foundation-security-role-bootstrap.md.'
+    }
+    if ($LASTEXITCODE -ne 0) { throw 'Authoring preflight failed.' }
+```
+
+Rename and constrain metadata authoring:
+
+```yaml
+- name: Reconcile demo-safe metadata
+  shell: pwsh
+  run: |
+    $root = $env:GITHUB_WORKSPACE
+    & (Join-Path $root 'scripts/solution/Publish-InsuranceFoundation.ps1') `
+      -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+      -ContractPath (Join-Path $root 'solution/schema/insurance-foundation.json') `
+      -Scope Demo `
+      -Confirm:$false
+    if ($LASTEXITCODE -ne 0) { throw 'Demo-safe metadata reconciliation failed.' }
+```
+
+Add the read-only export gate:
+
+```yaml
+- name: Validate complete demo convergence
+  shell: pwsh
+  run: |
+    $root = $env:GITHUB_WORKSPACE
+    & (Join-Path $root 'scripts/solution/Test-InsuranceFoundationConvergence.ps1') `
+      -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+      -ContractPath (Join-Path $root 'solution/schema/insurance-foundation.json')
+    if ($LASTEXITCODE -ne 0) { throw 'Demo convergence validation failed.' }
+```
+
+Replace inline export logic with:
+
+```yaml
+- name: Export managed and unmanaged solutions
+  shell: pwsh
+  run: |
+    $root = $env:GITHUB_WORKSPACE
+    $artifact = Join-Path $env:RUNNER_TEMP 'insurance-foundation-authoring'
+    & (Join-Path $root 'scripts/solution/Export-InsuranceFoundationPackages.ps1') `
+      -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+      -OutputDirectory $artifact `
+      -Confirm:$false
+    if ($LASTEXITCODE -ne 0) { throw 'Solution package export failed.' }
+```
+
+Remove the redundant inline package verification step because the tested export
+script performs exact verification.
+
+- [ ] **Step 4: Update the offline test list**
+
+Include all new suites:
+
+```powershell
+$targeted = Invoke-Pester -Path @(
+  (Join-Path $root 'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'),
+  (Join-Path $root 'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'),
+  (Join-Path $root 'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'),
+  (Join-Path $root 'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'),
+  (Join-Path $root 'scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1'),
+  (Join-Path $root 'scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1'),
+  (Join-Path $root 'infra/scripts/tests/Set-DataverseLanguages.Tests.ps1')
+) -PassThru -Output Detailed
+```
+
+- [ ] **Step 5: Run local workflow contract tests**
+
+Run:
+
+```powershell
+$result = Invoke-Pester -Path @(
+  '.\scripts\solution\tests\Publish-InsuranceFoundation.Tests.ps1',
+  '.\scripts\solution\tests\Test-InsuranceAuthoringPreflight.Tests.ps1',
+  '.\scripts\solution\tests\Test-InsuranceSecurityRoles.Tests.ps1',
+  '.\scripts\solution\tests\Test-InsuranceFoundationConvergence.Tests.ps1',
+  '.\scripts\solution\tests\Export-InsuranceFoundationPackages.Tests.ps1'
+) -PassThru -Output Detailed
+if ($result.Result -ne 'Passed') { throw 'Workflow contract tests failed.' }
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Review Actions security**
+
+Verify:
+
+- no `pull_request_target`, `workflow_run`, or `issue_comment` trigger;
+- top-level permissions remain `contents: read` and `id-token: write`;
+- no untrusted `${{ github.event.* }}` value appears in a `run:` block;
+- OIDC remains the only cloud authentication method;
+- `persist-credentials: false` is set;
+- no secret or token is logged.
+
+Run:
+
+```powershell
+rg "pull_request_target|workflow_run|issue_comment|github\.event|client-secret|password" .github/workflows/solution-author-dev.yml
+```
+
+Expected: no unsafe trigger, interpolation, or credential matches.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add .github/workflows/solution-author-dev.yml scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+git commit -m "ci(dataverse): gate DEV authoring by tenant capability (US-708)"
+```
+
+### Task 9: Validate the administrator gate and complete DEV export
+
+**Files:**
+- Modify: `docs/runbooks/insurance-foundation-security-role-bootstrap.md`
+- Modify: `docs/superpowers/plans/2026-08-08-insurance-foundation.md`
+- GitHub evidence: issue #8 and issue #40
+
+- [ ] **Step 1: Run the complete offline suite**
+
+Run:
+
+```powershell
+Import-Module Pester -RequiredVersion 6.0.1
+$result = Invoke-Pester -Path @(
+  '.\scripts\solution\tests',
+  '.\infra\scripts\tests'
+) -PassThru -Output Normal
+if ($result.Result -ne 'Passed') { throw 'Offline suites failed.' }
+```
+
+Expected: every suite passes.
+
+- [ ] **Step 2: Push a PR and wait for both existing CI gates**
+
+Run:
+
+```powershell
+git push -u origin HEAD
+gh pr create `
+  --base main `
+  --title "feat(dataverse): add demo-feasible DEV authoring gates" `
+  --body "Implements US-702 and US-708 under ADR-0022. Adds read-only preflight, demo-safe authoring, bounded metadata convergence, manual role bootstrap verification, and exact export gating. Relates to #8 and #40."
+gh pr checks --watch
+```
+
+Expected: both `gate1` checks pass.
+
+- [ ] **Step 3: Merge and run the workflow before administrator bootstrap**
+
+Run:
+
+```powershell
+gh pr merge --squash --delete-branch
+gh workflow run solution-author-dev.yml --ref main
+$runId = gh run list --workflow solution-author-dev.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch $runId --exit-status
+```
+
+Expected when roles are still absent:
+
+- preflight stops before `Reconcile Dataverse languages`;
+- no schema mutation step runs;
+- failure message identifies the manual security-role prerequisite;
+- issue #40 receives the run URL.
+
+- [ ] **Step 4: Perform the administrator prerequisite**
+
+An authorized Power Platform administrator follows
+`docs/runbooks/insurance-foundation-security-role-bootstrap.md`.
+
+Expected:
+
+- both roles exist in `crmshow_Foundation`;
+- role verification returns `Ready`;
+- no GitHub identity is elevated.
+
+- [ ] **Step 5: Rerun DEV authoring**
+
+Run:
+
+```powershell
+gh workflow run solution-author-dev.yml --ref main
+$runId = gh run list --workflow solution-author-dev.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch $runId --exit-status
+```
+
+Expected:
+
+- preflight passes;
+- metadata converges in one run;
+- convergence validation passes;
+- exactly four packages are uploaded.
+
+- [ ] **Step 6: Download and verify the artifact**
+
+Run:
+
+```powershell
+$runId = gh run list --workflow solution-author-dev.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+$output = Join-Path $env:TEMP "insurance-foundation-$runId"
+gh run download $runId -n insurance-foundation-authoring -D $output
+$actual = @(Get-ChildItem -LiteralPath $output -File | Sort-Object Name | ForEach-Object Name)
+$expected = @(
+  'crmshow_DataModel.zip',
+  'crmshow_DataModel_managed.zip',
+  'crmshow_Foundation.zip',
+  'crmshow_Foundation_managed.zip'
+)
+if (($actual -join '|') -ne ($expected -join '|')) {
+  throw "Unexpected package set: $($actual -join ', ')"
+}
+```
+
+Expected: exact match.
+
+- [ ] **Step 7: Prove steady-state idempotency**
+
+Trigger the workflow a second time without changing permissions or metadata:
+
+```powershell
+gh workflow run solution-author-dev.yml --ref main
+$runId = gh run list --workflow solution-author-dev.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch $runId --exit-status
+```
+
+Expected:
+
+- no `POST /roles`;
+- no `AddPrivilegesRole` or `ReplacePrivilegesRole`;
+- schema reports unchanged/updated localization only;
+- export succeeds again.
+
+- [ ] **Step 8: Record evidence and close the bootstrap blocker**
+
+Comment on issue #8 with:
+
+- successful first-run URL;
+- successful idempotency-run URL;
+- four package names;
+- Pester count;
+- statement that TEST promotion remains deferred.
+
+Comment on issue #40 with:
+
+- administrator bootstrap evidence;
+- read-only role verifier output;
+- confirmation that normal CI retained `System Customizer`.
+
+Close issue #40 only after both successful runs.
+
+- [ ] **Step 9: Update the original Sprint 3 plan**
+
+In `docs/superpowers/plans/2026-08-08-insurance-foundation.md`, mark the
+completed DEV authoring/export steps and add:
+
+```markdown
+Managed TEST promotion, fixtures, and persona security smoke tests remain
+separate follow-up work. Sprint 3 demo evidence is limited to the approved
+DEV package-authoring boundary in ADR-0022.
+```
+
+- [ ] **Step 10: Commit evidence documentation**
+
+```powershell
+git add docs/runbooks/insurance-foundation-security-role-bootstrap.md docs/superpowers/plans/2026-08-08-insurance-foundation.md
+git commit -m "docs(sprint-3): record DEV authoring evidence (US-708)"
+```
+
+## Completion criteria
+
+The plan is complete only when:
+
+- normal GitHub CI never attempts security-role mutation;
+- missing roles are reported before any environment mutation;
+- an authorized administrator creates the roles without sharing credentials;
+- metadata converges in one workflow run;
+- read-only validation passes before export;
+- exactly four packages are uploaded;
+- a second run succeeds under the steady-state `System Customizer` identity;
+- issue #8 contains the evidence;
+- issue #40 is closed with bootstrap and rollback evidence;
+- no claim is made that TEST promotion or automated privileged bootstrap is
+  delivered.

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -30,6 +30,7 @@ The administrator role prerequisite is intentionally a gate:
 | Path | Responsibility |
 | --- | --- |
 | `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md` | Records demo boundary and target bootstrap hypothesis |
+| `docs/adr/README.md` | Registers ADR-0023 in the numbering guidance, proposed list, and index |
 | `docs/BACKLOG.md` | Updates US-702/US-708 scope, defers US-709 follow-up evidence, and preserves issue links |
 | `scripts/solution/Test-InsuranceAuthoringPreflight.ps1` | Read-only environment, role, solution, and phase feasibility checks |
 | `scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1` | Preflight result and no-mutation tests |
@@ -49,6 +50,7 @@ The administrator role prerequisite is intentionally a gate:
 
 **Files:**
 - Create: `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md`
+- Modify: `docs/adr/README.md` (register ADR-0023 in the ADR range/index)
 - Modify: `docs/BACKLOG.md` (US-702/US-708 wording and US-709 deferral)
 - Modify: `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md`
 
@@ -133,17 +135,37 @@ promotion requires a different permission model.
   changing the schema contract.
 ```
 
-- [ ] **Step 2: Update Sprint 3 backlog wording**
+- [ ] **Step 2: Register ADR-0023 in the ADR README**
+
+In `docs/adr/README.md`, update the domain-and-delivery numbering range and
+ADR index so ADR-0023 is discoverable and the next allocation remains clear:
+
+```markdown
+- **Domain and delivery ADRs (0006–0023)** record the CRM Frontier Firm design position on the
+  illustrated insurance vertical: party model, portfolio placement, thin CRM over
+  the engines, consent, event cascade, jurisdiction eligibility, GA territory,
+  agents-advisory, voice, outbound, ALM, analytics split, and demo-feasible
+  Dataverse bootstrap boundaries.
+
+`0024` is allocated; use the next available sequence number for any new ADR.
+
+| [0023](./ADR-0023-demo-feasible-dataverse-bootstrap.md) | Demo-feasible Dataverse bootstrap and steady-state identities | A8 | Proposed hypothesis |
+
+ADRs 0011, 0012, 0013, 0017, 0018, 0019, 0020, and 0023 remain proposed until
+confirmed with customer architecture in the next review.
+```
+
+- [ ] **Step 3: Update Sprint 3 backlog wording**
 
 In `docs/BACKLOG.md`, change the affected Epic 7 rows to:
 
 ```markdown
 | US-702 | Deliver shared insurance choices; create security roles through the approved DEV administrator prerequisite and verify them in CI | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8), [#40](https://github.com/urruegg/CRMShowcase/issues/40) |
 | US-708 | Author and export unmanaged/managed packages from DEV; managed TEST promotion is a separate solution-versioning sprint | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
-| US-709 | Load synthetic fixtures and publish persona security smoke evidence after managed TEST promotion | Deferred - separate follow-up after the solution-versioning sprint - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+| US-709 | Load synthetic fixtures and publish persona security smoke evidence after managed TEST promotion | Deferred - included in the separate solution-versioning and managed TEST-promotion sprint - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 ```
 
-- [ ] **Step 3: Align the original Sprint 3 specification**
+- [ ] **Step 4: Align the original Sprint 3 specification**
 
 Add this note after the Outcome section in
 `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md`:
@@ -160,21 +182,21 @@ Add this note after the Outcome section in
 > security smoke tests remain separate follow-up work.
 ```
 
-- [ ] **Step 4: Validate documentation**
+- [ ] **Step 5: Validate documentation**
 
 Run:
 
 ```powershell
 git diff --check
-rg "TBD|TODO|placeholder" docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
+rg "TBD|TODO|placeholder" docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md docs/adr/README.md
 ```
 
 Expected: `git diff --check` exits 0 and `rg` returns no matches.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```powershell
-git add docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md docs/BACKLOG.md docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
+git add docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md docs/adr/README.md docs/BACKLOG.md docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
 git commit -m "docs(sprint-3): scope demo-feasible Dataverse bootstrap (US-702)"
 ```
 

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Deliver one deterministic DEV authoring workflow that stays within the existing `System Customizer` permissions, stops before mutation when the manual security-role prerequisite is missing, converges Dataverse metadata without operator reruns, and exports exactly four reviewed solution packages. `0023` is the latest allocated sequence; use `0024` for the next ADR.
+**Goal:** Deliver one deterministic DEV authoring workflow that stays within the existing `System Customizer` permissions, stops before mutation when the manual security-role prerequisite is missing, converges Dataverse metadata without operator reruns, and exports exactly four reviewed solution packages.
 
 **Architecture:** Split the current monolithic authoring path into read-only preflight, demo-safe schema reconciliation, read-only role/convergence verification, and exact package export. Keep security-role mutation available only as an explicit administrator-run bootstrap scope; document automated privileged bootstrap as an ADR hypothesis rather than implementing unavailable tenant capability.
 
@@ -138,8 +138,7 @@ promotion requires a different permission model.
 - [ ] **Step 2: Register ADR-0023 in the ADR README**
 
 In `docs/adr/README.md`, update the domain-and-delivery numbering range and
-ADR index so ADR-0023 is discoverable and the next allocation remains clear:
-`0023` is the latest allocated sequence; use `0024` for the next ADR.
+ADR index so ADR-0023 is discoverable and the next allocation remains clear.
 
 ```markdown
 - **Domain and delivery ADRs (0006–0023)** record the CRM Frontier Firm design position on the
@@ -148,7 +147,7 @@ ADR index so ADR-0023 is discoverable and the next allocation remains clear:
   agents-advisory, voice, outbound, ALM, analytics split, and demo-feasible
   Dataverse bootstrap boundaries.
 
-`0024` is allocated; use the next available sequence number for any new ADR.
+`0023` is the latest allocated sequence; use `0024` for the next ADR.
 
 | [0023](./ADR-0023-demo-feasible-dataverse-bootstrap.md) | Demo-feasible Dataverse bootstrap and steady-state identities | A8 | Proposed hypothesis |
 

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -29,7 +29,7 @@ The administrator role prerequisite is intentionally a gate:
 
 | Path | Responsibility |
 | --- | --- |
-| `docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md` | Records demo boundary and target bootstrap hypothesis |
+| `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md` | Records demo boundary and target bootstrap hypothesis |
 | `docs/BACKLOG.md` | Updates US-702/US-708 scope and issue links |
 | `scripts/solution/Test-InsuranceAuthoringPreflight.ps1` | Read-only environment, role, solution, and phase feasibility checks |
 | `scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1` | Preflight result and no-mutation tests |
@@ -48,16 +48,16 @@ The administrator role prerequisite is intentionally a gate:
 ### Task 1: Record the demo boundary and bootstrap hypothesis
 
 **Files:**
-- Create: `docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md`
+- Create: `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md`
 - Modify: `docs/BACKLOG.md`
 - Modify: `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md`
 
 - [ ] **Step 1: Write the ADR**
 
-Create `docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md`:
+Create `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md`:
 
 ```markdown
-# ADR-0022 - Demo-feasible Dataverse bootstrap and steady-state identities
+# ADR-0023 - Demo-feasible Dataverse bootstrap and steady-state identities
 
 | Field | Value |
 | --- | --- |
@@ -153,7 +153,7 @@ Add this note after the Outcome section in
 > security roles. The approved demo scope and administrator prerequisite are
 > defined in
 > [Demo-Feasible Dataverse Authoring and Bootstrap](./2026-08-09-demo-feasible-dataverse-authoring-design.md)
-> and ADR-0022. Managed TEST promotion remains a separate sprint.
+> and ADR-0023. Managed TEST promotion remains a separate sprint.
 ```
 
 - [ ] **Step 4: Validate documentation**
@@ -162,7 +162,7 @@ Run:
 
 ```powershell
 git diff --check
-rg "TBD|TODO|placeholder" docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md
+rg "TBD|TODO|placeholder" docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md
 ```
 
 Expected: `git diff --check` exits 0 and `rg` returns no matches.
@@ -170,7 +170,7 @@ Expected: `git diff --check` exits 0 and `rg` returns no matches.
 - [ ] **Step 5: Commit**
 
 ```powershell
-git add docs/adr/ADR-0022-demo-feasible-dataverse-bootstrap.md docs/BACKLOG.md docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
+git add docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md docs/BACKLOG.md docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
 git commit -m "docs(sprint-3): scope demo-feasible Dataverse bootstrap (US-702)"
 ```
 
@@ -1463,7 +1463,7 @@ git push -u origin HEAD
 gh pr create `
   --base main `
   --title "feat(dataverse): add demo-feasible DEV authoring gates" `
-  --body "Implements US-702 and US-708 under ADR-0022. Adds read-only preflight, demo-safe authoring, bounded metadata convergence, manual role bootstrap verification, and exact export gating. Relates to #8 and #40."
+  --body "Implements US-702 and US-708 under ADR-0023. Adds read-only preflight, demo-safe authoring, bounded metadata convergence, manual role bootstrap verification, and exact export gating. Relates to #8 and #40."
 gh pr checks --watch
 ```
 
@@ -1580,7 +1580,7 @@ completed DEV authoring/export steps and add:
 ```markdown
 Managed TEST promotion, fixtures, and persona security smoke tests remain
 separate follow-up work. Sprint 3 demo evidence is limited to the approved
-DEV package-authoring boundary in ADR-0022.
+DEV package-authoring boundary in ADR-0023.
 ```
 
 - [ ] **Step 10: Commit evidence documentation**

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -1021,18 +1021,34 @@ Describe 'New-ConvergenceSummary' {
             Should -Be 'Ready'
     }
 
-    It 'preserves the first blocking classification' {
+    It 'lets ContractConflict dominate later in result order' {
         $summary = New-ConvergenceSummary -Results @(
-            [pscustomobject]@{ Component='choices'; State='Ready' },
-            [pscustomobject]@{
-                Component='roles'; State='ManualPrerequisite'
-            }
+            [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
+            [pscustomobject]@{ Component='tables'; State='ContractConflict' }
         )
-        $summary.State | Should -Be 'ManualPrerequisite'
-        $summary.BlockingComponents | Should -Contain 'roles'
+
+        $summary.State | Should -Be 'ContractConflict'
+        $summary.BlockingComponents | Should -Be @('roles', 'tables')
+    }
+
+    It 'uses deterministic safety precedence when no contract conflict exists' {
+        $summary = New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
+            [pscustomobject]@{ Component='languages'; State='Precondition' },
+            [pscustomobject]@{ Component='tables'; State='UnsupportedInTenant' }
+        )
+
+        $summary.State | Should -Be 'UnsupportedInTenant'
+        $summary.BlockingComponents | Should -Be @('roles', 'languages', 'tables')
     }
 }
 ```
+
+> **Correction from review evidence (2026-08-09).** Task 6 no longer uses
+> first-blocking semantics. The convergence summary must preserve safety
+> evidence by prioritizing `ContractConflict`, then
+> `UnsupportedInTenant`, `Precondition`, `ManualPrerequisite`, then `Ready`.
+> `BlockingComponents` still reports every blocking component in result order.
 
 - [ ] **Step 2: Run tests and verify RED**
 
@@ -1049,15 +1065,30 @@ Expected: FAIL because the convergence script does not exist.
 Create the script with:
 
 ```powershell
+$blockingStatePriority = @(
+    'ContractConflict',
+    'UnsupportedInTenant',
+    'Precondition',
+    'ManualPrerequisite'
+)
+
+function Get-ConvergenceBlockingState {
+    param([object[]]$Results, [string]$Default = 'Ready')
+    $blocking = @($Results | Where-Object State -ne 'Ready')
+    foreach ($state in $blockingStatePriority) {
+        if (@($blocking | Where-Object State -eq $state).Count -gt 0) {
+            return $state
+        }
+    }
+    if ($blocking.Count -gt 0) { return [string]$blocking[0].State }
+    return $Default
+}
+
 function New-ConvergenceSummary {
     param([Parameter(Mandatory)] [object[]]$Results)
     $blocking = @($Results | Where-Object State -ne 'Ready')
     [pscustomobject]@{
-        State = if ($blocking.Count -eq 0) {
-            'Ready'
-        } else {
-            [string]$blocking[0].State
-        }
+        State = Get-ConvergenceBlockingState -Results @($Results)
         BlockingComponents = @($blocking.Component)
         Results = @($Results)
         MutationOccurred = $false

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -14,8 +14,8 @@
 
 This plan implements the **demo scope** from
 `docs/superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md`.
-It does not implement managed TEST promotion, automated privileged bootstrap,
-fixtures, or persona security smoke tests.
+It does not implement managed TEST promotion, TEST deployment evidence,
+automated privileged bootstrap, fixtures, or persona security smoke tests.
 
 The administrator role prerequisite is intentionally a gate:
 
@@ -30,7 +30,7 @@ The administrator role prerequisite is intentionally a gate:
 | Path | Responsibility |
 | --- | --- |
 | `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md` | Records demo boundary and target bootstrap hypothesis |
-| `docs/BACKLOG.md` | Updates US-702/US-708 scope and issue links |
+| `docs/BACKLOG.md` | Updates US-702/US-708 scope, defers US-709 follow-up evidence, and preserves issue links |
 | `scripts/solution/Test-InsuranceAuthoringPreflight.ps1` | Read-only environment, role, solution, and phase feasibility checks |
 | `scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1` | Preflight result and no-mutation tests |
 | `scripts/solution/Publish-InsuranceFoundation.ps1` | Adds explicit `Demo` and `SecurityRoles` scopes and bounded metadata waits |
@@ -43,13 +43,13 @@ The administrator role prerequisite is intentionally a gate:
 | `scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1` | Export command and package-set tests |
 | `.github/workflows/solution-author-dev.yml` | Preflight-first, demo-safe authoring, validation, and export |
 | `docs/runbooks/insurance-foundation-security-role-bootstrap.md` | Administrator prerequisite and verification procedure |
-| `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md` | Marks TEST promotion and automated role bootstrap as deferred |
+| `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md` | Marks managed TEST promotion, TEST deployment evidence, fixtures, persona security smoke tests, and automated role bootstrap as deferred |
 
 ### Task 1: Record the demo boundary and bootstrap hypothesis
 
 **Files:**
 - Create: `docs/adr/ADR-0023-demo-feasible-dataverse-bootstrap.md`
-- Modify: `docs/BACKLOG.md`
+- Modify: `docs/BACKLOG.md` (US-702/US-708 wording and US-709 deferral)
 - Modify: `docs/superpowers/specs/2026-08-08-insurance-foundation-design.md`
 
 - [ ] **Step 1: Write the ADR**
@@ -140,6 +140,7 @@ In `docs/BACKLOG.md`, change the affected Epic 7 rows to:
 ```markdown
 | US-702 | Deliver shared insurance choices; create security roles through the approved DEV administrator prerequisite and verify them in CI | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8), [#40](https://github.com/urruegg/CRMShowcase/issues/40) |
 | US-708 | Author and export unmanaged/managed packages from DEV; managed TEST promotion is a separate solution-versioning sprint | In progress - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
+| US-709 | Load synthetic fixtures and publish persona security smoke evidence after managed TEST promotion | Deferred - separate follow-up after the solution-versioning sprint - [#8](https://github.com/urruegg/CRMShowcase/issues/8) |
 ```
 
 - [ ] **Step 3: Align the original Sprint 3 specification**
@@ -150,10 +151,13 @@ Add this note after the Outcome section in
 ```markdown
 > **Demo feasibility amendment (2026-08-09).** The current tenant permits the
 > environment-scoped CI application user to author schema metadata but not
-> security roles. The approved demo scope and administrator prerequisite are
-> defined in
+> security roles. The approved Sprint 3 boundary is DEV authoring, validation,
+> and exact package export. The administrator prerequisite and follow-up target
+> sequence are defined in
 > [Demo-Feasible Dataverse Authoring and Bootstrap](./2026-08-09-demo-feasible-dataverse-authoring-design.md)
-> and ADR-0023. Managed TEST promotion remains a separate sprint.
+> and [ADR-0023](../../adr/ADR-0023-demo-feasible-dataverse-bootstrap.md).
+> Managed TEST promotion, TEST deployment evidence, fixtures, and persona
+> security smoke tests remain separate follow-up work.
 ```
 
 - [ ] **Step 4: Validate documentation**
@@ -1578,9 +1582,9 @@ In `docs/superpowers/plans/2026-08-08-insurance-foundation.md`, mark the
 completed DEV authoring/export steps and add:
 
 ```markdown
-Managed TEST promotion, fixtures, and persona security smoke tests remain
-separate follow-up work. Sprint 3 demo evidence is limited to the approved
-DEV package-authoring boundary in ADR-0023.
+Managed TEST promotion, TEST deployment evidence, fixtures, and persona
+security smoke tests remain separate follow-up work. Sprint 3 demo evidence
+is limited to the approved DEV package-authoring boundary in ADR-0023.
 ```
 
 - [ ] **Step 10: Commit evidence documentation**

--- a/docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
@@ -5,57 +5,63 @@
 | **Status** | Approved design — ready for implementation planning |
 | **Date** | 2026-08-08 |
 | **Decision mode** | Reversible implementation hypothesis |
-| **Working hypothesis** | A deliberately small Insurance Foundation is the safest first proof of the Option C layered-hybrid model and managed DEV-to-TEST lifecycle. |
+| **Working hypothesis** | A deliberately small Insurance Foundation is the safest first proof of the Option C layered-hybrid model and demo-feasible DEV authoring/export boundary, while keeping the managed DEV-to-TEST lifecycle visible as approved follow-up scope. |
 | **Maturity** | Design; not yet deployed |
 | **Licence** | 🧩 configuration / own build; Dynamics 365 and Power Platform entitlements must be validated per environment |
 | **Upgrade impact** | Additive MINOR release; target `crmshow_Foundation` and `crmshow_DataModel` version `1.1.0.BUILD` |
-| **Related ADRs** | [ADR-0006](../../adr/ADR-0006-account-centre-of-gravity.md) · [ADR-0007](../../adr/ADR-0007-portfolio-at-account.md) · [ADR-0008](../../adr/ADR-0008-thin-crm-over-systems-of-record.md) · [ADR-0017](../../adr/ADR-0017-alm-everything-through-the-pipeline.md) · [ADR-0019](../../adr/ADR-0019-provisional-insurance-data-model-shape.md) · [ADR-0020](../../adr/ADR-0020-domain-ownership-within-six-solution-architecture.md) · [ADR-0021](../../adr/ADR-0021-multilingual-semantic-dataverse-metadata.md) |
+| **Related ADRs** | [ADR-0006](../../adr/ADR-0006-account-centre-of-gravity.md) · [ADR-0007](../../adr/ADR-0007-portfolio-at-account.md) · [ADR-0008](../../adr/ADR-0008-thin-crm-over-systems-of-record.md) · [ADR-0017](../../adr/ADR-0017-alm-everything-through-the-pipeline.md) · [ADR-0019](../../adr/ADR-0019-provisional-insurance-data-model-shape.md) · [ADR-0020](../../adr/ADR-0020-domain-ownership-within-six-solution-architecture.md) · [ADR-0021](../../adr/ADR-0021-multilingual-semantic-dataverse-metadata.md) · [ADR-0023](../../adr/ADR-0023-demo-feasible-dataverse-bootstrap.md) |
 | **Frameworks** | CAF Ready, Adopt, Govern and Manage · WAF Reliability, Security, Operational Excellence and Cost Optimization · Zero Trust · Microsoft Responsible AI |
 
 ## 1. Outcome
 
 Sprint 3 delivers the first deployable insurance data-model slice into the CRM
-Showcase DEV environment and promotes it to TEST as managed solutions. It
-proves four things before the broader relocation use case is built:
+Showcase DEV environment, validates tenant-feasible metadata convergence, and
+exports exact Foundation/DataModel managed and unmanaged packages from the
+reviewed DEV state. It proves four things before the broader relocation use
+case is built:
 
 1. the Account-centred insurance model can represent households, businesses
    and brokers without turning Dataverse into a policy-administration system;
 2. effective-dated people-to-account and policy-party roles can represent the
    relationships needed by Mobiliar private and business customers;
-3. EN, DE, FR and IT metadata can be governed, deployed and validated as part
-   of the schema;
-4. an additive managed solution can be installed or updated in TEST through a
-   pipeline with explicit version and rollback evidence.
+3. EN, DE, FR and IT metadata can be governed, authored and validated as part
+   of the schema in DEV;
+4. the reviewed DEV state can yield exact managed and unmanaged solution
+   packages for the later source-first DEV-to-TEST promotion path.
 
-The sprint is a reviewable foundation, not a claim that the target model is
-final. Core-system and data-platform discovery may change the projection
-boundaries under the review triggers in ADR-0019.
+The sprint is a reviewable foundation, not a claim that the target model or
+deployment sequence is final. Core-system and data-platform discovery may
+change the projection boundaries under the review triggers in ADR-0019.
+Managed TEST promotion remains follow-up scope under ADR-0023.
 
 > **Demo feasibility amendment (2026-08-09).** The current tenant permits the
 > environment-scoped CI application user to author schema metadata but not
-> security roles. The approved demo scope and administrator prerequisite are
-> defined in
+> security roles. The approved Sprint 3 boundary is DEV authoring, validation,
+> and exact package export. The administrator prerequisite and follow-up target
+> sequence are defined in
 > [Demo-Feasible Dataverse Authoring and Bootstrap](./2026-08-09-demo-feasible-dataverse-authoring-design.md)
 > and [ADR-0023](../../adr/ADR-0023-demo-feasible-dataverse-bootstrap.md).
-> Managed TEST promotion remains a separate sprint.
+> Managed TEST promotion, TEST deployment evidence, fixtures, and persona
+> security smoke tests remain separate follow-up work.
 
 ## 2. Scope
 
 ### Included
 
 - enable and verify English (`1033`), German (`1031`), French (`1036`) and
-  Italian (`1040`) in DEV and TEST;
+  Italian (`1040`) in DEV, and preserve the same LCID contract for later TEST
+  promotion;
 - shared choices and security roles in `crmshow_Foundation`;
 - native Account and Contact extensions in `crmshow_DataModel`;
 - `AccountContactRole`, `PolicyProjection` and `PolicyPartyRole` custom tables;
 - semantic descriptions and localized labels/descriptions for all introduced
   metadata;
 - alternate keys, relationships, ownership and effective-dating rules;
-- synthetic, clearly labelled, idempotent fixtures;
-- solution source, validation, packaging and deployment automation;
-- unmanaged DEV deployment and managed TEST install/update;
-- metadata, schema, CRUD, security and deployment smoke tests;
-- deployment evidence suitable for the GitHub feature issue and PR.
+- solution source, validation, exact packaging and export automation;
+- unmanaged DEV import/publish and read-only convergence validation;
+- administrator-run custom-role bootstrap plus CI verification, per ADR-0023;
+- metadata, schema and export smoke tests in DEV;
+- authoring/export evidence suitable for the GitHub feature issue and PR.
 
 ### Excluded
 
@@ -67,10 +73,14 @@ boundaries under the review triggers in ADR-0019.
   needed for smoke testing;
 - automated customer communication, pricing, underwriting or case closure;
 - Copilot tools, prompts, runtime agents or AI-generated customer output;
-- destructive managed-solution upgrade in TEST.
+- synthetic fixtures and persona security smoke tests;
+- managed-solution install/update/upgrade in TEST, TEST deployment evidence,
+  and TEST rollback drills.
 
 Those exclusions keep the sprint small enough to validate schema, semantics
-and ALM independently. Sprint 4 adds the Relocation Vertical Slice.
+and exact package authoring independently. The follow-up solution-versioning
+sprint consumes the exported packages for managed TEST promotion; the
+Relocation Vertical Slice starts only after that path is proven.
 
 ## 3. Architectural approach
 
@@ -81,7 +91,7 @@ from ADR-0020:
 | --- | --- |
 | CRM-owned relationship and work | Account type, Contact lifecycle stage and effective-dated AccountContactRole |
 | Selective source-mastered insurance context | Thin PolicyProjection and PolicyPartyRole |
-| Orchestration and traceability | Source identity, retrieval timestamps and deployment evidence only; operational event tables remain Sprint 4 |
+| Orchestration and traceability | Source identity, retrieval timestamps and DEV authoring/export evidence only; managed TEST deployment evidence moves to the solution-versioning follow-up sprint and operational event tables remain future scope |
 | Canonical contracts and data products | Stable English logical names and explicit source/mastership semantics; no physical canonical lake model in this sprint |
 
 The portfolio belongs to Account. Contact participates through roles and never
@@ -115,6 +125,13 @@ Depends on `crmshow_Foundation` and owns:
 
 No app solution changes in Sprint 3. No `crmshow_Integration` component is
 needed until a live contract, event or synchronization mechanism exists.
+
+Sprint 3 delivery depends on DEV language readiness, the existing solution
+containers, the approved System Customizer CI identity, and the ADR-0023
+administrator prerequisite to create the two custom roles once so they can be
+verified and exported. Managed TEST promotion depends on the later
+solution-versioning sprint consuming the exact packages from this sprint; it
+is not a Sprint 3 completion criterion.
 
 ## 5. Data model
 
@@ -233,8 +250,8 @@ Rules:
 All lookups for a custom table are introduced in the table's initial solution
 definition. The implementation must not create, delete and recreate lookups.
 
-Sprint 3 validates fixture and import payloads and reports invalid date order
-for Data Steward remediation. Universal server-side enforcement across every
+Sprint 3 validates import payloads and reports invalid date order for Data
+Steward remediation. Universal server-side enforcement across every
 Dataverse write path is deferred to
 [OR-001](../../requirements/OR-001-effective-date-integrity.md) / issue #9
 because Dataverse does not publish a supported compiler contract for
@@ -295,9 +312,9 @@ the documented Dataverse `LanguageLocale` Web API:
 4. read the final state and fail unless all four LCIDs are active;
 5. emit environment, LCID and state evidence without tokens or customer data.
 
-DEV uses the existing System Customizer application user. TEST uses its
-environment-scoped System Administrator application user. No tenant-wide
-administrator identity is introduced.
+DEV uses the existing System Customizer application user. The deferred managed
+TEST promotion sequence uses its environment-scoped System Administrator
+application user. No tenant-wide administrator identity is introduced.
 
 The control is safe to re-run. It does not automatically disable a language:
 removing a supported language is a user-impacting architectural change and
@@ -305,8 +322,9 @@ requires a separate ADR. When the provider gains a first-class resource, the
 implementation migrates to that resource and retires the script.
 
 Language reconciliation runs after environment/application-user readiness and
-before multilingual solution import. Deployment preflight independently
-blocks import if any required LCID is inactive.
+before multilingual solution import in DEV. The follow-up managed TEST
+promotion preflight independently blocks TEST import if any required LCID is
+inactive.
 
 ## 8. Security and auditing
 
@@ -319,16 +337,21 @@ Custom tables are user/team owned.
 
 The pipeline identity receives only the role already approved for its
 environment. Runtime personas are assigned showcase roles explicitly; Sprint 3
-does not modify out-of-box roles.
+does not modify out-of-box roles or claim persona-based smoke evidence.
 
 Dataverse auditing is enabled for the custom tables and material columns.
-Fixtures and deployment evidence contain only synthetic, clearly labelled
-Contoso data. No Mobiliar customer data or exported CRM records enter source
-control, logs or tests.
+Export evidence, and any future fixtures or deployment evidence, contain only
+synthetic, clearly labelled Contoso data. No Mobiliar customer data or
+exported CRM records enter source control, logs or tests.
 
-## 9. Fixtures
+## 9. Deferred fixtures and persona security smoke tests
 
-Fixtures are deterministic and idempotent. They demonstrate:
+Sprint 3 does not load fixtures or execute persona security smoke tests. Those
+follow-up checks begin only after the custom roles are exported and the
+solution-versioning sprint establishes managed TEST promotion.
+
+The intended follow-up fixtures are deterministic and idempotent. They
+demonstrate:
 
 - one synthetic Household Account with two Contacts and effective-dated roles;
 - one synthetic Business Account with a business Contact;
@@ -348,30 +371,35 @@ This additive feature increments `crmshow_Foundation` and
 `crmshow_DataModel` to `1.1.0.BUILD`. Unchanged solutions remain at their
 current semantic version unless dependency metadata requires repackaging.
 
-### DEV
+### Sprint 3 delivery
 
-- validate source and localization;
-- pack unmanaged solutions in dependency order;
-- import Foundation, then DataModel;
-- publish;
-- load/update fixtures;
-- run schema, metadata, CRUD and security smoke tests.
+- validate source, localization and preflight prerequisites;
+- reconcile required languages in DEV;
+- author or verify Foundation and DataModel components in dependency order;
+- verify administrator-created custom roles rather than create them from the
+  normal CI identity;
+- publish and run read-only convergence validation;
+- export exact `crmshow_Foundation.zip`,
+  `crmshow_Foundation_managed.zip`, `crmshow_DataModel.zip`, and
+  `crmshow_DataModel_managed.zip`;
+- verify the four-file artifact set and attach authoring/export evidence to
+  the workflow run.
 
-### TEST
+### Follow-up managed TEST promotion
 
-- pack managed solutions from the same reviewed source;
-- preflight installed solution versions and required languages;
+- consume the same reviewed source or exported packages;
+- preflight installed solution versions and required languages in TEST;
 - install if no managed solution exists;
 - otherwise import as managed **Update**, retaining components absent from the
   newer package;
-- run smoke tests and attach evidence to the workflow run.
+- execute fixtures, persona security smoke tests and TEST deployment evidence
+  capture;
+- later exercise `StageForUpgrade` and `ApplyUpgrade` when there is a
+  legitimate upgrade case.
 
-Sprint 3 does not manufacture a destructive component removal to demonstrate
-Upgrade. Sprint 4 will execute both an additive managed Update and a controlled
-Stage-for-Upgrade/Apply-Upgrade exercise when there is a legitimate upgrade
-case. The import wrapper must nevertheless expose explicit `InstallOrUpdate`,
-`StageForUpgrade` and `ApplyUpgrade` modes rather than always forcing
-overwrite.
+Sprint 3 therefore stops at exact package export. The import wrapper must
+nevertheless expose explicit `InstallOrUpdate`, `StageForUpgrade` and
+`ApplyUpgrade` modes rather than always forcing overwrite.
 
 Deployments occur only through GitHub Actions in accordance with ADR-0017.
 Local scripts may validate or prepare artefacts but do not create an
@@ -381,24 +409,25 @@ alternative release path.
 
 | Failure | Required behavior |
 | --- | --- |
-| Required language missing/inactive | Stop before solution import; report environment and LCID. |
+| Required language missing/inactive in DEV | Stop before authoring/export; report environment and LCID. |
+| Missing custom-role prerequisite | Stop before export and report the administrator action required by ADR-0023. |
 | Metadata validation failure | Stop packaging; identify component, language and failed rule. |
-| Solution import failure | Preserve PAC import logs and correlation details; do not run fixtures. |
-| Fixture validation failure | Stop and retain imported additive schema for diagnosis; do not report deployment success. |
-| TEST version not monotonic | Stop before import and report installed versus package version. |
+| DEV solution import failure | Preserve PAC import logs and correlation details; do not export packages. |
+| Export verification failure | Preserve authored metadata and fail without publishing an incomplete artifact. |
 | Partial language activation | Fail reconciliation after final read; rerun is safe. |
-| Security smoke failure | Mark deployment failed; do not widen permissions automatically. |
+| Role contract verification failure | Mark the run failed; do not widen permissions automatically. |
 
-Because Sprint 3 is additive, rollback means:
+Because Sprint 3 stops in DEV and exports packages, recovery means:
 
-1. stop subsequent deployments;
-2. disable fixture-driven use if needed;
-3. restore the prior managed package only where Dataverse supports a safe
-   monotonic package operation;
-4. otherwise correct forward with a PATCH/MINOR release.
+1. stop subsequent exports from the branch;
+2. correct forward in DEV until convergence is re-established;
+3. re-export the exact package set from the reviewed DEV state;
+4. carry TEST version monotonicity, managed rollback and destructive upgrade
+   handling in the follow-up solution-versioning sprint.
 
-Data-bearing tables are not casually uninstalled from TEST. Any rollback that
-would delete data requires explicit approval, backup evidence and an ADR.
+Managed rollback in TEST remains future scope; data-bearing tables are not
+casually uninstalled. Any rollback that would delete data still requires
+explicit approval, backup evidence and an ADR.
 
 ## 12. Validation
 
@@ -406,50 +435,74 @@ would delete data requires explicit approval, backup evidence and an ADR.
 
 - manifest and dependency validation;
 - solution checker;
-- no unmanaged active layer in TEST;
 - stable schema/logical names and publisher prefix;
 - no lookup delete/recreate pattern;
 - no secrets or non-synthetic personal data;
 - metadata completeness in EN, DE, FR and IT;
 - rejection of blank, tautological, placeholder or untranslated metadata;
 - alternate-key and relationship definitions present;
-- expected MINOR version bump.
+- expected MINOR version bump;
+- the steady-state DEV CI path excludes role mutation;
+- exact four-package export list after convergence.
 
-### Environment smoke tests
+### DEV authoring and export smoke tests
 
-- all required LCIDs active;
-- both solutions present with expected managed state and versions;
+- all required LCIDs active in DEV;
+- Foundation and DataModel present in DEV with expected unmanaged state and
+  versions;
+- the two reviewed custom roles exist in `crmshow_Foundation` and match the
+  reviewed privilege contract;
 - Account and Contact extension columns available;
 - three custom tables, relationships and alternate keys available;
-- Reader can read but cannot mutate;
-- Data Steward can create/update but cannot administer security;
-- fixture rerun creates no duplicates;
-- fixture and import payloads with invalid effective-date order are rejected
-  before mutation; online data-quality checks report any invalid records
-  created through other write paths;
+- import payloads with invalid effective-date order are rejected before
+  mutation; online data-quality checks report any invalid records created
+  through other write paths;
 - the Customer lookup accepts exactly one Account or Contact reference;
 - duplicate or overlapping role intervals are reported for Data Steward
   review;
 - source-removal simulation end-dates/deactivates rather than deletes;
-- localized labels and descriptions can be retrieved for all four LCIDs.
+- localized labels and descriptions can be retrieved for all four LCIDs;
+- exact managed and unmanaged Foundation/DataModel packages are exported as one
+  immutable artifact;
+- a second run under the DEV identity is idempotent and does not attempt role
+  mutation.
 
-The PR and feature issue link the green workflow run, package versions and
-smoke-test evidence.
+### Follow-up managed TEST promotion validation
+
+- required LCIDs active in TEST;
+- no unmanaged active layer in TEST after managed import;
+- both solutions present with expected managed state and versions;
+- persona-based Reader/Data Steward smoke tests pass;
+- fixtures rerun without duplicates;
+- package versions, managed import evidence and rollback evidence are attached
+  to the workflow run.
+
+The PR and feature issue link the green Sprint 3 authoring/export run, package
+versions and evidence. The TEST deployment evidence above remains tracked for
+the follow-up solution-versioning sprint.
 
 Universal server-side effective-date enforcement is not a Sprint 3 completion
 criterion. It is tracked as
 [OR-001](../../requirements/OR-001-effective-date-integrity.md) and
 [feature #9](https://github.com/urruegg/CRMShowcase/issues/9).
 
-## 13. Sprint 4 dependency
+## 13. Follow-up sequence
 
-Sprint 4 — Relocation Vertical Slice — starts only after Sprint 3 is deployed
-successfully to TEST. It extends the foundation with Location, Jurisdiction,
+The next sprint/work after Sprint 3 consumes the exported packages for managed
+TEST promotion. It establishes:
+
+- managed install/update/upgrade behavior in TEST;
+- TEST deployment evidence and version-monotonicity controls;
+- synthetic fixtures and persona security smoke tests;
+- rollback handling for managed package promotion.
+
+The Relocation Vertical Slice starts only after that managed promotion path is
+proven. It extends the foundation with Location, Jurisdiction,
 CoverageProjection, RiskObjectProjection and typed facets, AccountAssignment,
 ChangeEvent, ImpactAssessment, EligibilityDecision and integration contracts.
 
-Sprint 4 reopens the Option C hypothesis if core-system or data-platform
-evidence shows that:
+The follow-up sequence reopens the Option C hypothesis if core-system or
+data-platform evidence shows that:
 
 - source identities cannot support the alternate-key strategy;
 - party roles or effective dates are mastered differently;
@@ -463,13 +516,21 @@ Sprint 3 is complete when:
 
 - the feature issue and implementation PR provide story-to-ADR-to-test
   traceability;
-- required languages are active in DEV and TEST through the IaC control;
+- required languages are active in DEV through the IaC control, and the same
+  LCID contract is preserved for later TEST promotion;
 - Foundation and DataModel source is committed with complete localized
   semantic metadata;
+- the administrator prerequisite for the two custom roles is completed and
+  read-only verification confirms the reviewed role contract before export;
 - automated validation is green;
-- unmanaged DEV and managed TEST deployments succeed through the pipeline;
-- fixtures and smoke tests pass in both environments;
-- package versions and evidence are attached to the PR;
-- the sandbox deployment is reviewable by the Product Owner, Enterprise
-  Architect, Dataverse Modeler, CRM Domain Expert, Insurance Domain Expert and
-  Responsible-AI Officer.
+- unmanaged DEV authoring/import and exact package export succeed through the
+  pipeline;
+- the exact four-file package set and authoring/export evidence are attached
+  to the PR and linked issue;
+- a second DEV run is idempotent and does not attempt role mutation;
+- the DEV environment and exported packages are reviewable by the Product
+  Owner, Enterprise Architect, Dataverse Modeler, CRM Domain Expert,
+  Insurance Domain Expert and Responsible-AI Officer;
+- managed TEST promotion, TEST deployment evidence, fixtures and persona
+  security smoke tests remain linked follow-up work rather than being implied
+  as delivered.

--- a/docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
@@ -36,7 +36,8 @@ boundaries under the review triggers in ADR-0019.
 > security roles. The approved demo scope and administrator prerequisite are
 > defined in
 > [Demo-Feasible Dataverse Authoring and Bootstrap](./2026-08-09-demo-feasible-dataverse-authoring-design.md)
-> and ADR-0023. Managed TEST promotion remains a separate sprint.
+> and [ADR-0023](../../adr/ADR-0023-demo-feasible-dataverse-bootstrap.md).
+> Managed TEST promotion remains a separate sprint.
 
 ## 2. Scope
 

--- a/docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-08-insurance-foundation-design.md
@@ -31,6 +31,13 @@ The sprint is a reviewable foundation, not a claim that the target model is
 final. Core-system and data-platform discovery may change the projection
 boundaries under the review triggers in ADR-0019.
 
+> **Demo feasibility amendment (2026-08-09).** The current tenant permits the
+> environment-scoped CI application user to author schema metadata but not
+> security roles. The approved demo scope and administrator prerequisite are
+> defined in
+> [Demo-Feasible Dataverse Authoring and Bootstrap](./2026-08-09-demo-feasible-dataverse-authoring-design.md)
+> and ADR-0023. Managed TEST promotion remains a separate sprint.
+
 ## 2. Scope
 
 ### Included

--- a/docs/superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md
+++ b/docs/superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md
@@ -1,0 +1,415 @@
+# Demo-Feasible Dataverse Authoring and Bootstrap
+
+| Field | Value |
+| --- | --- |
+| **Status** | Approved design - ready for implementation planning |
+| **Date** | 2026-08-09 |
+| **Decision mode** | Reversible implementation hypothesis |
+| **Working hypothesis** | Separate tenant-feasible demo delivery from privileged target-state automation so the showcase can complete without weakening the steady-state CI identity. |
+| **Confidence** | High for the demo boundary; medium for the target bootstrap pattern until tenant administration capabilities are validated |
+| **Maturity** | Demo approach approved; target bootstrap remains a hypothesis |
+| **Licence** | Configuration / own build; Power Platform and Dynamics 365 entitlements must be validated per environment |
+| **Upgrade impact** | Medium - splits the initial authoring workflow into preflight, schema authoring, manual security bootstrap, and export gates |
+| **Related** | [Sprint 3 Insurance Foundation](./2026-08-08-insurance-foundation-design.md) - [ADR-0005](../../adr/ADR-0005-power-platform-application-users-for-ci.md) - [ADR-0017](../../adr/ADR-0017-alm-everything-through-the-pipeline.md) - [ADR-0021](../../adr/ADR-0021-multilingual-semantic-dataverse-metadata.md) - [Issue #8](https://github.com/urruegg/CRMShowcase/issues/8) - [Issue #40](https://github.com/urruegg/CRMShowcase/issues/40) |
+| **Frameworks** | CAF Ready, Adopt, Govern, Secure and Manage - WAF Reliability, Security and Operational Excellence - Zero Trust |
+
+## 1. Outcome
+
+The CRM Showcase must demonstrate a multilingual Insurance Foundation in the
+available demo tenant without pretending that every target-state platform
+operation is automatable under the current tenant permissions.
+
+The implementation therefore has two explicit scopes:
+
+1. **Demo-deliverable now:** a repeatable DEV workflow using the existing
+   environment-scoped OIDC application user and its `System Customizer` role.
+   It authors and validates tenant-feasible metadata and exports the reviewed
+   Foundation and DataModel packages.
+2. **Target-architecture hypothesis:** privileged environment bootstrap,
+   automated security-role creation, and managed TEST promotion. These remain
+   documented and reviewable, but they do not block the demo when the current
+   tenant cannot support them safely.
+
+The design does not solve permission failures by permanently elevating the DEV
+CI identity. Expected Dataverse authorization boundaries are treated as
+preconditions and scope decisions, not as transient GitHub Actions errors.
+
+## 2. Evidence and root cause
+
+GitHub Actions run
+[31302762752](https://github.com/urruegg/CRMShowcase/actions/runs/31302762752/job/93218095999)
+successfully reconciled:
+
+- the four required languages;
+- five shared choices;
+- Account and Contact extensions;
+- `AccountContactRole`, `PolicyProjection`, and `PolicyPartyRole`;
+- ordinary and Customer lookups;
+- alternate keys;
+- invalid-date and overlap reporting views;
+- administration views and forms;
+- multilingual record metadata.
+
+It then failed when `Publish-InsuranceFoundation.ps1 -Scope All` attempted to
+create a Dataverse security role. The environment-scoped application user has
+`System Customizer`, which intentionally lacks `prvCreateRole`.
+
+The immediate authorization error is not the only root cause. The current
+implementation also:
+
+- combines environment bootstrap, schema authoring, security administration,
+  convergence, and package export in one workflow;
+- validates privileges only when a mutation is attempted;
+- treats security roles like ordinary solution metadata even though they
+  control access for the identity running the workflow;
+- assumes immediate read-after-write consistency for metadata that Dataverse
+  persists asynchronously;
+- depends on operator-triggered reruns to recover newly visible relationships
+  and columns;
+- uses live Web API authoring for both the one-time bootstrap and the
+  steady-state delivery path.
+
+The design must remove these couplings rather than add retries around the final
+authorization error.
+
+## 3. Constraints
+
+### Known tenant and platform constraints
+
+- `crm-showcase-ci-dev` is an environment-scoped Dataverse application user
+  with `System Customizer`.
+- The identity can author the tested schema metadata but cannot create security
+  roles or grant itself additional privileges.
+- CI must not self-elevate.
+- Creating or changing the application user's role requires an authorized
+  Power Platform administrator.
+- Dataverse metadata writes can be asynchronous and can normalize stored XML,
+  component ownership, and key ordering.
+- The current Terraform provider cannot create the Dataverse application user
+  with its role; the repository uses an administrator-run bootstrap script.
+- The showcase is a demo. It must not be blocked by target-state automation
+  that cannot be executed safely in the available tenant.
+
+### Non-negotiable guardrails
+
+- OIDC federation remains mandatory; no client secret is introduced.
+- The steady-state DEV identity remains least-privileged.
+- No production tenant or real customer data is used.
+- Every environment mutation is reviewable and traceable to a story and ADR.
+- Partial metadata is never deleted and recreated to make a run pass.
+- Unsupported target-state automation is documented as a hypothesis instead
+  of being presented as delivered capability.
+
+## 4. Options evaluated
+
+### Option A - Permanently elevate the DEV CI identity
+
+Assign `System Administrator` or a broad custom role that includes security-role
+management to `crm-showcase-ci-dev`.
+
+**Advantages**
+
+- The existing monolithic workflow can create all components.
+- Minimal workflow refactoring.
+
+**Disadvantages**
+
+- Violates least privilege for every subsequent run.
+- Expands the impact of a compromised workflow or repository.
+- Makes a one-time bootstrap permission a permanent runtime permission.
+- Does not solve late precondition discovery or metadata convergence.
+
+**Decision:** rejected for both demo and target architecture.
+
+### Option B - Remove security roles from the showcase
+
+Author only choices and data-model components, then export packages without the
+two custom roles.
+
+**Advantages**
+
+- Runs under the current CI identity.
+- Lowest implementation effort.
+
+**Disadvantages**
+
+- Weakens the reviewed Foundation solution and demo access story.
+- Produces packages that do not match the approved Sprint 3 design.
+- Avoids rather than models the bootstrap boundary.
+
+**Decision:** rejected as the default. It remains an emergency fallback only if
+the tenant administrator cannot perform the bounded manual prerequisite.
+
+### Option C - Split demo delivery from privileged bootstrap
+
+Keep schema authoring and export in the least-privileged workflow. Create the
+two reviewed roles once through an authorized Power Platform administrator
+runbook, then have CI verify rather than create them. Document a
+dedicated automated bootstrap identity as the target-state hypothesis.
+
+**Advantages**
+
+- Delivers the intended demo packages without permanent CI elevation.
+- Makes the tenant restriction explicit and auditable.
+- Removes the circular dependency between the CI identity and role creation.
+- Supports a later transition to automated privileged bootstrap.
+- Keeps normal DEV reruns within the tested `System Customizer` capability.
+
+**Disadvantages**
+
+- The first demo deployment has a manual administrator prerequisite.
+- Initial environment bootstrap is not fully pipeline-driven.
+- The manual role creation must be captured back into exported solution source.
+
+**Decision:** preferred.
+
+## 5. Scope boundary
+
+| Capability | Demo implementation | Target-architecture hypothesis |
+| --- | --- | --- |
+| Authentication | Existing environment-scoped OIDC application user | Separate OIDC identities for bootstrap and deployment |
+| DEV steady-state role | `System Customizer` | Purpose-built deployment role validated against a capability matrix |
+| Languages | Verify and reconcile EN, DE, FR, IT with the current control | Environment bootstrap fully automated where tenant APIs and permissions permit |
+| Shared choices | Author and reconcile in `crmshow_Foundation` | Import from versioned solution source |
+| Data model | Author and reconcile all reviewed Sprint 3 tables and children | Import from versioned solution source |
+| Custom security roles | One-time administrator/maker creation from the reviewed contract; CI verifies | Approved bootstrap workflow creates and updates roles |
+| DEV packages | Export exact managed and unmanaged Foundation/DataModel packages | Build packages from reviewed unpacked source |
+| TEST promotion | Deferred to the solution-versioning sprint | Managed install/update/upgrade with approvals and rollback |
+| Fixtures and persona security smoke tests | Deferred until custom roles exist and are exported | Automated after managed deployment |
+
+## 6. Workflow architecture
+
+### 6.1 Read-only preflight
+
+The first job performs no Dataverse mutation. It validates:
+
+- GitHub Environment variables and OIDC authentication;
+- target environment identity;
+- required languages and their current provisioned state;
+- solution existence and publisher ownership;
+- required privileges for the selected workflow phase;
+- the existence and solution membership of the two custom roles;
+- contract integrity and offline Pester suites;
+- whether metadata authoring, role bootstrap, or export is required.
+
+The preflight emits a structured plan with these phase states:
+
+- `Ready`
+- `AlreadyConverged`
+- `ManualPrerequisite`
+- `UnsupportedInTenant`
+- `ContractConflict`
+
+If a selected phase is not feasible, the workflow stops before mutation and
+reports the exact prerequisite. A missing `prvCreateRole` is therefore found
+before any schema operation when role creation is requested.
+
+### 6.2 Demo schema authoring
+
+The normal DEV authoring workflow runs only tenant-feasible scopes:
+
+1. shared choices;
+2. Account and Contact extensions;
+3. one custom table at a time;
+4. table publication;
+5. relationship and column convergence;
+6. alternate keys;
+7. views and forms;
+8. read-only full-contract validation.
+
+Security-role creation is not part of this mutation path.
+
+Each table phase must poll for the metadata it just created before dependent
+components are submitted. Polling is condition-based and bounded. A timeout
+reports `EventualConsistencyTimeout` with the table and missing component; it
+does not rely on a new workflow run to continue.
+
+### 6.3 Manual security bootstrap
+
+The demo accepts a one-time authorized Power Platform administrator action:
+
+1. create the two reviewed custom roles in `crmshow_Foundation`;
+2. configure only the privileges defined by the reviewed contract;
+3. publish the roles;
+4. verify their solution membership;
+5. rerun the read-only preflight.
+
+The implementation plan must provide an idempotent runbook and verification
+script. It must not require the administrator to expose credentials to GitHub.
+
+If the tenant cannot support custom role creation at all, the fallback is:
+
+- demonstrate schema and multilingual metadata in DEV;
+- document security roles as not delivered in the demo;
+- do not claim the Foundation package is complete;
+- record the gap and target-state hypothesis in the ADR and issue evidence.
+
+This fallback is a reduced showcase, not Sprint 3 completion.
+
+### 6.4 Export gate
+
+Export runs only after the full demo convergence check succeeds. It verifies
+exactly:
+
+- `crmshow_Foundation.zip`
+- `crmshow_Foundation_managed.zip`
+- `crmshow_DataModel.zip`
+- `crmshow_DataModel_managed.zip`
+
+The workflow uploads the four files as one immutable run artifact. Export does
+not run after a partial authoring result.
+
+### 6.5 Source-first steady state
+
+After the first successful export:
+
+1. unpack both unmanaged packages into `solution/`;
+2. review and commit the actual Dataverse source;
+3. stop reconstructing released metadata through live Web API authoring;
+4. use package import for subsequent DEV and TEST deployment;
+5. retain the authoring script only for initial environment bootstrap,
+   diagnostics, and contract comparison.
+
+This is the transition point from prototype authoring to normal ALM.
+
+## 7. Component boundaries
+
+The current `Publish-InsuranceFoundation.ps1 -Scope All` contract must be
+split into independently invokable capabilities:
+
+| Capability | Responsibility |
+| --- | --- |
+| `Test-InsuranceAuthoringPreflight` | Read-only identity, privilege, environment, solution, and contract checks |
+| `Set-InsuranceFoundationChoices` | Shared choices only |
+| `Set-InsuranceDataModel` | Native extensions, tables, relationships, keys, views, and forms |
+| `Test-InsuranceSecurityRoles` | Read-only role existence, ownership, and privilege comparison |
+| `Set-InsuranceSecurityRoles` | Privileged target-state/bootstrap operation; excluded from normal demo CI |
+| `Test-InsuranceFoundationConvergence` | Full read-only semantic verification before export |
+| `Export-InsuranceFoundationPackages` | Exact package export and verification |
+
+Each capability has one privilege profile and one failure boundary. Consumers
+do not need to understand its internal Web API calls.
+
+## 8. Error handling and diagnostics
+
+Failures are classified as:
+
+| Classification | Meaning | Workflow behavior |
+| --- | --- | --- |
+| `Precondition` | Required input, language, solution, or role is missing | Stop before mutation and identify the prerequisite |
+| `Authorization` | The identity lacks a required Dataverse privilege | Stop before mutation when detectable; never retry or elevate |
+| `ContractConflict` | Existing metadata differs semantically from the reviewed contract | Fail closed with actual and expected structure |
+| `PlatformNormalization` | Dataverse added or reordered platform-owned metadata | Compare canonical semantic structure |
+| `EventualConsistencyTimeout` | Created metadata did not become readable within the bounded wait | Stop with component-specific recovery evidence |
+| `Transport` | Authentication, OIDC assertion, PAC, or Web API request failed | Report the failed boundary and safe rerun point |
+| `Export` | Package export or exact package verification failed | Preserve authored metadata and fail without publishing an incomplete artifact |
+
+Every failure includes:
+
+- phase;
+- component;
+- classification;
+- identity and environment slot, without tokens;
+- required capability or privilege;
+- whether mutation occurred;
+- safe next action.
+
+## 9. Testing strategy
+
+### Offline tests
+
+- preflight capability and privilege mapping;
+- workflow phase selection;
+- security-role creation excluded from the normal demo scope;
+- condition-based metadata polling and timeout;
+- semantic XML normalization;
+- alternate-key set comparison;
+- exact package list;
+- no mutation when preflight returns `ManualPrerequisite` or
+  `UnsupportedInTenant`.
+
+### Online DEV evidence
+
+1. preflight reports the role prerequisite before mutation when roles are
+   absent;
+2. schema authoring converges in one workflow run without operator reruns;
+3. the administrator-created roles pass read-only verification;
+4. export produces exactly four packages;
+5. a second run under `System Customizer` is idempotent and does not attempt
+   role mutation.
+
+### Negative evidence
+
+- a role-create request under `System Customizer` is rejected by tests before
+  reaching Dataverse;
+- a contract conflict fails closed;
+- an unavailable language or missing solution blocks mutation;
+- a polling timeout names the unresolved component.
+
+## 10. Demo acceptance criteria
+
+Sprint 3 is demo-complete when:
+
+- EN, DE, FR, and IT are provisioned and verified in DEV;
+- all reviewed choices, native extensions, tables, lookups, relationships,
+  keys, views, and forms converge;
+- the two reviewed custom roles exist in `crmshow_Foundation`;
+- the normal CI workflow does not require `prvCreateRole`;
+- one clean run under the steady-state DEV identity reaches export;
+- exactly four Foundation/DataModel packages are uploaded;
+- a second run is idempotent;
+- evidence is linked to issue #8;
+- TEST promotion, fixtures, and persona security smoke tests remain separately
+  scoped rather than being implied as complete.
+
+## 11. Target-architecture hypothesis and review triggers
+
+A new ADR must record the hypothesis that mature environments use:
+
+- a dedicated bootstrap identity with environment approval;
+- a separate least-privileged deployment identity;
+- explicit privilege capability matrices;
+- source-first managed solution promotion after bootstrap;
+- automated removal or expiry of temporary bootstrap access.
+
+Reopen the hypothesis when:
+
+- the Power Platform Terraform provider can manage application users and role
+  assignments;
+- Power Platform exposes a supported environment bootstrap API that removes
+  the manual prerequisite;
+- the customer tenant provides privileged identity management or just-in-time
+  environment administration;
+- managed TEST promotion reveals permissions not covered by the proposed
+  deployment role;
+- solution imports can reliably create and update the reviewed security roles
+  without a separate role-authoring identity.
+
+The Enterprise Architect and SecDevOps owner decide whether new evidence moves
+the target bootstrap from hypothesis to committed architecture.
+
+## 12. Consequences
+
+### Positive
+
+- The demo becomes deliverable under known tenant restrictions.
+- Expected authorization boundaries are discovered before mutation.
+- The steady-state CI identity remains least-privileged.
+- Workflow reruns are no longer the convergence mechanism.
+- The target architecture remains documented without being falsely claimed as
+  implemented.
+
+### Trade-offs
+
+- Initial custom-role creation remains a manual administrator prerequisite.
+- The authoring workflow and script gain explicit phase boundaries.
+- Full managed TEST promotion moves to the next sprint.
+- The first exported source remains the bridge from prototype authoring to
+  source-first ALM.
+
+### Reversibility
+
+The demo scoping is reversible. When the tenant supports a dedicated automated
+bootstrap identity, the privileged security-role phase can move from the
+runbook into an approved workflow without changing the schema contract or the
+steady-state deployment path.

--- a/infra/scripts/Set-DataverseLanguages.ps1
+++ b/infra/scripts/Set-DataverseLanguages.ps1
@@ -18,6 +18,8 @@ param(
     [int[]]$LocaleId
 )
 
+. (Join-Path $PSScriptRoot '..\..\scripts\solution\ConvertTo-SafeCliDiagnosticLine.ps1')
+
 $ErrorActionPreference = 'Stop'
 $script:SupportedLocaleIds = @(1031, 1033, 1036, 1040)
 
@@ -118,9 +120,10 @@ function Invoke-DataverseRest {
             )
         }
 
-        $result = & az @arguments
+        $result = & az @arguments 2>&1
         if ($LASTEXITCODE -ne 0) {
-            throw "Dataverse request failed: $Method $Url."
+            $detail = ConvertTo-SafeCliDiagnosticLine -Value $result
+            throw "Dataverse request failed: $Method $Url. Output: $detail"
         }
         if ($result) {
             return $result | ConvertFrom-Json
@@ -172,7 +175,13 @@ function Invoke-DataverseLanguageReconciliation {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    $baseUrl = $EnvironmentUrl.TrimEnd('/')
-    $requiredLocaleIds = Get-NormalizedLocaleIds -LocaleId $LocaleId
-    Invoke-DataverseLanguageReconciliation -BaseUrl $baseUrl -RequiredLocaleId $requiredLocaleIds
+    try {
+        $baseUrl = $EnvironmentUrl.TrimEnd('/')
+        $requiredLocaleIds = Get-NormalizedLocaleIds -LocaleId $LocaleId
+        Invoke-DataverseLanguageReconciliation -BaseUrl $baseUrl -RequiredLocaleId $requiredLocaleIds
+    }
+    catch {
+        Write-SafeCliErrorLine -ErrorRecord $_
+        exit 1
+    }
 }

--- a/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
+++ b/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
@@ -183,9 +183,10 @@ Describe 'Invoke-DataverseRest' {
         script:Assert-SafeDiagnosticLine -Text $message -MaxLength 400
         $message | Should -Match 'Dataverse request failed: GET'
         $message | Should -Match 'RetrieveProvisionedLanguages\(\)'
+        $message | Should -Match 'Output:'
         $message | Should -Match (
             [regex]::Escape(
-                "Output: '::warning::language transport Permission denied blocked"
+                '::warning::language transport Permission denied blocked'
             )
         )
         $message | Should -Not -Match 'At line:|--method|--url|--resource'
@@ -266,9 +267,10 @@ Describe 'Set-DataverseLanguages entry point' {
         script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
         $invocation.Output | Should -Match 'Dataverse request failed: GET'
         $invocation.Output | Should -Match 'RetrieveProvisionedLanguages\(\)'
+        $invocation.Output | Should -Match 'Output:'
         $invocation.Output | Should -Match (
             [regex]::Escape(
-                "'::warning::language transport Permission denied blocked"
+                '::warning::language transport Permission denied blocked'
             )
         )
         $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'

--- a/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
+++ b/infra/scripts/tests/Set-DataverseLanguages.Tests.ps1
@@ -1,6 +1,108 @@
 BeforeAll {
-    $scriptPath = Join-Path $PSScriptRoot '..\Set-DataverseLanguages.ps1'
-    . $scriptPath -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' -LocaleId 1033
+    $script:scriptPath = Join-Path $PSScriptRoot '..\Set-DataverseLanguages.ps1'
+    $script:childPowerShellPath = if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+        (Get-Command pwsh -ErrorAction Stop).Source
+    }
+    else {
+        (Get-Command powershell -ErrorAction Stop).Source
+    }
+    . $script:scriptPath -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' -LocaleId 1033
+
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+
+    function script:New-LanguageAzShim {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath
+        )
+
+        $shimScriptPath = Join-Path $RootPath 'az.ps1'
+        $shimCommandPath = Join-Path $RootPath 'az'
+        $shimScript = @'
+#!/usr/bin/env pwsh
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+)
+
+$ErrorActionPreference = 'Stop'
+$escape = [char]27
+Write-Error (
+    "::warning::language transport`r`nPermission denied`t" +
+    "$escape[31mblocked$escape[0m"
+) -ErrorAction Continue
+exit 23
+'@
+
+        $shimScript = $shimScript -replace "`r`n", "`n"
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
+        [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
+
+        if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
+            & chmod +x -- $shimCommandPath
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to make az shim executable: $shimCommandPath"
+            }
+        }
+    }
+
+    function script:Invoke-LanguageEntryScript {
+        [CmdletBinding()]
+        param()
+
+        $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+        $null = New-Item -ItemType Directory -Path $testRoot -Force
+        script:New-LanguageAzShim -RootPath $testRoot
+
+        $previousPath = $env:PATH
+        try {
+            $pathSeparator = [System.IO.Path]::PathSeparator
+            $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
+                $testRoot
+            }
+            else {
+                "$testRoot$pathSeparator$previousPath"
+            }
+
+            $previousErrorActionPreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            try {
+                $output = & $script:childPowerShellPath `
+                    -NoLogo `
+                    -NoProfile `
+                    -NonInteractive `
+                    -File $script:scriptPath `
+                    -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' `
+                    -LocaleId 1033 2>&1
+                $exitCode = $LASTEXITCODE
+            }
+            finally {
+                $ErrorActionPreference = $previousErrorActionPreference
+            }
+        }
+        finally {
+            $env:PATH = $previousPath
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+        }
+    }
 }
 
 Describe 'Get-NormalizedLocaleIds' {
@@ -48,6 +150,45 @@ Describe 'Wait-DataverseLanguage' {
 
         Should -Invoke Get-ProvisionedLocaleIds -Times 1 -Exactly
         Should -Invoke Start-Sleep -Times 0 -Exactly
+    }
+}
+
+Describe 'Invoke-DataverseRest' {
+    AfterEach {
+        Remove-Item Function:\az -ErrorAction SilentlyContinue
+    }
+
+    It 'sanitizes hostile az output on transport failure' {
+        $escape = [char]27
+        function global:az {
+            Write-Error (
+                "::warning::language transport`r`nPermission denied`t" +
+                "$escape[31mblocked$escape[0m"
+            ) -ErrorAction Continue
+            $global:LASTEXITCODE = 23
+        }
+
+        $message = $null
+        try {
+            Invoke-DataverseRest `
+                -Method GET `
+                -Url 'https://crmshowdev.crm.dynamics.com/api/data/v9.2/RetrieveProvisionedLanguages()' |
+                Out-Null
+            throw 'Expected transport failure.'
+        }
+        catch {
+            $message = $_.Exception.Message
+        }
+
+        script:Assert-SafeDiagnosticLine -Text $message -MaxLength 400
+        $message | Should -Match 'Dataverse request failed: GET'
+        $message | Should -Match 'RetrieveProvisionedLanguages\(\)'
+        $message | Should -Match (
+            [regex]::Escape(
+                "Output: '::warning::language transport Permission denied blocked"
+            )
+        )
+        $message | Should -Not -Match 'At line:|--method|--url|--resource'
     }
 }
 
@@ -114,5 +255,22 @@ Describe 'Invoke-DataverseLanguageReconciliation' {
         Should -Invoke Wait-DataverseLanguage -Times 0 -Exactly
         $evidence.LocaleId | Should -Be @(1031, 1033)
         $evidence.State | Should -Be @('Planned', 'Active')
+    }
+}
+
+Describe 'Set-DataverseLanguages entry point' {
+    It 'emits a single safe error line when az transport fails' {
+        $invocation = script:Invoke-LanguageEntryScript
+
+        $invocation.ExitCode | Should -Be 1
+        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
+        $invocation.Output | Should -Match 'Dataverse request failed: GET'
+        $invocation.Output | Should -Match 'RetrieveProvisionedLanguages\(\)'
+        $invocation.Output | Should -Match (
+            [regex]::Escape(
+                "'::warning::language transport Permission denied blocked"
+            )
+        )
+        $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'
     }
 }

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -15,7 +15,7 @@ Design: [../../docs/adr/ADR-0003-terraform-as-iac-toolchain.md](../../docs/adr/A
 | `terraform.tfvars.example` | **Committed placeholder** values. |
 | `terraform.tfvars` | **GIT-IGNORED** real values (create locally). |
 | `modules/entra/` | Entra app registrations + federated credentials for CI. |
-| `modules/github/` | GitHub Environments, deployment policies, variables, and desired branch protection. |
+| `modules/github/` | GitHub Environments, deployment policies, variables, and branch protection. |
 | `modules/powerplatform/` | Power Platform environments + tenant settings. |
 
 ## Bootstrap on the current tenant (ABSx demo)
@@ -58,20 +58,24 @@ terraform init
 # 5. Import existing GitHub Environments (import ID format: <repo>:<environment>)
 terraform import 'module.github.github_repository_environment.envs["dev"]' 'CRMShowcase:dev'
 terraform import 'module.github.github_repository_environment.envs["test"]' 'CRMShowcase:test'
-# 6. Import the existing TEST main deployment policy (import ID format: <repo>:<environment>:<policy_id>)
+# 6. Import the existing live DEV + TEST main deployment policies
+#    (IDs captured from live evidence on 2026-08-10; re-check if either GitHub Environment is recreated)
+terraform import 'module.github.github_repository_environment_deployment_policy.allowed_branches["dev:main"]' 'CRMShowcase:dev:56913774'
 terraform import 'module.github.github_repository_environment_deployment_policy.allowed_branches["test:main"]' 'CRMShowcase:test:56680080'
-# 7. Review the plan carefully
+# 7. Import the existing live main branch protection
+terraform import 'module.github.github_branch_protection.main' 'CRMShowcase:main'
+# 8. Review the plan carefully
 terraform plan
-# 8. Only if the plan shows exactly the intended changes:
+# 9. Only if the plan shows exactly the intended changes:
 terraform apply
-# 9. Add the two CI service principals as Dataverse application users
+# 10. Add the two CI service principals as Dataverse application users
 #    (Terraform provider does not yet support this — see ADR-0005)
 ../../infra/scripts/add-ci-app-users.ps1 -Slot all
-# 10. Reconcile required languages before importing multilingual solutions
+# 11. Reconcile required languages before importing multilingual solutions
 ../../infra/scripts/Set-DataverseLanguages.ps1 `
   -EnvironmentUrl https://crmshowdev.crm.dynamics.com `
   -LocaleId 1033,1031,1036,1040
-# 11. Import solutions only after language reconciliation reports every LCID Active
+# 12. Import solutions only after language reconciliation reports every LCID Active
 ../../scripts/solution/Import-Solution.ps1 -ZipFile <SOLUTION_ZIP>
 ```
 
@@ -82,11 +86,14 @@ Before `terraform apply`, confirm all of the following in the plan:
 - `module.github.github_repository_environment.envs["test"]` keeps
   `prevent_self_review = false`.
 - `module.github.github_repository_environment_deployment_policy.allowed_branches["dev:main"]`
-  is a create, because DEV currently has no live deployment branch policy.
-- `module.github.github_branch_protection.main` is a create unless the live repo
-  already has matching branch protection. If live state changes, import
-  `module.github.github_branch_protection.main` with `CRMShowcase:main` before
-  apply instead of letting Terraform replace or drift it.
+  and `["test:main"]` both remain imported from live state. At time of
+  evidence, the live policy IDs are `56913774` for `dev:main` and `56680080`
+  for `test:main`; if either GitHub Environment is recreated, re-check the
+  current live policy ID before re-importing Terraform state.
+- `module.github.github_branch_protection.main` remains imported from live
+  state and shows `required_linear_history = true`,
+  `dismiss_stale_reviews = true`, `required_approving_review_count = 0`, and
+  `contexts = ["gate1"]` with no unexpected replacement.
 
 ## Bootstrap on a fresh tenant
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -14,38 +14,79 @@ Design: [../../docs/adr/ADR-0003-terraform-as-iac-toolchain.md](../../docs/adr/A
 | `outputs.tf` | Useful outputs (env URLs, IDs). |
 | `terraform.tfvars.example` | **Committed placeholder** values. |
 | `terraform.tfvars` | **GIT-IGNORED** real values (create locally). |
+| `modules/entra/` | Entra app registrations + federated credentials for CI. |
+| `modules/github/` | GitHub Environments, deployment policies, variables, and desired branch protection. |
 | `modules/powerplatform/` | Power Platform environments + tenant settings. |
 
 ## Bootstrap on the current tenant (ABSx demo)
 
 The two showcase environments already exist and were renamed to the anonymised
-`crmshowdev` / `crmshowtest` slot names. To bring them under Terraform management
-without recreating them:
+`crmshowdev` / `crmshowtest` slot names. The GitHub repository also already has
+live Environment objects. Start from a clean local state, import the existing
+live objects, then inspect the first plan before any apply. `../../infra/scripts/bootstrap-import.ps1`
+only imports the Power Platform environments; the GitHub reviewed-ref controls
+stay explicit in the runbook below.
+
+### Auth prerequisites
+
+```powershell
+# Azure / Power Platform provider auth
+az login --tenant <TENANT_ID> --use-device-code --allow-no-subscriptions
+
+# GitHub CLI session for operator checks
+gh auth status
+
+# GitHub provider auth for Terraform (do not paste tokens into files)
+$env:GH_TOKEN = (gh auth token)
+$env:GITHUB_TOKEN = $env:GH_TOKEN
+```
+
+Use a GitHub session or token that can administer this repository's
+environments, deployment policies, and branch protection. Do not store it in
+`terraform.tfvars`, shell profile files, or any committed artifact.
+
+### Existing-tenant bootstrap sequence
 
 ```powershell
 # 1. Copy the example to the git-ignored real tfvars
 Copy-Item terraform.tfvars.example terraform.tfvars
 # 2. Fill in real tenant_id, github_owner, environment id GUIDs, security_group_id
-# 3. Sign in to the demo tenant if not already
-az login --tenant <TENANT_ID> --use-device-code --allow-no-subscriptions
-# 4. Initialise Terraform
+# 3. Initialise Terraform
 terraform init
-# 5. Import existing envs (uses the id values from terraform.tfvars)
+# 4. Import existing Power Platform envs (uses the id values from terraform.tfvars)
 ../../infra/scripts/bootstrap-import.ps1
-# 6. Review the plan carefully
+# 5. Import existing GitHub Environments (import ID format: <repo>:<environment>)
+terraform import 'module.github.github_repository_environment.envs["dev"]' 'CRMShowcase:dev'
+terraform import 'module.github.github_repository_environment.envs["test"]' 'CRMShowcase:test'
+# 6. Import the existing TEST main deployment policy (import ID format: <repo>:<environment>:<policy_id>)
+terraform import 'module.github.github_repository_environment_deployment_policy.allowed_branches["test:main"]' 'CRMShowcase:test:56680080'
+# 7. Review the plan carefully
 terraform plan
-# 7. Only if the plan shows exactly the intended changes:
+# 8. Only if the plan shows exactly the intended changes:
 terraform apply
-# 8. Add the two CI service principals as Dataverse application users
+# 9. Add the two CI service principals as Dataverse application users
 #    (Terraform provider does not yet support this — see ADR-0005)
 ../../infra/scripts/add-ci-app-users.ps1 -Slot all
-# 9. Reconcile required languages before importing multilingual solutions
+# 10. Reconcile required languages before importing multilingual solutions
 ../../infra/scripts/Set-DataverseLanguages.ps1 `
   -EnvironmentUrl https://crmshowdev.crm.dynamics.com `
   -LocaleId 1033,1031,1036,1040
-# 10. Import solutions only after language reconciliation reports every LCID Active
+# 11. Import solutions only after language reconciliation reports every LCID Active
 ../../scripts/solution/Import-Solution.ps1 -ZipFile <SOLUTION_ZIP>
 ```
+
+Before `terraform apply`, confirm all of the following in the plan:
+
+- `module.github.github_repository_environment.envs["test"]` retains reviewer
+  user ID `46865858`; there must be **no reviewer removal**.
+- `module.github.github_repository_environment.envs["test"]` keeps
+  `prevent_self_review = false`.
+- `module.github.github_repository_environment_deployment_policy.allowed_branches["dev:main"]`
+  is a create, because DEV currently has no live deployment branch policy.
+- `module.github.github_branch_protection.main` is a create unless the live repo
+  already has matching branch protection. If live state changes, import
+  `module.github.github_branch_protection.main` with `CRMShowcase:main` before
+  apply instead of letting Terraform replace or drift it.
 
 ## Bootstrap on a fresh tenant
 
@@ -54,14 +95,24 @@ For "deploy to any tenant" reproducibility:
 ```powershell
 # 1. Sign in to the new tenant
 az login --tenant <NEW_TENANT_ID> --use-device-code --allow-no-subscriptions
-# 2. Copy the example, set id = "" for each environment (so they get created)
+# 2. Provide GitHub provider auth in the current shell
+gh auth status
+$env:GH_TOKEN = (gh auth token)
+$env:GITHUB_TOKEN = $env:GH_TOKEN
+# 3. Copy the example, set id = "" for each environment (so they get created)
 Copy-Item terraform.tfvars.example terraform.tfvars
-# 3. Fill in tenant_id, github_owner, github_repository, security_group_id
-# 4. Initialise + apply
+# 4. Fill in tenant_id, github_owner, github_repository, security_group_id
+# 5. Initialise + apply
 terraform init
 terraform plan
 terraform apply
 ```
+
+On a fresh tenant, Terraform creates the Power Platform environments. The GitHub
+module also creates the repository environments, `dev:main` and `test:main`
+deployment policies, and the desired `main` branch protection rule unless those
+objects already exist in the live repo. If the repo is not fresh, import the
+existing GitHub objects first instead of applying over unmanaged state.
 
 For both existing and fresh environments, deployment ordering is strict:
 Dataverse application users first, language reconciliation second, and solution
@@ -76,9 +127,12 @@ The reconciler only activates desired languages and never disables languages.
 - Providers use CLI-based auth by default (`az login` locally). In CI, the same
   providers use OIDC via workload identity federation per
   [ADR-0002](../../docs/adr/ADR-0002-oidc-federation-for-github-actions-to-entra.md).
-- The Entra (`azuread`) and GitHub (`integrations/github`) provider blocks are wired
-  in `providers.tf` but their resources are **not scaffolded yet** — coming in the
-  next milestone (Entra app registrations + federated credentials).
+- The GitHub provider also needs authenticated repo-admin access in the current
+  shell (`GITHUB_TOKEN`; `GH_TOKEN` if you are using `gh` CLI helpers). Never
+  write that token to disk.
+- The Entra (`azuread`) and GitHub (`integrations/github`) resources in this
+  directory are active, not scaffold-only. On any repo or tenant with existing
+  live objects, import first and only then review the plan.
 - `powerplatform_tenant_settings` is a singleton per tenant; managing it here means
   changes to tenant-wide settings become PR-reviewable and reversible.
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -54,6 +54,8 @@ module "github" {
       powerplatform_env_id    = module.powerplatform.environment_ids["test"]
       powerplatform_env_url   = module.powerplatform.environment_urls["test"]
       allowed_branch_patterns = ["main"]
+      reviewer_user_ids       = [data.github_user.owner.id]
+      prevent_self_review     = false
     }
   }
 }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -42,16 +42,18 @@ module "github" {
 
   environments = {
     dev = {
-      ci_client_id          = module.entra.client_ids["dev"]
-      ci_tenant_id          = var.tenant_id
-      powerplatform_env_id  = module.powerplatform.environment_ids["dev"]
-      powerplatform_env_url = module.powerplatform.environment_urls["dev"]
+      ci_client_id            = module.entra.client_ids["dev"]
+      ci_tenant_id            = var.tenant_id
+      powerplatform_env_id    = module.powerplatform.environment_ids["dev"]
+      powerplatform_env_url   = module.powerplatform.environment_urls["dev"]
+      allowed_branch_patterns = ["main"]
     }
     test = {
-      ci_client_id          = module.entra.client_ids["test"]
-      ci_tenant_id          = var.tenant_id
-      powerplatform_env_id  = module.powerplatform.environment_ids["test"]
-      powerplatform_env_url = module.powerplatform.environment_urls["test"]
+      ci_client_id            = module.entra.client_ids["test"]
+      ci_tenant_id            = var.tenant_id
+      powerplatform_env_id    = module.powerplatform.environment_ids["test"]
+      powerplatform_env_url   = module.powerplatform.environment_urls["test"]
+      allowed_branch_patterns = ["main"]
     }
   }
 }

--- a/infra/terraform/modules/github/main.tf
+++ b/infra/terraform/modules/github/main.tf
@@ -28,6 +28,15 @@ resource "github_repository_environment" "envs" {
   can_admins_bypass   = each.value.can_admins_bypass
   prevent_self_review = each.value.prevent_self_review
 
+  dynamic "reviewers" {
+    for_each = length(each.value.reviewer_user_ids) + length(each.value.reviewer_team_ids) > 0 ? [each.value] : []
+
+    content {
+      users = length(reviewers.value.reviewer_user_ids) == 0 ? null : reviewers.value.reviewer_user_ids
+      teams = length(reviewers.value.reviewer_team_ids) == 0 ? null : reviewers.value.reviewer_team_ids
+    }
+  }
+
   deployment_branch_policy {
     protected_branches     = false
     custom_branch_policies = true

--- a/infra/terraform/modules/github/main.tf
+++ b/infra/terraform/modules/github/main.tf
@@ -96,6 +96,7 @@ resource "github_branch_protection" "main" {
   pattern       = "main"
 
   enforce_admins                  = true
+  required_linear_history         = true
   allows_force_pushes             = false
   force_push_bypassers            = []
   allows_deletions                = false
@@ -107,6 +108,7 @@ resource "github_branch_protection" "main" {
   }
 
   required_pull_request_reviews {
+    dismiss_stale_reviews           = true
     required_approving_review_count = 0
     pull_request_bypassers          = []
   }

--- a/infra/terraform/modules/github/main.tf
+++ b/infra/terraform/modules/github/main.tf
@@ -1,3 +1,25 @@
+data "github_repository" "self" {
+  name = var.repository
+}
+
+locals {
+  environment_deployment_policies = tomap({
+    for policy in flatten([
+      for environment_name, environment in var.environments : [
+        for branch_pattern in environment.allowed_branch_patterns : {
+          key            = "${environment_name}:${branch_pattern}"
+          environment    = environment_name
+          branch_pattern = branch_pattern
+        }
+      ]
+    ]) :
+    policy.key => {
+      environment    = policy.environment
+      branch_pattern = policy.branch_pattern
+    }
+  })
+}
+
 resource "github_repository_environment" "envs" {
   for_each = var.environments
 
@@ -5,6 +27,19 @@ resource "github_repository_environment" "envs" {
   repository          = var.repository
   can_admins_bypass   = each.value.can_admins_bypass
   prevent_self_review = each.value.prevent_self_review
+
+  deployment_branch_policy {
+    protected_branches     = false
+    custom_branch_policies = true
+  }
+}
+
+resource "github_repository_environment_deployment_policy" "allowed_branches" {
+  for_each = local.environment_deployment_policies
+
+  repository     = var.repository
+  environment    = github_repository_environment.envs[each.value.environment].environment
+  branch_pattern = each.value.branch_pattern
 }
 
 # Non-secret variables the CI workflow reads to authenticate + target the right env.
@@ -45,4 +80,25 @@ resource "github_actions_environment_variable" "pp_env_url" {
   environment   = github_repository_environment.envs[each.key].environment
   variable_name = "POWER_PLATFORM_ENV_URL"
   value         = each.value.powerplatform_env_url
+}
+
+resource "github_branch_protection" "main" {
+  repository_id = data.github_repository.self.node_id
+  pattern       = "main"
+
+  enforce_admins                  = true
+  allows_force_pushes             = false
+  force_push_bypassers            = []
+  allows_deletions                = false
+  require_conversation_resolution = true
+
+  required_status_checks {
+    strict   = true
+    contexts = ["gate1"]
+  }
+
+  required_pull_request_reviews {
+    required_approving_review_count = 0
+    pull_request_bypassers          = []
+  }
 }

--- a/infra/terraform/modules/github/variables.tf
+++ b/infra/terraform/modules/github/variables.tf
@@ -5,12 +5,13 @@ variable "repository" {
 
 variable "environments" {
   type = map(object({
-    ci_client_id          = string
-    ci_tenant_id          = string
-    powerplatform_env_id  = string
-    powerplatform_env_url = string
-    prevent_self_review   = optional(bool, true)
-    can_admins_bypass     = optional(bool, false)
+    ci_client_id            = string
+    ci_tenant_id            = string
+    powerplatform_env_id    = string
+    powerplatform_env_url   = string
+    allowed_branch_patterns = optional(set(string), ["main"])
+    prevent_self_review     = optional(bool, true)
+    can_admins_bypass       = optional(bool, false)
   }))
   description = "GitHub Environment slots to create with matching CI variables."
 }

--- a/infra/terraform/modules/github/variables.tf
+++ b/infra/terraform/modules/github/variables.tf
@@ -10,8 +10,10 @@ variable "environments" {
     powerplatform_env_id    = string
     powerplatform_env_url   = string
     allowed_branch_patterns = optional(set(string), ["main"])
+    reviewer_user_ids       = optional(set(number), [])
+    reviewer_team_ids       = optional(set(number), [])
     prevent_self_review     = optional(bool, true)
     can_admins_bypass       = optional(bool, false)
   }))
-  description = "GitHub Environment slots to create with matching CI variables."
+  description = "GitHub Environment slots to create with matching CI variables and optional reviewer IDs."
 }

--- a/scripts/solution/ConvertTo-SafeCliDiagnosticLine.ps1
+++ b/scripts/solution/ConvertTo-SafeCliDiagnosticLine.ps1
@@ -1,0 +1,187 @@
+$script:SafeCliDiagnosticDefaultMaxLength = 240
+$script:SafeCliErrorDefaultMaxLength = 400
+$script:SafeCliDiagnosticTruncationMarker = ' ...[truncated]... '
+
+function Get-SafeCliDiagnosticText {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return ''
+    }
+
+    if ($Value -is [string]) {
+        return $Value
+    }
+
+    if ($Value -is [System.Management.Automation.ErrorRecord]) {
+        if ($null -ne $Value.Exception -and
+            -not [string]::IsNullOrWhiteSpace([string]$Value.Exception.Message)) {
+            return [string]$Value.Exception.Message
+        }
+
+        return [string]$Value
+    }
+
+    if ($Value -is [System.Exception]) {
+        return [string]$Value.Message
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return [string]$Value
+    }
+
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $parts = [System.Collections.Generic.List[string]]::new()
+        foreach ($item in $Value) {
+            $text = Get-SafeCliDiagnosticText -Value $item
+            if (-not [string]::IsNullOrWhiteSpace($text)) {
+                [void]$parts.Add([string]$text)
+            }
+        }
+
+        return ($parts.ToArray() -join [Environment]::NewLine)
+    }
+
+    return [string]$Value
+}
+
+function Remove-SafeCliAnsiEscapeSequences {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    if ([string]::IsNullOrEmpty($Text)) {
+        return $Text
+    }
+
+    $pattern = '[\u001B\u009B][[\]()#;?]*(?:(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-ntqry=><~]|(?:[^\u001B\u009B]*)(?:\u0007|\u001B\\))'
+    return [regex]::Replace($Text, $pattern, '')
+}
+
+function ConvertTo-SafeCliDiagnosticLine {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Value,
+
+        [ValidateRange(24, 8192)]
+        [int]$MaxLength = $script:SafeCliDiagnosticDefaultMaxLength,
+
+        [string]$EmptyText = '<no output>'
+    )
+
+    $text = Get-SafeCliDiagnosticText -Value $Value
+    $text = Remove-SafeCliAnsiEscapeSequences -Text $text
+
+    if ([string]::IsNullOrEmpty($text)) {
+        return $EmptyText
+    }
+
+    $text = $text -replace "[`r`n`t]+", ' '
+    $text = [regex]::Replace(
+        $text,
+        '[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]',
+        ' '
+    )
+    $text = [regex]::Replace($text, '\s+', ' ').Trim()
+
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $EmptyText
+    }
+
+    if ($text.StartsWith('::', [System.StringComparison]::Ordinal)) {
+        $text = "'$text"
+    }
+
+    if ($text.Length -le $MaxLength) {
+        return $text
+    }
+
+    $marker = $script:SafeCliDiagnosticTruncationMarker
+    if ($marker.Length -ge $MaxLength) {
+        return $marker.Substring(0, $MaxLength)
+    }
+
+    $availableLength = $MaxLength - $marker.Length
+    $headLength = [Math]::Max([int][Math]::Ceiling($availableLength * 0.7), 1)
+    $tailLength = [Math]::Max($availableLength - $headLength, 0)
+    if ($headLength -gt $text.Length) {
+        $headLength = $text.Length
+        $tailLength = 0
+    }
+    elseif ($tailLength -gt ($text.Length - $headLength)) {
+        $tailLength = $text.Length - $headLength
+    }
+
+    $head = $text.Substring(0, $headLength).TrimEnd()
+    if ($tailLength -le 0) {
+        return $head + $marker
+    }
+
+    $tail = $text.Substring($text.Length - $tailLength).TrimStart()
+    if ([string]::IsNullOrEmpty($tail)) {
+        return $head + $marker
+    }
+
+    return $head + $marker + $tail
+}
+
+function Get-SafeCliErrorMessage {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $ErrorRecord,
+
+        [ValidateRange(24, 8192)]
+        [int]$MaxLength = $script:SafeCliErrorDefaultMaxLength,
+
+        [string]$Fallback = 'Unexpected failure.'
+    )
+
+    $messageSource = if ($ErrorRecord -is [System.Management.Automation.ErrorRecord]) {
+        if ($null -ne $ErrorRecord.Exception -and
+            -not [string]::IsNullOrWhiteSpace([string]$ErrorRecord.Exception.Message)) {
+            $ErrorRecord.Exception.Message
+        }
+        else {
+            [string]$ErrorRecord
+        }
+    }
+    elseif ($ErrorRecord -is [System.Exception]) {
+        $ErrorRecord.Message
+    }
+    else {
+        $ErrorRecord
+    }
+
+    return ConvertTo-SafeCliDiagnosticLine `
+        -Value $messageSource `
+        -MaxLength $MaxLength `
+        -EmptyText $Fallback
+}
+
+function Write-SafeCliErrorLine {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $ErrorRecord,
+
+        [ValidateRange(24, 8192)]
+        [int]$MaxLength = $script:SafeCliErrorDefaultMaxLength,
+
+        [string]$Fallback = 'Unexpected failure.'
+    )
+
+    [Console]::Error.WriteLine(
+        (Get-SafeCliErrorMessage `
+            -ErrorRecord $ErrorRecord `
+            -MaxLength $MaxLength `
+            -Fallback $Fallback)
+    )
+}

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -22,6 +22,8 @@ param(
     [string]$OutputDirectory
 )
 
+. (Join-Path $PSScriptRoot 'ConvertTo-SafeCliDiagnosticLine.ps1')
+
 $ErrorActionPreference = 'Stop'
 
 function Get-InsuranceFoundationExports {
@@ -633,10 +635,7 @@ function Invoke-InsuranceFoundationPackageExport {
             $output = & $pacCommand @arguments 2>&1
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0) {
-                $detail = ($output | Out-String).Trim()
-                if ([string]::IsNullOrWhiteSpace($detail)) {
-                    $detail = '<no output>'
-                }
+                $detail = ConvertTo-SafeCliDiagnosticLine -Value $output
 
                 throw (
                     "pac solution export failed for '{0}' (solution '{1}', " +
@@ -685,23 +684,29 @@ function Invoke-InsuranceFoundationPackageExportEntry {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    $target = Resolve-InsuranceFoundationPackageExportTarget `
-        -EnvironmentUrl $EnvironmentUrl `
-        -OutputDirectory $OutputDirectory
-    $packageSummary = ((
-            Get-InsuranceFoundationExports |
-                ForEach-Object {
-                    '{0} ({1})' -f $_.File, ($(if ([bool]$_.Managed) { 'managed' } else { 'unmanaged' }))
-                }
-        ) -join ', ')
+    try {
+        $target = Resolve-InsuranceFoundationPackageExportTarget `
+            -EnvironmentUrl $EnvironmentUrl `
+            -OutputDirectory $OutputDirectory
+        $packageSummary = ((
+                Get-InsuranceFoundationExports |
+                    ForEach-Object {
+                        '{0} ({1})' -f $_.File, ($(if ([bool]$_.Managed) { 'managed' } else { 'unmanaged' }))
+                    }
+            ) -join ', ')
 
-    Invoke-InsuranceFoundationPackageExportEntry `
-        -EnvironmentUrl $target.EnvironmentUrl `
-        -OutputDirectory $target.OutputDirectory `
-        -ApprovalGranted:$(
-            $PSCmdlet.ShouldProcess(
-                $target.OutputDirectory,
-                "Export four reviewed packages: $packageSummary"
+        Invoke-InsuranceFoundationPackageExportEntry `
+            -EnvironmentUrl $target.EnvironmentUrl `
+            -OutputDirectory $target.OutputDirectory `
+            -ApprovalGranted:$(
+                $PSCmdlet.ShouldProcess(
+                    $target.OutputDirectory,
+                    "Export four reviewed packages: $packageSummary"
+                )
             )
-        )
+    }
+    catch {
+        Write-SafeCliErrorLine -ErrorRecord $_
+        exit 1
+    }
 }

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -90,6 +90,31 @@ function Get-InsuranceFoundationPackageNameCounts {
     return $counts
 }
 
+function Get-InsuranceFoundationOrdinalSortedStrings {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Values
+    )
+
+    $items = [System.Collections.Generic.List[string]]::new()
+    foreach ($value in @($Values)) {
+        if ($null -eq $value) {
+            $items.Add($null) | Out-Null
+            continue
+        }
+
+        $items.Add([string]$value) | Out-Null
+    }
+
+    $sorted = $items.ToArray()
+    if ($sorted.Length -gt 1) {
+        [Array]::Sort($sorted, [System.StringComparer]::Ordinal)
+    }
+
+    return $sorted
+}
+
 function Format-InsuranceFoundationPackageList {
     [CmdletBinding()]
     param(
@@ -118,7 +143,7 @@ function Format-InsuranceFoundationPackageList {
         return '<none>'
     }
 
-    return (@($values | Sort-Object) -join ', ')
+    return (@(Get-InsuranceFoundationOrdinalSortedStrings -Values $values) -join ', ')
 }
 
 function Assert-InsuranceFoundationPackageSet {
@@ -151,7 +176,7 @@ function Assert-InsuranceFoundationPackageSet {
     $extra = New-Object 'System.Collections.Generic.List[string]'
     $duplicates = New-Object 'System.Collections.Generic.List[string]'
 
-    foreach ($name in @($allNames | Sort-Object)) {
+    foreach ($name in @(Get-InsuranceFoundationOrdinalSortedStrings -Values @($allNames))) {
         $expectedCount = 0
         if ($expectedCounts.ContainsKey($name)) {
             $expectedCount = $expectedCounts[$name]

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -326,58 +326,131 @@ function Resolve-InsuranceFoundationPackageExportTarget {
     }
 }
 
-function Remove-InsuranceFoundationCreatedOutputDirectoryParent {
+function New-InsuranceFoundationDirectoryCreationContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $firstPreExistingAncestor = $null
+    $missingDirectories = New-Object 'System.Collections.Generic.List[string]'
+    $currentPath = $resolvedPath
+
+    while ($true) {
+        if (Test-Path -LiteralPath $currentPath) {
+            if (-not (Test-Path -LiteralPath $currentPath -PathType Container)) {
+                throw "OutputDirectory parent is not a directory: $currentPath"
+            }
+
+            $firstPreExistingAncestor = $currentPath
+            break
+        }
+
+        $missingDirectories.Add($currentPath) | Out-Null
+
+        $nextPath = Split-Path -Path $currentPath -Parent
+        if ([string]::IsNullOrWhiteSpace($nextPath)) {
+            throw "OutputDirectory parent must be below an existing filesystem root: $resolvedPath"
+        }
+
+        $resolvedNextPath = [System.IO.Path]::GetFullPath($nextPath)
+        if ($resolvedNextPath -ceq $currentPath) {
+            throw "OutputDirectory parent must be below an existing filesystem root: $resolvedPath"
+        }
+
+        $currentPath = $resolvedNextPath
+    }
+
+    $createdDirectories = @()
+    $directoriesToCreate = @($missingDirectories)
+    [array]::Reverse($directoriesToCreate)
+
+    try {
+        foreach ($directoryPath in $directoriesToCreate) {
+            if (Test-Path -LiteralPath $directoryPath) {
+                if (-not (Test-Path -LiteralPath $directoryPath -PathType Container)) {
+                    throw "OutputDirectory parent is not a directory: $directoryPath"
+                }
+
+                continue
+            }
+
+            try {
+                New-Item -ItemType Directory -Path $directoryPath -ErrorAction Stop | Out-Null
+            }
+            catch {
+                if (Test-Path -LiteralPath $directoryPath -PathType Container) {
+                    continue
+                }
+
+                throw
+            }
+
+            $createdDirectories += $directoryPath
+        }
+
+        return [pscustomobject][ordered]@{
+            Path                     = $resolvedPath
+            FirstPreExistingAncestor = $firstPreExistingAncestor
+            CreatedDirectories       = @($createdDirectories)
+        }
+    }
+    catch {
+        Remove-InsuranceFoundationCreatedDirectories `
+            -FirstPreExistingAncestor $firstPreExistingAncestor `
+            -CreatedDirectories $createdDirectories
+        throw
+    }
+}
+
+function Remove-InsuranceFoundationCreatedDirectories {
     [CmdletBinding()]
     param(
         [AllowNull()]
-        [string]$Path,
+        [string]$FirstPreExistingAncestor,
 
         [AllowNull()]
-        [string]$ExpectedPath,
-
-        [AllowNull()]
-        [string[]]$CreatedPaths
+        [string[]]$CreatedDirectories
     )
 
-    if ([string]::IsNullOrWhiteSpace($Path)) {
-        return
-    }
-    if ([string]::IsNullOrWhiteSpace($ExpectedPath)) {
+    if (-not $CreatedDirectories) {
         return
     }
 
-    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
-    $resolvedExpectedPath = [System.IO.Path]::GetFullPath($ExpectedPath)
-    if ($resolvedPath -cne $resolvedExpectedPath) {
-        return
+    $resolvedFirstPreExistingAncestor = $null
+    if (-not [string]::IsNullOrWhiteSpace($FirstPreExistingAncestor)) {
+        $resolvedFirstPreExistingAncestor = [System.IO.Path]::GetFullPath($FirstPreExistingAncestor)
     }
 
-    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Container)) {
-        return
-    }
-
-    $pathsToCheck = @()
-    if ($CreatedPaths) {
-        $pathsToCheck = @($CreatedPaths | ForEach-Object {
+    $pathsToCheck = @(
+        @($CreatedDirectories | ForEach-Object {
             if (-not [string]::IsNullOrWhiteSpace($_)) {
                 [System.IO.Path]::GetFullPath($_)
             }
-        })
-    }
+        }) | Where-Object { $_ }
+    )
 
-    foreach ($candidatePath in @($pathsToCheck | Where-Object { $_ })) {
-        if (-not (Test-Path -LiteralPath $candidatePath -PathType Container)) {
+    for ($index = ($pathsToCheck.Count - 1); $index -ge 0; $index--) {
+        $candidatePath = $pathsToCheck[$index]
+        if ($resolvedFirstPreExistingAncestor -and $candidatePath -ceq $resolvedFirstPreExistingAncestor) {
             continue
         }
+        if (-not (Test-Path -LiteralPath $candidatePath -PathType Container)) {
+            if (Test-Path -LiteralPath $candidatePath) {
+                break
+            }
+
+            continue
+        }
+
         $entries = @(Get-InsuranceFoundationDirectoryEntries -Path $candidatePath)
         if ($entries.Count -gt 0) {
             break
         }
+
         Remove-Item -LiteralPath $candidatePath -Force
-        if ($candidatePath -cne $resolvedPath) {
-            continue
-        }
-        return
     }
 }
 
@@ -392,19 +465,13 @@ function New-InsuranceFoundationPackageStagingDirectory {
     )
 
     $parentPath = [System.IO.Path]::GetFullPath($OutputDirectoryParent)
-    $createdPaths = @()
+    $parentDirectoryContext = $null
     $stagingDirectory = $null
 
     try {
-        if (Test-Path -LiteralPath $parentPath) {
-            if (-not (Test-Path -LiteralPath $parentPath -PathType Container)) {
-                throw "OutputDirectory parent is not a directory: $parentPath"
-            }
-        }
-        else {
-            New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
-            $createdPaths += $parentPath
-        }
+        $parentDirectoryContext = New-InsuranceFoundationDirectoryCreationContext `
+            -Path $parentPath
+        $parentPath = [string]$parentDirectoryContext.Path
 
         $leafName = Split-Path -Path $OutputDirectory -Leaf
         if ([string]::IsNullOrWhiteSpace($leafName)) {
@@ -418,20 +485,18 @@ function New-InsuranceFoundationPackageStagingDirectory {
         } while (Test-Path -LiteralPath $stagingDirectory)
 
         New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
-        $createdPaths += $stagingDirectory
-
         return [pscustomobject][ordered]@{
             StagingDirectory             = $stagingDirectory
             OutputDirectoryParent        = $parentPath
-            CreatedPaths                 = @($createdPaths)
+            FirstPreExistingAncestor     = $parentDirectoryContext.FirstPreExistingAncestor
+            CreatedDirectories           = @($parentDirectoryContext.CreatedDirectories)
         }
     }
     catch {
         Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
-        Remove-InsuranceFoundationCreatedOutputDirectoryParent `
-            -Path $parentPath `
-            -ExpectedPath $parentPath `
-            -CreatedPaths $createdPaths
+        Remove-InsuranceFoundationCreatedDirectories `
+            -FirstPreExistingAncestor $parentDirectoryContext.FirstPreExistingAncestor `
+            -CreatedDirectories $parentDirectoryContext.CreatedDirectories
         throw
     }
 }
@@ -540,6 +605,7 @@ function Invoke-InsuranceFoundationPackageExport {
     $exports = @(Get-InsuranceFoundationExports)
     $pacCommand = $null
     $stagingDirectory = $null
+    $stagingDirectoryInfo = $null
 
     try {
         $stagingDirectoryInfo = New-InsuranceFoundationPackageStagingDirectory `
@@ -590,10 +656,9 @@ function Invoke-InsuranceFoundationPackageExport {
     }
     finally {
         Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
-        Remove-InsuranceFoundationCreatedOutputDirectoryParent `
-            -Path $outputDirectoryParent `
-            -ExpectedPath $outputDirectoryParent `
-            -CreatedPaths $stagingDirectoryInfo.CreatedPaths
+        Remove-InsuranceFoundationCreatedDirectories `
+            -FirstPreExistingAncestor $stagingDirectoryInfo.FirstPreExistingAncestor `
+            -CreatedDirectories $stagingDirectoryInfo.CreatedDirectories
     }
 }
 

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -290,32 +290,128 @@ function Get-InsuranceFoundationOutputDirectoryParent {
     return [System.IO.Path]::GetFullPath($parentPath)
 }
 
-function New-InsuranceFoundationPackageStagingDirectory {
+function Resolve-InsuranceFoundationPackageExportTarget {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
         [Parameter(Mandatory)]
         [string]$OutputDirectory
     )
 
-    $parentPath = Get-InsuranceFoundationOutputDirectoryParent `
-        -OutputDirectory $OutputDirectory
-    if (-not (Test-Path -LiteralPath $parentPath -PathType Container)) {
-        New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+    if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
+        throw 'EnvironmentUrl is required.'
+    }
+    if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        throw 'OutputDirectory is required.'
     }
 
-    $leafName = Split-Path -Path $OutputDirectory -Leaf
-    if ([string]::IsNullOrWhiteSpace($leafName)) {
-        $leafName = 'insurance-foundation-packages'
+    $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+    Assert-InsuranceFoundationOutputDirectorySafety `
+        -OutputDirectory $resolvedOutputDirectory
+
+    $outputDirectoryParent = Get-InsuranceFoundationOutputDirectoryParent `
+        -OutputDirectory $resolvedOutputDirectory
+    if (Test-Path -LiteralPath $outputDirectoryParent) {
+        if (-not (Test-Path -LiteralPath $outputDirectoryParent -PathType Container)) {
+            throw "OutputDirectory parent is not a directory: $outputDirectoryParent"
+        }
     }
 
-    do {
-        $stagingDirectory = Join-Path `
-            $parentPath `
-            ('{0}.staging.{1}' -f $leafName, [guid]::NewGuid().Guid)
-    } while (Test-Path -LiteralPath $stagingDirectory)
+    return [pscustomobject][ordered]@{
+        EnvironmentUrl        = $EnvironmentUrl
+        OutputDirectory       = $resolvedOutputDirectory
+        OutputDirectoryParent = $outputDirectoryParent
+    }
+}
 
-    New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
-    return $stagingDirectory
+function Remove-InsuranceFoundationCreatedOutputDirectoryParent {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string]$Path,
+
+        [AllowNull()]
+        [string]$ExpectedPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+    if ([string]::IsNullOrWhiteSpace($ExpectedPath)) {
+        return
+    }
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $resolvedExpectedPath = [System.IO.Path]::GetFullPath($ExpectedPath)
+    if ($resolvedPath -cne $resolvedExpectedPath) {
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Container)) {
+        return
+    }
+
+    $entries = @(Get-InsuranceFoundationDirectoryEntries -Path $resolvedPath)
+    if ($entries.Count -gt 0) {
+        return
+    }
+
+    Remove-Item -LiteralPath $resolvedPath -Force
+}
+
+function New-InsuranceFoundationPackageStagingDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory)]
+        [string]$OutputDirectoryParent
+    )
+
+    $parentPath = [System.IO.Path]::GetFullPath($OutputDirectoryParent)
+    $createdOutputDirectoryParent = $null
+    $stagingDirectory = $null
+
+    try {
+        if (Test-Path -LiteralPath $parentPath) {
+            if (-not (Test-Path -LiteralPath $parentPath -PathType Container)) {
+                throw "OutputDirectory parent is not a directory: $parentPath"
+            }
+        }
+        else {
+            New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+            $createdOutputDirectoryParent = $parentPath
+        }
+
+        $leafName = Split-Path -Path $OutputDirectory -Leaf
+        if ([string]::IsNullOrWhiteSpace($leafName)) {
+            $leafName = 'insurance-foundation-packages'
+        }
+
+        do {
+            $stagingDirectory = Join-Path `
+                $parentPath `
+                ('{0}.staging.{1}' -f $leafName, [guid]::NewGuid().Guid)
+        } while (Test-Path -LiteralPath $stagingDirectory)
+
+        New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
+
+        return [pscustomobject][ordered]@{
+            StagingDirectory             = $stagingDirectory
+            OutputDirectoryParent        = $parentPath
+            CreatedOutputDirectoryParent = $createdOutputDirectoryParent
+        }
+    }
+    catch {
+        Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
+        Remove-InsuranceFoundationCreatedOutputDirectoryParent `
+            -Path $createdOutputDirectoryParent `
+            -ExpectedPath $parentPath
+        throw
+    }
 }
 
 function Assert-InsuranceFoundationStagingDirectory {
@@ -413,24 +509,23 @@ function Invoke-InsuranceFoundationPackageExport {
         [string]$OutputDirectory
     )
 
-    if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
-        throw 'EnvironmentUrl is required.'
-    }
-    if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
-        throw 'OutputDirectory is required.'
-    }
-
-    $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
-    Assert-InsuranceFoundationOutputDirectorySafety `
-        -OutputDirectory $resolvedOutputDirectory
+    $target = Resolve-InsuranceFoundationPackageExportTarget `
+        -EnvironmentUrl $EnvironmentUrl `
+        -OutputDirectory $OutputDirectory
+    $resolvedOutputDirectory = $target.OutputDirectory
+    $outputDirectoryParent = $target.OutputDirectoryParent
 
     $exports = @(Get-InsuranceFoundationExports)
     $pacCommand = $null
     $stagingDirectory = $null
+    $createdOutputDirectoryParent = $null
 
     try {
-        $stagingDirectory = New-InsuranceFoundationPackageStagingDirectory `
-            -OutputDirectory $resolvedOutputDirectory
+        $stagingDirectoryInfo = New-InsuranceFoundationPackageStagingDirectory `
+            -OutputDirectory $resolvedOutputDirectory `
+            -OutputDirectoryParent $outputDirectoryParent
+        $stagingDirectory = [string]$stagingDirectoryInfo.StagingDirectory
+        $createdOutputDirectoryParent = [string]$stagingDirectoryInfo.CreatedOutputDirectoryParent
 
         foreach ($export in $exports) {
             $packagePath = Join-Path $stagingDirectory $export.File
@@ -475,6 +570,9 @@ function Invoke-InsuranceFoundationPackageExport {
     }
     finally {
         Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
+        Remove-InsuranceFoundationCreatedOutputDirectoryParent `
+            -Path $createdOutputDirectoryParent `
+            -ExpectedPath $outputDirectoryParent
     }
 }
 
@@ -501,7 +599,9 @@ function Invoke-InsuranceFoundationPackageExportEntry {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+    $target = Resolve-InsuranceFoundationPackageExportTarget `
+        -EnvironmentUrl $EnvironmentUrl `
+        -OutputDirectory $OutputDirectory
     $packageSummary = ((
             Get-InsuranceFoundationExports |
                 ForEach-Object {
@@ -510,11 +610,11 @@ if ($MyInvocation.InvocationName -ne '.') {
         ) -join ', ')
 
     Invoke-InsuranceFoundationPackageExportEntry `
-        -EnvironmentUrl $EnvironmentUrl `
-        -OutputDirectory $resolvedOutputDirectory `
+        -EnvironmentUrl $target.EnvironmentUrl `
+        -OutputDirectory $target.OutputDirectory `
         -ApprovalGranted:$(
             $PSCmdlet.ShouldProcess(
-                $resolvedOutputDirectory,
+                $target.OutputDirectory,
                 "Export four reviewed packages: $packageSummary"
             )
         )

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -4,8 +4,9 @@
 .DESCRIPTION
     Produces only the four approved Insurance Foundation packages from a
     Dataverse DEV environment. The script refuses to export into a directory
-    that already contains files, resolves PAC via Resolve-PacCommand.ps1, and
-    verifies every exported package before asserting the final exact file set.
+    that already contains files or subdirectories, stages exports into a
+    unique sibling directory, resolves PAC via Resolve-PacCommand.ps1, and
+    publishes only a fully validated exact package set.
 .PARAMETER EnvironmentUrl
     Dataverse environment URL passed to pac solution export.
 .PARAMETER OutputDirectory
@@ -228,6 +229,180 @@ function Assert-InsuranceFoundationExportedPackage {
     }
 }
 
+function Get-InsuranceFoundationDirectoryEntries {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return @()
+    }
+
+    return @(
+        Get-ChildItem `
+            -LiteralPath $Path `
+            -Force
+    )
+}
+
+function Assert-InsuranceFoundationOutputDirectorySafety {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    if (-not (Test-Path -LiteralPath $OutputDirectory)) {
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $OutputDirectory -PathType Container)) {
+        throw "OutputDirectory is not a directory: $OutputDirectory"
+    }
+
+    $existingItems = @(Get-InsuranceFoundationDirectoryEntries -Path $OutputDirectory)
+    if ($existingItems.Count -eq 0) {
+        return
+    }
+
+    throw (
+        "Output directory already contains item(s): {0}. " +
+        'Use a new empty directory and rerun the export.'
+    ) -f (Format-InsuranceFoundationPackageList -FileNames (
+            $existingItems | ForEach-Object { $_.Name }
+        ))
+}
+
+function Get-InsuranceFoundationOutputDirectoryParent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    $parentPath = Split-Path -Path $OutputDirectory -Parent
+    if ([string]::IsNullOrWhiteSpace($parentPath)) {
+        throw "OutputDirectory must not be a filesystem root: $OutputDirectory"
+    }
+
+    return [System.IO.Path]::GetFullPath($parentPath)
+}
+
+function New-InsuranceFoundationPackageStagingDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    $parentPath = Get-InsuranceFoundationOutputDirectoryParent `
+        -OutputDirectory $OutputDirectory
+    if (-not (Test-Path -LiteralPath $parentPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+    }
+
+    $leafName = Split-Path -Path $OutputDirectory -Leaf
+    if ([string]::IsNullOrWhiteSpace($leafName)) {
+        $leafName = 'insurance-foundation-packages'
+    }
+
+    do {
+        $stagingDirectory = Join-Path `
+            $parentPath `
+            ('{0}.staging.{1}' -f $leafName, [guid]::NewGuid().Guid)
+    } while (Test-Path -LiteralPath $stagingDirectory)
+
+    New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
+    return $stagingDirectory
+}
+
+function Assert-InsuranceFoundationStagingDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        throw "Export staging directory is missing: $Path"
+    }
+
+    $entries = @(Get-InsuranceFoundationDirectoryEntries -Path $Path)
+    $directories = @($entries | Where-Object { $_.PSIsContainer })
+    if ($directories.Count -gt 0) {
+        throw (
+            "Export staging directory contains unexpected subdirector(ies): {0}."
+        ) -f (Format-InsuranceFoundationPackageList -FileNames (
+                $directories | ForEach-Object { $_.Name }
+            ))
+    }
+
+    foreach ($export in @(Get-InsuranceFoundationExports)) {
+        Assert-InsuranceFoundationExportedPackage `
+            -Path (Join-Path $Path $export.File) `
+            -File $export.File
+    }
+
+    Assert-InsuranceFoundationPackageSet -FileNames @(
+        $entries |
+            Where-Object { -not $_.PSIsContainer } |
+            ForEach-Object { $_.Name }
+    )
+}
+
+function Publish-InsuranceFoundationStagingDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$StagingDirectory,
+
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    if (-not (Test-Path -LiteralPath $StagingDirectory -PathType Container)) {
+        throw "Export staging directory is missing before publish: $StagingDirectory"
+    }
+
+    if (Test-Path -LiteralPath $OutputDirectory) {
+        if (-not (Test-Path -LiteralPath $OutputDirectory -PathType Container)) {
+            throw "OutputDirectory is not a directory: $OutputDirectory"
+        }
+
+        $existingItems = @(Get-InsuranceFoundationDirectoryEntries -Path $OutputDirectory)
+        if ($existingItems.Count -gt 0) {
+            throw (
+                "Output directory became non-empty before publish: {0}. " +
+                'Refusing to replace an existing path.'
+            ) -f (Format-InsuranceFoundationPackageList -FileNames (
+                    $existingItems | ForEach-Object { $_.Name }
+                ))
+        }
+
+        Remove-Item -LiteralPath $OutputDirectory -Force
+    }
+
+    [System.IO.Directory]::Move($StagingDirectory, $OutputDirectory)
+}
+
+function Remove-InsuranceFoundationStagingDirectory {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+
+    if (Test-Path -LiteralPath $Path -PathType Container) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+}
+
 function Invoke-InsuranceFoundationPackageExport {
     [CmdletBinding()]
     param(
@@ -246,83 +421,61 @@ function Invoke-InsuranceFoundationPackageExport {
     }
 
     $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
-
-    if (Test-Path -LiteralPath $resolvedOutputDirectory) {
-        if (-not (Test-Path -LiteralPath $resolvedOutputDirectory -PathType Container)) {
-            throw "OutputDirectory is not a directory: $resolvedOutputDirectory"
-        }
-
-        $existingFiles = @(
-            Get-ChildItem `
-                -LiteralPath $resolvedOutputDirectory `
-                -File `
-                -Force `
-                -Recurse
-        )
-        if ($existingFiles.Count -gt 0) {
-            throw (
-                "Output directory already contains file(s): {0}. " +
-                'Use a new empty directory and rerun the export.'
-            ) -f (Format-InsuranceFoundationPackageList -FileNames (
-                    $existingFiles | ForEach-Object { $_.Name }
-                ))
-        }
-    }
+    Assert-InsuranceFoundationOutputDirectorySafety `
+        -OutputDirectory $resolvedOutputDirectory
 
     $exports = @(Get-InsuranceFoundationExports)
     $pacCommand = $null
+    $stagingDirectory = $null
 
-    if (-not (Test-Path -LiteralPath $resolvedOutputDirectory -PathType Container)) {
-        New-Item `
-            -ItemType Directory `
-            -Path $resolvedOutputDirectory `
-            -Force | Out-Null
-    }
+    try {
+        $stagingDirectory = New-InsuranceFoundationPackageStagingDirectory `
+            -OutputDirectory $resolvedOutputDirectory
 
-    foreach ($export in $exports) {
-        $packagePath = Join-Path $resolvedOutputDirectory $export.File
-        $managedValue = if ([bool]$export.Managed) { 'true' } else { 'false' }
-        if ($null -eq $pacCommand) {
-            $pacCommand = Resolve-InsuranceFoundationPacCommand
-        }
-
-        $arguments = @(
-            'solution',
-            'export',
-            '--environment', $EnvironmentUrl,
-            '--name', [string]$export.Name,
-            '--path', $packagePath,
-            '--managed', $managedValue,
-            '--overwrite'
-        )
-
-        $output = & $pacCommand @arguments 2>&1
-        $exitCode = $LASTEXITCODE
-        if ($exitCode -ne 0) {
-            $detail = ($output | Out-String).Trim()
-            if ([string]::IsNullOrWhiteSpace($detail)) {
-                $detail = '<no output>'
+        foreach ($export in $exports) {
+            $packagePath = Join-Path $stagingDirectory $export.File
+            $managedValue = if ([bool]$export.Managed) { 'true' } else { 'false' }
+            if ($null -eq $pacCommand) {
+                $pacCommand = Resolve-InsuranceFoundationPacCommand
             }
 
-            throw (
-                "pac solution export failed for '{0}' (solution '{1}', " +
-                'managed={2}, exit code {3}). Output: {4}'
-            ) -f $export.File, $export.Name, $managedValue, $exitCode, $detail
+            $arguments = @(
+                'solution',
+                'export',
+                '--environment', $EnvironmentUrl,
+                '--name', [string]$export.Name,
+                '--path', $packagePath,
+                '--managed', $managedValue,
+                '--overwrite'
+            )
+
+            $output = & $pacCommand @arguments 2>&1
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+                $detail = ($output | Out-String).Trim()
+                if ([string]::IsNullOrWhiteSpace($detail)) {
+                    $detail = '<no output>'
+                }
+
+                throw (
+                    "pac solution export failed for '{0}' (solution '{1}', " +
+                    'managed={2}, exit code {3}). Output: {4}'
+                ) -f $export.File, $export.Name, $managedValue, $exitCode, $detail
+            }
+
+            Assert-InsuranceFoundationExportedPackage `
+                -Path $packagePath `
+                -File $export.File
         }
 
-        Assert-InsuranceFoundationExportedPackage `
-            -Path $packagePath `
-            -File $export.File
+        Assert-InsuranceFoundationStagingDirectory -Path $stagingDirectory
+        Publish-InsuranceFoundationStagingDirectory `
+            -StagingDirectory $stagingDirectory `
+            -OutputDirectory $resolvedOutputDirectory
     }
-
-    Assert-InsuranceFoundationPackageSet -FileNames @(
-        Get-ChildItem `
-            -LiteralPath $resolvedOutputDirectory `
-            -File `
-            -Force `
-            -Recurse |
-            ForEach-Object { $_.Name }
-    )
+    finally {
+        Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
+    }
 }
 
 function Invoke-InsuranceFoundationPackageExportEntry {

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -1,0 +1,341 @@
+<#
+.SYNOPSIS
+    Exports the exact reviewed Insurance Foundation solution package set.
+.DESCRIPTION
+    Produces only the four approved Insurance Foundation packages from a
+    Dataverse DEV environment. The script refuses to export into a directory
+    that already contains files, resolves PAC via Resolve-PacCommand.ps1, and
+    verifies every exported package before asserting the final exact file set.
+.PARAMETER EnvironmentUrl
+    Dataverse environment URL passed to pac solution export.
+.PARAMETER OutputDirectory
+    Directory that will receive the four package zip files. The directory must
+    be empty when it already exists.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [string]$EnvironmentUrl,
+
+    [Parameter(Mandatory)]
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-InsuranceFoundationExports {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        [pscustomobject][ordered]@{
+            Name    = 'crmshow_Foundation'
+            Managed = $false
+            File    = 'crmshow_Foundation.zip'
+        }
+        [pscustomobject][ordered]@{
+            Name    = 'crmshow_Foundation'
+            Managed = $true
+            File    = 'crmshow_Foundation_managed.zip'
+        }
+        [pscustomobject][ordered]@{
+            Name    = 'crmshow_DataModel'
+            Managed = $false
+            File    = 'crmshow_DataModel.zip'
+        }
+        [pscustomobject][ordered]@{
+            Name    = 'crmshow_DataModel'
+            Managed = $true
+            File    = 'crmshow_DataModel_managed.zip'
+        }
+    )
+}
+
+function Get-InsuranceFoundationPackageNameCounts {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$FileNames
+    )
+
+    $counts = New-Object 'System.Collections.Generic.Dictionary[string,int]' (
+        [System.StringComparer]::Ordinal
+    )
+
+    foreach ($fileName in @($FileNames)) {
+        $normalized = if ($null -eq $fileName) {
+            '<null>'
+        }
+        else {
+            $text = [string]$fileName
+            if ([string]::IsNullOrEmpty($text)) {
+                '<empty>'
+            }
+            else {
+                $text
+            }
+        }
+
+        if ($counts.ContainsKey($normalized)) {
+            $counts[$normalized] = $counts[$normalized] + 1
+        }
+        else {
+            $counts.Add($normalized, 1)
+        }
+    }
+
+    return $counts
+}
+
+function Format-InsuranceFoundationPackageList {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$FileNames
+    )
+
+    $values = @(
+        foreach ($fileName in @($FileNames)) {
+            if ($null -eq $fileName) {
+                '<null>'
+                continue
+            }
+
+            $text = [string]$fileName
+            if ([string]::IsNullOrEmpty($text)) {
+                '<empty>'
+                continue
+            }
+
+            $text
+        }
+    )
+
+    if ($values.Count -eq 0) {
+        return '<none>'
+    }
+
+    return (@($values | Sort-Object) -join ', ')
+}
+
+function Assert-InsuranceFoundationPackageSet {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$FileNames
+    )
+
+    $expectedFiles = @(
+        Get-InsuranceFoundationExports |
+            ForEach-Object { [string]$_.File }
+    )
+    $actualFiles = @($FileNames | ForEach-Object { [string]$_ })
+
+    $expectedCounts = Get-InsuranceFoundationPackageNameCounts -FileNames $expectedFiles
+    $actualCounts = Get-InsuranceFoundationPackageNameCounts -FileNames $actualFiles
+    $allNames = New-Object 'System.Collections.Generic.HashSet[string]' (
+        [System.StringComparer]::Ordinal
+    )
+
+    foreach ($name in $expectedCounts.Keys) {
+        $null = $allNames.Add($name)
+    }
+    foreach ($name in $actualCounts.Keys) {
+        $null = $allNames.Add($name)
+    }
+
+    $missing = New-Object 'System.Collections.Generic.List[string]'
+    $extra = New-Object 'System.Collections.Generic.List[string]'
+    $duplicates = New-Object 'System.Collections.Generic.List[string]'
+
+    foreach ($name in @($allNames | Sort-Object)) {
+        $expectedCount = 0
+        if ($expectedCounts.ContainsKey($name)) {
+            $expectedCount = $expectedCounts[$name]
+        }
+
+        $actualCount = 0
+        if ($actualCounts.ContainsKey($name)) {
+            $actualCount = $actualCounts[$name]
+        }
+
+        if ($actualCount -lt $expectedCount) {
+            for ($index = 0; $index -lt ($expectedCount - $actualCount); $index++) {
+                $missing.Add($name) | Out-Null
+            }
+        }
+
+        if ($actualCount -gt $expectedCount) {
+            for ($index = 0; $index -lt ($actualCount - $expectedCount); $index++) {
+                $extra.Add($name) | Out-Null
+            }
+        }
+
+        if ($actualCount -gt 1) {
+            $duplicates.Add(('{0} x{1}' -f $name, $actualCount)) | Out-Null
+        }
+    }
+
+    if ($missing.Count -eq 0 -and $extra.Count -eq 0 -and $duplicates.Count -eq 0) {
+        return
+    }
+
+    $message = @(
+        'Unexpected authored package set.'
+        'Expected exactly: {0}.' -f (Format-InsuranceFoundationPackageList -FileNames $expectedFiles)
+        'Actual: {0}.' -f (Format-InsuranceFoundationPackageList -FileNames $actualFiles)
+    )
+
+    if ($missing.Count -gt 0) {
+        $message += 'Missing: {0}.' -f (Format-InsuranceFoundationPackageList -FileNames $missing)
+    }
+    if ($extra.Count -gt 0) {
+        $message += 'Extra: {0}.' -f (Format-InsuranceFoundationPackageList -FileNames $extra)
+    }
+    if ($duplicates.Count -gt 0) {
+        $message += 'Duplicates: {0}.' -f (Format-InsuranceFoundationPackageList -FileNames $duplicates)
+    }
+
+    $message += 'Keep only the four reviewed .zip files with exact casing.'
+    throw ($message -join ' ')
+}
+
+function Resolve-InsuranceFoundationPacCommand {
+    [CmdletBinding()]
+    param()
+
+    . (Join-Path $PSScriptRoot 'Resolve-PacCommand.ps1')
+    return Resolve-PacCommand
+}
+
+function Assert-InsuranceFoundationExportedPackage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$File
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Export did not produce package '$File' at '$Path'."
+    }
+
+    $item = Get-Item -LiteralPath $Path -Force
+    if ($item.Length -le 0) {
+        throw "Export produced a zero-byte package '$File' at '$Path'."
+    }
+}
+
+function Invoke-InsuranceFoundationPackageExport {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
+        throw 'EnvironmentUrl is required.'
+    }
+    if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        throw 'OutputDirectory is required.'
+    }
+
+    $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+
+    if (Test-Path -LiteralPath $resolvedOutputDirectory) {
+        if (-not (Test-Path -LiteralPath $resolvedOutputDirectory -PathType Container)) {
+            throw "OutputDirectory is not a directory: $resolvedOutputDirectory"
+        }
+
+        $existingFiles = @(
+            Get-ChildItem `
+                -LiteralPath $resolvedOutputDirectory `
+                -File `
+                -Force `
+                -Recurse
+        )
+        if ($existingFiles.Count -gt 0) {
+            throw (
+                "Output directory already contains file(s): {0}. " +
+                'Use a new empty directory and rerun the export.'
+            ) -f (Format-InsuranceFoundationPackageList -FileNames (
+                    $existingFiles | ForEach-Object { $_.Name }
+                ))
+        }
+    }
+
+    $exports = @(Get-InsuranceFoundationExports)
+    $completedExports = 0
+    $pacCommand = $null
+
+    foreach ($export in $exports) {
+        $packagePath = Join-Path $resolvedOutputDirectory $export.File
+        $managedValue = if ([bool]$export.Managed) { 'true' } else { 'false' }
+        $action = "Export $($export.Name) managed=$managedValue"
+
+        if ($PSCmdlet.ShouldProcess($packagePath, $action)) {
+            if (-not (Test-Path -LiteralPath $resolvedOutputDirectory -PathType Container)) {
+                New-Item `
+                    -ItemType Directory `
+                    -Path $resolvedOutputDirectory `
+                    -Force | Out-Null
+            }
+
+            if ($null -eq $pacCommand) {
+                $pacCommand = Resolve-InsuranceFoundationPacCommand
+            }
+
+            $arguments = @(
+                'solution',
+                'export',
+                '--environment', $EnvironmentUrl,
+                '--name', [string]$export.Name,
+                '--path', $packagePath,
+                '--managed', $managedValue,
+                '--overwrite'
+            )
+
+            $output = & $pacCommand @arguments 2>&1
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+                $detail = ($output | Out-String).Trim()
+                if ([string]::IsNullOrWhiteSpace($detail)) {
+                    $detail = '<no output>'
+                }
+
+                throw (
+                    "pac solution export failed for '{0}' (solution '{1}', " +
+                    'managed={2}, exit code {3}). Output: {4}'
+                ) -f $export.File, $export.Name, $managedValue, $exitCode, $detail
+            }
+
+            Assert-InsuranceFoundationExportedPackage `
+                -Path $packagePath `
+                -File $export.File
+            $completedExports++
+        }
+    }
+
+    if ($completedExports -eq $exports.Count) {
+        Assert-InsuranceFoundationPackageSet -FileNames @(
+            Get-ChildItem `
+                -LiteralPath $resolvedOutputDirectory `
+                -File `
+                -Force `
+                -Recurse |
+                ForEach-Object { $_.Name }
+        )
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-InsuranceFoundationPackageExport `
+        -EnvironmentUrl $EnvironmentUrl `
+        -OutputDirectory $OutputDirectory `
+        -WhatIf:$WhatIfPreference
+}

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -333,7 +333,10 @@ function Remove-InsuranceFoundationCreatedOutputDirectoryParent {
         [string]$Path,
 
         [AllowNull()]
-        [string]$ExpectedPath
+        [string]$ExpectedPath,
+
+        [AllowNull()]
+        [string[]]$CreatedPaths
     )
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
@@ -353,12 +356,29 @@ function Remove-InsuranceFoundationCreatedOutputDirectoryParent {
         return
     }
 
-    $entries = @(Get-InsuranceFoundationDirectoryEntries -Path $resolvedPath)
-    if ($entries.Count -gt 0) {
-        return
+    $pathsToCheck = @()
+    if ($CreatedPaths) {
+        $pathsToCheck = @($CreatedPaths | ForEach-Object {
+            if (-not [string]::IsNullOrWhiteSpace($_)) {
+                [System.IO.Path]::GetFullPath($_)
+            }
+        })
     }
 
-    Remove-Item -LiteralPath $resolvedPath -Force
+    foreach ($candidatePath in @($pathsToCheck | Where-Object { $_ })) {
+        if (-not (Test-Path -LiteralPath $candidatePath -PathType Container)) {
+            continue
+        }
+        $entries = @(Get-InsuranceFoundationDirectoryEntries -Path $candidatePath)
+        if ($entries.Count -gt 0) {
+            break
+        }
+        Remove-Item -LiteralPath $candidatePath -Force
+        if ($candidatePath -cne $resolvedPath) {
+            continue
+        }
+        return
+    }
 }
 
 function New-InsuranceFoundationPackageStagingDirectory {
@@ -372,7 +392,7 @@ function New-InsuranceFoundationPackageStagingDirectory {
     )
 
     $parentPath = [System.IO.Path]::GetFullPath($OutputDirectoryParent)
-    $createdOutputDirectoryParent = $null
+    $createdPaths = @()
     $stagingDirectory = $null
 
     try {
@@ -383,7 +403,7 @@ function New-InsuranceFoundationPackageStagingDirectory {
         }
         else {
             New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
-            $createdOutputDirectoryParent = $parentPath
+            $createdPaths += $parentPath
         }
 
         $leafName = Split-Path -Path $OutputDirectory -Leaf
@@ -398,18 +418,20 @@ function New-InsuranceFoundationPackageStagingDirectory {
         } while (Test-Path -LiteralPath $stagingDirectory)
 
         New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
+        $createdPaths += $stagingDirectory
 
         return [pscustomobject][ordered]@{
             StagingDirectory             = $stagingDirectory
             OutputDirectoryParent        = $parentPath
-            CreatedOutputDirectoryParent = $createdOutputDirectoryParent
+            CreatedPaths                 = @($createdPaths)
         }
     }
     catch {
         Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
         Remove-InsuranceFoundationCreatedOutputDirectoryParent `
-            -Path $createdOutputDirectoryParent `
-            -ExpectedPath $parentPath
+            -Path $parentPath `
+            -ExpectedPath $parentPath `
+            -CreatedPaths $createdPaths
         throw
     }
 }
@@ -518,14 +540,12 @@ function Invoke-InsuranceFoundationPackageExport {
     $exports = @(Get-InsuranceFoundationExports)
     $pacCommand = $null
     $stagingDirectory = $null
-    $createdOutputDirectoryParent = $null
 
     try {
         $stagingDirectoryInfo = New-InsuranceFoundationPackageStagingDirectory `
             -OutputDirectory $resolvedOutputDirectory `
             -OutputDirectoryParent $outputDirectoryParent
         $stagingDirectory = [string]$stagingDirectoryInfo.StagingDirectory
-        $createdOutputDirectoryParent = [string]$stagingDirectoryInfo.CreatedOutputDirectoryParent
 
         foreach ($export in $exports) {
             $packagePath = Join-Path $stagingDirectory $export.File
@@ -571,8 +591,9 @@ function Invoke-InsuranceFoundationPackageExport {
     finally {
         Remove-InsuranceFoundationStagingDirectory -Path $stagingDirectory
         Remove-InsuranceFoundationCreatedOutputDirectoryParent `
-            -Path $createdOutputDirectoryParent `
-            -ExpectedPath $outputDirectoryParent
+            -Path $outputDirectoryParent `
+            -ExpectedPath $outputDirectoryParent `
+            -CreatedPaths $stagingDirectoryInfo.CreatedPaths
     }
 }
 

--- a/scripts/solution/Export-InsuranceFoundationPackages.ps1
+++ b/scripts/solution/Export-InsuranceFoundationPackages.ps1
@@ -229,7 +229,7 @@ function Assert-InsuranceFoundationExportedPackage {
 }
 
 function Invoke-InsuranceFoundationPackageExport {
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [string]$EnvironmentUrl,
@@ -270,72 +270,99 @@ function Invoke-InsuranceFoundationPackageExport {
     }
 
     $exports = @(Get-InsuranceFoundationExports)
-    $completedExports = 0
     $pacCommand = $null
+
+    if (-not (Test-Path -LiteralPath $resolvedOutputDirectory -PathType Container)) {
+        New-Item `
+            -ItemType Directory `
+            -Path $resolvedOutputDirectory `
+            -Force | Out-Null
+    }
 
     foreach ($export in $exports) {
         $packagePath = Join-Path $resolvedOutputDirectory $export.File
         $managedValue = if ([bool]$export.Managed) { 'true' } else { 'false' }
-        $action = "Export $($export.Name) managed=$managedValue"
-
-        if ($PSCmdlet.ShouldProcess($packagePath, $action)) {
-            if (-not (Test-Path -LiteralPath $resolvedOutputDirectory -PathType Container)) {
-                New-Item `
-                    -ItemType Directory `
-                    -Path $resolvedOutputDirectory `
-                    -Force | Out-Null
-            }
-
-            if ($null -eq $pacCommand) {
-                $pacCommand = Resolve-InsuranceFoundationPacCommand
-            }
-
-            $arguments = @(
-                'solution',
-                'export',
-                '--environment', $EnvironmentUrl,
-                '--name', [string]$export.Name,
-                '--path', $packagePath,
-                '--managed', $managedValue,
-                '--overwrite'
-            )
-
-            $output = & $pacCommand @arguments 2>&1
-            $exitCode = $LASTEXITCODE
-            if ($exitCode -ne 0) {
-                $detail = ($output | Out-String).Trim()
-                if ([string]::IsNullOrWhiteSpace($detail)) {
-                    $detail = '<no output>'
-                }
-
-                throw (
-                    "pac solution export failed for '{0}' (solution '{1}', " +
-                    'managed={2}, exit code {3}). Output: {4}'
-                ) -f $export.File, $export.Name, $managedValue, $exitCode, $detail
-            }
-
-            Assert-InsuranceFoundationExportedPackage `
-                -Path $packagePath `
-                -File $export.File
-            $completedExports++
+        if ($null -eq $pacCommand) {
+            $pacCommand = Resolve-InsuranceFoundationPacCommand
         }
+
+        $arguments = @(
+            'solution',
+            'export',
+            '--environment', $EnvironmentUrl,
+            '--name', [string]$export.Name,
+            '--path', $packagePath,
+            '--managed', $managedValue,
+            '--overwrite'
+        )
+
+        $output = & $pacCommand @arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $detail = ($output | Out-String).Trim()
+            if ([string]::IsNullOrWhiteSpace($detail)) {
+                $detail = '<no output>'
+            }
+
+            throw (
+                "pac solution export failed for '{0}' (solution '{1}', " +
+                'managed={2}, exit code {3}). Output: {4}'
+            ) -f $export.File, $export.Name, $managedValue, $exitCode, $detail
+        }
+
+        Assert-InsuranceFoundationExportedPackage `
+            -Path $packagePath `
+            -File $export.File
     }
 
-    if ($completedExports -eq $exports.Count) {
-        Assert-InsuranceFoundationPackageSet -FileNames @(
-            Get-ChildItem `
-                -LiteralPath $resolvedOutputDirectory `
-                -File `
-                -Force `
-                -Recurse |
-                ForEach-Object { $_.Name }
-        )
+    Assert-InsuranceFoundationPackageSet -FileNames @(
+        Get-ChildItem `
+            -LiteralPath $resolvedOutputDirectory `
+            -File `
+            -Force `
+            -Recurse |
+            ForEach-Object { $_.Name }
+    )
+}
+
+function Invoke-InsuranceFoundationPackageExportEntry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory)]
+        [bool]$ApprovalGranted
+    )
+
+    if (-not $ApprovalGranted) {
+        return
     }
+
+    Invoke-InsuranceFoundationPackageExport `
+        -EnvironmentUrl $EnvironmentUrl `
+        -OutputDirectory $OutputDirectory
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-InsuranceFoundationPackageExport `
+    $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+    $packageSummary = ((
+            Get-InsuranceFoundationExports |
+                ForEach-Object {
+                    '{0} ({1})' -f $_.File, ($(if ([bool]$_.Managed) { 'managed' } else { 'unmanaged' }))
+                }
+        ) -join ', ')
+
+    Invoke-InsuranceFoundationPackageExportEntry `
         -EnvironmentUrl $EnvironmentUrl `
-        -OutputDirectory $OutputDirectory `
-        -WhatIf:$WhatIfPreference
+        -OutputDirectory $resolvedOutputDirectory `
+        -ApprovalGranted:$(
+            $PSCmdlet.ShouldProcess(
+                $resolvedOutputDirectory,
+                "Export four reviewed packages: $packageSummary"
+            )
+        )
 }

--- a/scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1
+++ b/scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1
@@ -1,0 +1,85 @@
+function Format-InsuranceAuthoringPreflightList {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value
+    )
+
+    $items = foreach ($item in @($Value)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $text = [string]$item
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        $text.Trim()
+    }
+
+    return '[{0}]' -f (@($items) -join ', ')
+}
+
+function Get-InsuranceAuthoringPreflightFailureMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [int]$ExitCode,
+
+        [AllowEmptyString()]
+        [string]$JsonText
+    )
+
+    if ($ExitCode -ne 2) {
+        return 'Authoring preflight transport or execution failed. Review the error output above.'
+    }
+
+    try {
+        $result = $JsonText | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        return 'Authoring preflight reported a non-ready state. Review the preflight JSON echoed above for details.'
+    }
+
+    switch ([string]$result.State) {
+        'ManualPrerequisite' {
+            $missingRoles = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingRoles
+            )
+            return "Authoring preflight reported ManualPrerequisite. MissingRoles=$missingRoles. Follow docs/runbooks/insurance-foundation-security-role-bootstrap.md, then rerun."
+        }
+        'Precondition' {
+            $missingSolutions = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingSolutions
+            )
+            $missingLanguageLcid = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingLanguageLcid
+            )
+            $languageAction = if ([string]::IsNullOrWhiteSpace([string]$result.LanguageAction)) {
+                '(not reported)'
+            }
+            else {
+                [string]$result.LanguageAction
+            }
+
+            return "Authoring preflight reported Precondition. Required solution/environment prerequisites are missing. MissingSolutions=$missingSolutions. MissingLanguageLcid=$missingLanguageLcid. LanguageAction=$languageAction. Review the preflight JSON echoed above, satisfy the prerequisites, and rerun."
+        }
+        'UnsupportedInTenant' {
+            $assignedRoleNames = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.AssignedRoleNames
+            )
+            return "Authoring preflight reported UnsupportedInTenant. The CI identity or tenant capability is unsupported for demo schema authoring. AssignedRoleNames=$assignedRoleNames. Escalate for identity correction or tenant capability review, then rerun."
+        }
+        default {
+            $stateText = if ([string]::IsNullOrWhiteSpace([string]$result.State)) {
+                '(not reported)'
+            }
+            else {
+                [string]$result.State
+            }
+
+            return "Authoring preflight reported a non-ready state. State=$stateText. Review the preflight JSON echoed above for details."
+        }
+    }
+}

--- a/scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1
+++ b/scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1
@@ -1,24 +1,193 @@
+$script:InsuranceAuthoringPreflightMaxValueLength = 120
+$script:InsuranceAuthoringPreflightMaxListLength = 240
+$script:InsuranceAuthoringPreflightMaxRawLength = 240
+
+function ConvertTo-InsuranceAuthoringPreflightSafeLiteral {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object]$Value,
+
+        [ValidateRange(16, 4096)]
+        [int]$MaxLength = $script:InsuranceAuthoringPreflightMaxValueLength
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $text = [string]$Value
+    $text = [regex]::Replace($text, '[\x00-\x1F\x7F-\x9F]', ' ')
+    $text = [regex]::Replace($text, '\s+', ' ')
+    $text = $text.Trim()
+
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    if ($text.StartsWith('::')) {
+        $text = "[literal] $text"
+    }
+
+    if ($text.Length -gt $MaxLength) {
+        $text = $text.Substring(0, $MaxLength - 3) + '...'
+    }
+
+    return $text | ConvertTo-Json -Compress
+}
+
+function Format-InsuranceAuthoringPreflightValue {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object]$Value,
+
+        [string]$Fallback = '(not reported)',
+
+        [ValidateRange(16, 4096)]
+        [int]$MaxLength = $script:InsuranceAuthoringPreflightMaxValueLength
+    )
+
+    $literal = ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+        -Value $Value `
+        -MaxLength $MaxLength
+    if ($null -ne $literal) {
+        return $literal
+    }
+
+    return ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+        -Value $Fallback `
+        -MaxLength $MaxLength
+}
+
 function Format-InsuranceAuthoringPreflightList {
     [CmdletBinding()]
     param(
         [AllowNull()]
-        [object[]]$Value
+        [object[]]$Value,
+
+        [ValidateRange(32, 4096)]
+        [int]$MaxLength = $script:InsuranceAuthoringPreflightMaxListLength
     )
 
-    $items = foreach ($item in @($Value)) {
-        if ($null -eq $item) {
+    $items = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($item in @($Value)) {
+        $literal = ConvertTo-InsuranceAuthoringPreflightSafeLiteral -Value $item
+        if ($null -eq $literal) {
             continue
         }
 
-        $text = [string]$item
-        if ([string]::IsNullOrWhiteSpace($text)) {
-            continue
-        }
-
-        $text.Trim()
+        $items.Add($literal)
     }
 
-    return '[{0}]' -f (@($items) -join ', ')
+    if ($items.Count -eq 0) {
+        return '[]'
+    }
+
+    $fullText = '[{0}]' -f ($items.ToArray() -join ', ')
+    if ($fullText.Length -le $MaxLength) {
+        return $fullText
+    }
+
+    $displayItems = New-Object 'System.Collections.Generic.List[string]'
+    for ($index = 0; $index -lt $items.Count; $index++) {
+        $remaining = $items.Count - $index - 1
+        $displayItems.Add($items[$index])
+
+        $candidateItems = @($displayItems.ToArray())
+        if ($remaining -gt 0) {
+            $candidateItems += ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+                -Value "... (+$remaining more)"
+        }
+
+        $candidate = '[{0}]' -f ($candidateItems -join ', ')
+        if ($candidate.Length -gt $MaxLength) {
+            $displayItems.RemoveAt($displayItems.Count - 1)
+            break
+        }
+    }
+
+    if ($displayItems.Count -eq 0) {
+        return '[{0}]' -f (
+            ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+                -Value "... (+$($items.Count) items omitted)"
+        )
+    }
+
+    $omitted = $items.Count - $displayItems.Count
+    if ($omitted -le 0) {
+        return '[{0}]' -f ($displayItems.ToArray() -join ', ')
+    }
+
+    $suffix = ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+        -Value "... (+$omitted more)"
+    while ($displayItems.Count -gt 0 -and
+        ('[{0}]' -f ((@($displayItems.ToArray()) + $suffix) -join ', ')).Length -gt $MaxLength) {
+        $displayItems.RemoveAt($displayItems.Count - 1)
+        $omitted = $items.Count - $displayItems.Count
+        $suffix = ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+            -Value "... (+$omitted more)"
+    }
+
+    if ($displayItems.Count -eq 0) {
+        return '[{0}]' -f (
+            ConvertTo-InsuranceAuthoringPreflightSafeLiteral `
+                -Value "... (+$($items.Count) items omitted)"
+        )
+    }
+
+    return '[{0}]' -f ((@($displayItems.ToArray()) + $suffix) -join ', ')
+}
+
+function Get-InsuranceAuthoringPreflightDiagnosticSummary {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$JsonText
+    )
+
+    try {
+        $result = $JsonText | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        $stateText = Format-InsuranceAuthoringPreflightValue -Value '(unparseable)'
+        $rawText = Format-InsuranceAuthoringPreflightValue `
+            -Value $JsonText `
+            -Fallback '(not reported)' `
+            -MaxLength $script:InsuranceAuthoringPreflightMaxRawLength
+        return "Authoring preflight diagnostics: State=$stateText; RawResult=$rawText."
+    }
+
+    $stateText = Format-InsuranceAuthoringPreflightValue -Value $result.State
+    switch ([string]$result.State) {
+        'ManualPrerequisite' {
+            $missingRoles = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingRoles
+            )
+            return "Authoring preflight diagnostics: State=$stateText; MissingRoles=$missingRoles."
+        }
+        'Precondition' {
+            $missingSolutions = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingSolutions
+            )
+            $missingLanguageLcid = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingLanguageLcid
+            )
+            $languageAction = Format-InsuranceAuthoringPreflightValue `
+                -Value $result.LanguageAction
+
+            return "Authoring preflight diagnostics: State=$stateText; MissingSolutions=$missingSolutions; MissingLanguageLcid=$missingLanguageLcid; LanguageAction=$languageAction."
+        }
+        'UnsupportedInTenant' {
+            $assignedRoleNames = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.AssignedRoleNames
+            )
+            return "Authoring preflight diagnostics: State=$stateText; AssignedRoleNames=$assignedRoleNames."
+        }
+        default {
+            return "Authoring preflight diagnostics: State=$stateText."
+        }
+    }
 }
 
 function Get-InsuranceAuthoringPreflightFailureMessage {
@@ -39,7 +208,7 @@ function Get-InsuranceAuthoringPreflightFailureMessage {
         $result = $JsonText | ConvertFrom-Json -ErrorAction Stop
     }
     catch {
-        return 'Authoring preflight reported a non-ready state. Review the preflight JSON echoed above for details.'
+        return 'Authoring preflight reported a non-ready state. Review the preflight diagnostics above for details.'
     }
 
     switch ([string]$result.State) {
@@ -56,14 +225,10 @@ function Get-InsuranceAuthoringPreflightFailureMessage {
             $missingLanguageLcid = Format-InsuranceAuthoringPreflightList -Value @(
                 $result.MissingLanguageLcid
             )
-            $languageAction = if ([string]::IsNullOrWhiteSpace([string]$result.LanguageAction)) {
-                '(not reported)'
-            }
-            else {
-                [string]$result.LanguageAction
-            }
+            $languageAction = Format-InsuranceAuthoringPreflightValue `
+                -Value $result.LanguageAction
 
-            return "Authoring preflight reported Precondition. Required solution/environment prerequisites are missing. MissingSolutions=$missingSolutions. MissingLanguageLcid=$missingLanguageLcid. LanguageAction=$languageAction. Review the preflight JSON echoed above, satisfy the prerequisites, and rerun."
+            return "Authoring preflight reported Precondition. Required solution/environment prerequisites are missing. MissingSolutions=$missingSolutions. MissingLanguageLcid=$missingLanguageLcid. LanguageAction=$languageAction. Review the preflight diagnostics above, satisfy the prerequisites, and rerun."
         }
         'UnsupportedInTenant' {
             $assignedRoleNames = Format-InsuranceAuthoringPreflightList -Value @(
@@ -72,14 +237,10 @@ function Get-InsuranceAuthoringPreflightFailureMessage {
             return "Authoring preflight reported UnsupportedInTenant. The CI identity or tenant capability is unsupported for demo schema authoring. AssignedRoleNames=$assignedRoleNames. Escalate for identity correction or tenant capability review, then rerun."
         }
         default {
-            $stateText = if ([string]::IsNullOrWhiteSpace([string]$result.State)) {
-                '(not reported)'
-            }
-            else {
-                [string]$result.State
-            }
+            $stateText = Format-InsuranceAuthoringPreflightValue `
+                -Value $result.State
 
-            return "Authoring preflight reported a non-ready state. State=$stateText. Review the preflight JSON echoed above for details."
+            return "Authoring preflight reported a non-ready state. State=$stateText. Review the preflight diagnostics above for details."
         }
     }
 }

--- a/scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1
+++ b/scripts/solution/Get-InsuranceAuthoringPreflightFailureMessage.ps1
@@ -160,6 +160,18 @@ function Get-InsuranceAuthoringPreflightDiagnosticSummary {
 
     $stateText = Format-InsuranceAuthoringPreflightValue -Value $result.State
     switch ([string]$result.State) {
+        'ContractConflict' {
+            $missingSolutions = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.MissingSolutions
+            )
+            $solutionConflicts = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.SolutionConflicts
+            )
+            $roleConflicts = Format-InsuranceAuthoringPreflightList -Value @(
+                $result.RoleConflicts
+            )
+            return "Authoring preflight diagnostics: State=$stateText; MissingSolutions=$missingSolutions; SolutionConflicts=$solutionConflicts; RoleConflicts=$roleConflicts."
+        }
         'ManualPrerequisite' {
             $missingRoles = Format-InsuranceAuthoringPreflightList -Value @(
                 $result.MissingRoles
@@ -200,7 +212,7 @@ function Get-InsuranceAuthoringPreflightFailureMessage {
         [string]$JsonText
     )
 
-    if ($ExitCode -ne 2) {
+    if ($ExitCode -ne 2 -and $ExitCode -ne 3) {
         return 'Authoring preflight transport or execution failed. Review the error output above.'
     }
 
@@ -208,7 +220,24 @@ function Get-InsuranceAuthoringPreflightFailureMessage {
         $result = $JsonText | ConvertFrom-Json -ErrorAction Stop
     }
     catch {
+        if ($ExitCode -eq 3) {
+            return 'Authoring preflight reported ContractConflict. Review the preflight diagnostics above for the reviewed contract conflict details. No mutation was performed.'
+        }
         return 'Authoring preflight reported a non-ready state. Review the preflight diagnostics above for details.'
+    }
+
+    if ($ExitCode -eq 3) {
+        $missingSolutions = Format-InsuranceAuthoringPreflightList -Value @(
+            $result.MissingSolutions
+        )
+        $solutionConflicts = Format-InsuranceAuthoringPreflightList -Value @(
+            $result.SolutionConflicts
+        )
+        $roleConflicts = Format-InsuranceAuthoringPreflightList -Value @(
+            $result.RoleConflicts
+        )
+
+        return "Authoring preflight reported ContractConflict. Reviewed publisher or role ownership differs from the contract. MissingSolutions=$missingSolutions. SolutionConflicts=$solutionConflicts. RoleConflicts=$roleConflicts. Review the preflight diagnostics above. No mutation was performed."
     }
 
     switch ([string]$result.State) {

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -253,9 +253,9 @@ function Get-TableCreateRequest {
                 -GlobalChoiceMetadataIds $GlobalChoiceMetadataIds
         }
     }
-    $relationships = foreach ($relationship in @($Table.relationships | Where-Object {
-        $_.authoring -eq 'InitialTableCreate'
-    })) {
+    $relationships = foreach ($relationship in @(
+            Get-InitialTableCreateOrdinaryRelationships -Table $Table
+        )) {
         New-OrdinaryRelationshipMetadata -Table $Table -Relationship $relationship
     }
     return [pscustomobject]@{
@@ -1194,6 +1194,43 @@ function Wait-TableMetadataSnapshot {
     }
 }
 
+function Get-InitialTableCreateOrdinaryRelationships {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Table)
+
+    return @($Table.relationships | Where-Object {
+        $_.authoring -eq 'InitialTableCreate'
+    } | Sort-Object lookupColumn, schemaName)
+}
+
+function Wait-InitialTableCreateTableSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Table)
+
+    $relationships = @(
+        Get-InitialTableCreateOrdinaryRelationships -Table $Table
+    )
+    $component = if ($relationships.Count -eq 0) {
+        $Table.logicalName
+    } else {
+        @($relationships | ForEach-Object {
+            "$($Table.logicalName)/$($_.lookupColumn)"
+        }) -join ', '
+    }
+
+    return Wait-TableMetadataSnapshot -Table $Table `
+        -Component $component -Ready {
+            param($candidate)
+            foreach ($relationship in $relationships) {
+                if (-not (Test-OrdinaryRelationshipVisibility -Table $Table `
+                            -Relationship $relationship -Snapshot $candidate)) {
+                    return $false
+                }
+            }
+            return $true
+        }
+}
+
 function Test-OrdinaryRelationshipVisibility {
     [CmdletBinding()]
     param(
@@ -1596,7 +1633,8 @@ function Invoke-ExistingOrdinaryRelationshipReconciliation {
     param(
         [Parameter(Mandatory)] $Table,
         [Parameter(Mandatory)] $Relationship,
-        [Parameter(Mandatory)] $Snapshot
+        [Parameter(Mandatory)] $Snapshot,
+        [switch]$ForbidCreate
     )
 
     $expected = [pscustomobject]@{
@@ -1610,6 +1648,14 @@ function Invoke-ExistingOrdinaryRelationshipReconciliation {
         Where-Object SchemaName -eq $expected.SchemaName)
     if ($actualRelationship.Count -eq 0 -and
         $attributeCandidates.Count -eq 0) {
+        if ($ForbidCreate) {
+            throw (
+                "Structural relationship conflict for " +
+                "'$($expected.SchemaName)': current-run " +
+                "InitialTableCreate metadata is absent after atomic " +
+                'readiness; recovery POST is forbidden.'
+            )
+        }
         Invoke-PlannedRequest (
             Get-OrdinaryRelationshipRequest $Table $Relationship
         ) | Out-Null
@@ -1681,14 +1727,7 @@ function Invoke-TableReconciliation {
         $tableWasCreated = $true
         Write-Output "$($Table.logicalName): Created"
         Publish-TableMetadata $Table
-        $snapshot = Wait-TableMetadataSnapshot -Table $Table `
-            -Component $Table.logicalName
-        foreach ($relationship in @($Table.relationships | Where-Object {
-            $_.authoring -eq 'InitialTableCreate'
-        })) {
-            $snapshot = Wait-OrdinaryRelationshipVisibility -Table $Table `
-                -Relationship $relationship
-        }
+        $snapshot = Wait-InitialTableCreateTableSnapshot -Table $Table
     }
 
     Assert-SolutionOwnership $snapshot $Table.solution $Table.logicalName
@@ -1740,7 +1779,11 @@ function Invoke-TableReconciliation {
         $_.authoring -ne 'CreateCustomerRelationships'
     })) {
         $lookupCreated = Invoke-ExistingOrdinaryRelationshipReconciliation `
-            -Table $Table -Relationship $relationship -Snapshot $snapshot
+            -Table $Table -Relationship $relationship -Snapshot $snapshot `
+            -ForbidCreate:(
+                $tableWasCreated -and
+                $relationship.authoring -eq 'InitialTableCreate'
+            )
         if ($lookupCreated) {
             $snapshot = Wait-OrdinaryRelationshipVisibility -Table $Table `
                 -Relationship $relationship

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1208,6 +1208,18 @@ function Get-TableContractAttributeLogicalNames {
     )
 }
 
+function Get-TableExistenceSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$LogicalName)
+
+    $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
+    return Get-One (
+        "/EntityDefinitions?" +
+        "`$select=MetadataId,LogicalName,SchemaName&" +
+        "`$filter=LogicalName eq '$escapedLogicalName'"
+    )
+}
+
 function Get-TableMetadataSnapshot {
     [CmdletBinding()]
     param(
@@ -1910,10 +1922,10 @@ function Invoke-TableReconciliation {
         Get-TableContractAttributeLogicalNames -Table $Table
     )
     $initialTableCreateAttributeLogicalNames = @()
-    $snapshot = Get-TableMetadataSnapshot `
-        -LogicalName $Table.logicalName `
-        -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
-    if ($null -eq $snapshot) {
+    $snapshot = $null
+    $existingTable = Get-TableExistenceSnapshot `
+        -LogicalName $Table.logicalName
+    if ($null -eq $existingTable) {
         $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
         $tableCreateRequest = Get-TableCreateRequest $Table $choiceMetadataIds
         $initialTableCreateAttributeLogicalNames = @(
@@ -1928,6 +1940,10 @@ function Invoke-TableReconciliation {
         Publish-TableMetadata $Table
         $snapshot = Wait-InitialTableCreateTableSnapshot -Table $Table `
             -TableCreateRequest $tableCreateRequest `
+            -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
+    } else {
+        $snapshot = Wait-TableMetadataSnapshot -Table $Table `
+            -Component $Table.logicalName `
             -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
     }
     $initialTableCreateAttributeLookup = @{}

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -10,7 +10,8 @@
 param(
     [Parameter(Mandatory)] [string]$EnvironmentUrl,
     [Parameter(Mandatory)] [string]$ContractPath,
-    [ValidateSet('Foundation', 'DataModel', 'All')] [string]$Scope = 'All'
+    [ValidateSet('Foundation', 'DataModel', 'Demo', 'SecurityRoles', 'All')]
+    [string]$Scope = 'Demo'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -1672,21 +1673,26 @@ function Invoke-InsuranceFoundationReconciliation {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)] $Contract,
-        [ValidateSet('Foundation', 'DataModel', 'All')] [string]$Scope = 'All'
+        [ValidateSet('Foundation', 'DataModel', 'Demo', 'SecurityRoles', 'All')]
+        [string]$Scope = 'Demo'
     )
 
     # This must remain the first operation: malformed or unresolved contracts
     # cannot cause even a metadata read, much less a mutation.
     Assert-InsuranceFoundationIntegrity $Contract
 
-    if ($Scope -in @('Foundation', 'All')) {
+    $includeChoices = $Scope -in @('Foundation', 'Demo', 'All')
+    $includeDataModel = $Scope -in @('DataModel', 'Demo', 'All')
+    $includeRoles = $Scope -in @('SecurityRoles', 'All')
+
+    if ($includeChoices) {
         foreach ($choice in $Contract.choices) {
             if ($PSCmdlet.ShouldProcess($choice.logicalName, 'Reconcile global choice')) {
                 Invoke-ChoiceReconciliation $choice
             }
         }
     }
-    if ($Scope -in @('DataModel', 'All')) {
+    if ($includeDataModel) {
         foreach ($extension in $Contract.nativeExtensions) {
             if ($PSCmdlet.ShouldProcess("$($extension.table)/$($extension.logicalName)", 'Reconcile native extension')) {
                 Invoke-NativeExtensionReconciliation $extension
@@ -1698,7 +1704,7 @@ function Invoke-InsuranceFoundationReconciliation {
             }
         }
     }
-    if ($Scope -in @('Foundation', 'All')) {
+    if ($includeRoles) {
         foreach ($role in $Contract.roles) {
             if ($PSCmdlet.ShouldProcess($role.name, 'Reconcile security role')) {
                 Invoke-RoleReconciliation $role $Contract
@@ -1706,9 +1712,14 @@ function Invoke-InsuranceFoundationReconciliation {
         }
     }
     if ($PSCmdlet.ShouldProcess($script:DataverseBaseUrl, 'Publish all customizations')) {
-        $solution = if ($Scope -eq 'Foundation') { 'crmshow_Foundation' } else { 'crmshow_DataModel' }
+        $publishSolution = if ($Scope -eq 'SecurityRoles' -or
+            ($includeChoices -and -not $includeDataModel)) {
+            'crmshow_Foundation'
+        } else {
+            'crmshow_DataModel'
+        }
         Invoke-DataverseRequest -Method POST -Path '/PublishAllXml' -Body @{} `
-            -Headers (Get-DataverseHeaders $solution) | Out-Null
+            -Headers (Get-DataverseHeaders $publishSolution) | Out-Null
         Write-Output 'Customizations: Published'
     }
 }

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -14,6 +14,8 @@ param(
     [string]$Scope = 'Demo'
 )
 
+. (Join-Path $PSScriptRoot 'ConvertTo-SafeCliDiagnosticLine.ps1')
+
 $ErrorActionPreference = 'Stop'
 $script:DataverseBaseUrl = $EnvironmentUrl.TrimEnd('/')
 $script:ContractFile = $ContractPath
@@ -71,8 +73,8 @@ function Invoke-DataverseRequest {
         $output = & az @arguments 2>&1
         $exitCode = $LASTEXITCODE
         if ($exitCode -ne 0) {
-            $detail = ($output | Out-String).Trim()
-            throw "Dataverse request failed ($Method $Path); az rest exited with code $exitCode. $detail"
+            $detail = ConvertTo-SafeCliDiagnosticLine -Value $output
+            throw "Dataverse request failed ($Method $Path); az rest exited with code $exitCode. Output: $detail"
         }
         if (-not [string]::IsNullOrWhiteSpace(($output | Out-String))) {
             return ($output | Out-String) | ConvertFrom-Json
@@ -2474,7 +2476,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $contract = Test-InsuranceFoundationContract -Path $ContractPath
         Invoke-InsuranceFoundationReconciliation -Contract $contract -Scope $Scope
     } catch {
-        Write-Error $_
+        Write-SafeCliErrorLine -ErrorRecord $_
         exit 1
     }
 }

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -119,6 +119,24 @@ function Wait-DataverseCondition {
     }
 }
 
+function Test-IncompleteMetadataError {
+    [CmdletBinding()]
+    param($ErrorRecord)
+
+    $message = if ($ErrorRecord -is [System.Management.Automation.ErrorRecord]) {
+        [string]$ErrorRecord.Exception.Message
+    } elseif ($ErrorRecord -is [System.Exception]) {
+        [string]$ErrorRecord.Message
+    } else {
+        [string]$ErrorRecord
+    }
+    if ([string]::IsNullOrWhiteSpace($message)) {
+        return $false
+    }
+    return $message -like 'Incomplete *' -or
+        $message -like '*typed metadata is unavailable*'
+}
+
 function ConvertTo-LocalizedLabel {
     param([Parameter(Mandatory)] $Text)
     $labels = foreach ($language in $script:RequiredLanguages) {
@@ -367,6 +385,42 @@ function Get-OrdinaryRelationshipRequest {
     }
 }
 
+function Get-CustomerRelationshipContract {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Column
+    )
+
+    $relationship = @($Table.relationships | Where-Object {
+        $_.lookupColumn -eq $Column.logicalName -and
+        $_.authoring -eq 'CreateCustomerRelationships'
+    })
+    if ($relationship.Count -ne 1) {
+        throw "Customer column '$($Column.logicalName)' must have one relationship contract."
+    }
+    return $relationship[0]
+}
+
+function Get-ExpectedCustomerRelationships {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Column
+    )
+
+    $relationship = Get-CustomerRelationshipContract -Table $Table `
+        -Column $Column
+    return @(
+        foreach ($target in @($Column.lookup.targets)) {
+            [pscustomobject]@{
+                SchemaName = "$($relationship.schemaName)_$target"
+                ReferencedEntity = [string]$target
+            }
+        }
+    )
+}
+
 function Get-CustomerRelationshipRequest {
     [CmdletBinding()]
     param(
@@ -374,13 +428,8 @@ function Get-CustomerRelationshipRequest {
         [Parameter(Mandatory)] $Column
     )
 
-    $relationship = $Table.relationships | Where-Object {
-        $_.lookupColumn -eq $Column.logicalName -and
-        $_.authoring -eq 'CreateCustomerRelationships'
-    }
-    if (@($relationship).Count -ne 1) {
-        throw "Customer column '$($Column.logicalName)' must have one relationship contract."
-    }
+    $relationship = Get-CustomerRelationshipContract -Table $Table `
+        -Column $Column
     $oneToMany = foreach ($target in $Column.lookup.targets) {
         @{
             SchemaName = "$($relationship.schemaName)_$target"
@@ -1296,11 +1345,16 @@ function Get-TableMetadataSnapshot {
         }
         foreach ($property in 'MetadataId', 'LogicalName', 'SchemaName',
             'AttributeType') {
-            if ($null -eq $attribute.$property -or
-                $null -eq $actual[0].$property -or
-                [string]$attribute.$property -ne
-                [string]$actual[0].$property) {
-                throw "Structural metadata conflict for '$LogicalName/$($attribute.LogicalName)': base and typed '$property' values differ or are incomplete."
+            $baseValue = $attribute.$property
+            $typedValue = $actual[0].$property
+            if ($null -eq $baseValue -or
+                $null -eq $typedValue -or
+                [string]::IsNullOrWhiteSpace([string]$baseValue) -or
+                [string]::IsNullOrWhiteSpace([string]$typedValue)) {
+                throw "Incomplete typed metadata for '$LogicalName/$($attribute.LogicalName)': base and typed '$property' are not both populated."
+            }
+            if ([string]$baseValue -ne [string]$typedValue) {
+                throw "Structural metadata conflict for '$LogicalName/$($attribute.LogicalName)': base and typed '$property' values differ."
             }
         }
 
@@ -1348,13 +1402,20 @@ function Wait-TableMetadataSnapshot {
                 -LogicalName $Table.logicalName `
                 -RequestedAttributeLogicalNames $RequestedAttributeLogicalNames
         } catch {
-            if ($_.Exception.Message -like '*typed metadata is unavailable*') {
+            if (Test-IncompleteMetadataError $_) {
                 return $null
             }
             throw
         }
         if ($null -eq $snapshot) { return $null }
-        if ($Ready -and -not (& $Ready $snapshot)) { return $null }
+        try {
+            if ($Ready -and -not (& $Ready $snapshot)) { return $null }
+        } catch {
+            if (Test-IncompleteMetadataError $_) {
+                return $null
+            }
+            throw
+        }
         return $snapshot
     }
 }
@@ -1395,6 +1456,19 @@ function Wait-InitialTableCreateTableSnapshot {
         }
         $matches[0]
     }
+    $initialColumns = foreach ($attributeLogicalName in
+        $initialAttributeLogicalNames) {
+        $matches = @($Table.columns | Where-Object {
+            $_.logicalName -eq $attributeLogicalName
+        })
+        if ($matches.Count -ne 1) {
+            throw (
+                "Initial create attribute '$attributeLogicalName' must " +
+                "resolve one table column contract."
+            )
+        }
+        $matches[0]
+    }
     $component = if ($relationships.Count -eq 0) {
         $Table.logicalName
     } else {
@@ -1408,16 +1482,18 @@ function Wait-InitialTableCreateTableSnapshot {
         -RequestedAttributeLogicalNames $RequestedAttributeLogicalNames `
         -Ready {
             param($candidate)
-            foreach ($attributeLogicalName in $initialAttributeLogicalNames) {
+            foreach ($column in $initialColumns) {
                 $attributeMatches = @($candidate.Attributes | Where-Object {
-                    $_.LogicalName -eq $attributeLogicalName
+                    $_.LogicalName -eq $column.logicalName
                 })
                 if ($attributeMatches.Count -gt 1) {
-                    throw "Duplicate physical attributes found for '$($Table.logicalName)/$attributeLogicalName'."
+                    throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
                 }
                 if ($attributeMatches.Count -ne 1) {
                     return $false
                 }
+                Test-AttributeCompatibility $attributeMatches[0] $column `
+                    $Table.logicalName
             }
             foreach ($relationship in $relationships) {
                 if (-not (Test-OrdinaryRelationshipVisibility -Table $Table `
@@ -1559,6 +1635,98 @@ function Wait-NonLookupAttributeVisibility {
                 $Table.logicalName
             return $true
         }
+}
+
+function Test-CustomerRelationshipVisibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Column,
+        [Parameter(Mandatory)] $Snapshot
+    )
+
+    $component = "$($Table.logicalName)/$($Column.logicalName)"
+    $attributeMatches = @($Snapshot.Attributes | Where-Object {
+        $_.LogicalName -eq $Column.logicalName -or
+        $_.SchemaName -eq $Column.schemaName
+    })
+    if ($attributeMatches.Count -gt 1) {
+        throw "Structural Customer lookup conflict for '$component': expected one typed lookup attribute, found $($attributeMatches.Count)."
+    }
+    if ($attributeMatches.Count -ne 1) {
+        return $false
+    }
+
+    $attribute = $attributeMatches[0]
+    if ($attribute.LogicalName -ne $Column.logicalName -or
+        $attribute.SchemaName -ne $Column.schemaName) {
+        throw "Structural Customer lookup conflict for '$component': expected logical/schema names '$($Column.logicalName)'/'$($Column.schemaName)', found '$($attribute.LogicalName)'/'$($attribute.SchemaName)'."
+    }
+    Test-AttributeCompatibility $attribute $Column $Table.logicalName
+
+    $relationship = Get-CustomerRelationshipContract -Table $Table `
+        -Column $Column
+    $expectedRelationships = @(Get-ExpectedCustomerRelationships `
+        -Table $Table -Column $Column)
+    $expectedSchemas = @($expectedRelationships | ForEach-Object {
+        [string]$_.SchemaName
+    })
+    $relationshipCandidates = @($Snapshot.ManyToOneRelationships |
+        Where-Object {
+            $_.ReferencingAttribute -eq $Column.logicalName -or
+            $_.SchemaName -eq $relationship.schemaName -or
+            $_.SchemaName -in $expectedSchemas
+        })
+    $unexpectedRelationships = @($relationshipCandidates | Where-Object {
+        [string]$_.SchemaName -notin $expectedSchemas
+    })
+    if ($unexpectedRelationships.Count -gt 0) {
+        throw "Structural Customer relationship conflict for '$component': unexpected relationship metadata exists for the customer lookup."
+    }
+    if ($relationshipCandidates.Count -lt $expectedRelationships.Count) {
+        return $false
+    }
+    if ($relationshipCandidates.Count -ne $expectedRelationships.Count) {
+        throw "Structural Customer relationship conflict for '$component': expected $($expectedRelationships.Count) complete relationships, found $($relationshipCandidates.Count); automatic recovery cannot continue from partial metadata."
+    }
+    foreach ($expected in $expectedRelationships) {
+        $matches = @($relationshipCandidates | Where-Object {
+            $_.SchemaName -eq $expected.SchemaName
+        })
+        if ($matches.Count -gt 1) {
+            throw "Structural Customer relationship conflict for '$component': relationship '$($expected.SchemaName)' is missing or ambiguous."
+        }
+        if ($matches.Count -ne 1) {
+            return $false
+        }
+        $actual = $matches[0]
+        $referencedEntity = [string]$actual.ReferencedEntity
+        $referencingEntity = [string]$actual.ReferencingEntity
+        $referencingAttribute = [string]$actual.ReferencingAttribute
+        if ([string]::IsNullOrWhiteSpace($referencedEntity) -or
+            [string]::IsNullOrWhiteSpace($referencingEntity) -or
+            [string]::IsNullOrWhiteSpace($referencingAttribute)) {
+            return $false
+        }
+        if ($referencedEntity -ne $expected.ReferencedEntity -or
+            $referencingEntity -ne $Table.logicalName -or
+            $referencingAttribute -ne $Column.logicalName) {
+            throw "Structural Customer relationship conflict for '$component': relationship '$($expected.SchemaName)' has conflicting target or schema metadata."
+        }
+        $expectedCascade = Get-ExpectedOrdinaryRelationshipCascade `
+            -ReferencedEntity $expected.ReferencedEntity
+        foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
+            $actualValue = [string]$actual.CascadeConfiguration.$action
+            if ([string]::IsNullOrWhiteSpace($actualValue)) {
+                return $false
+            }
+            if ($actualValue -ne [string]$expectedCascade[$action]) {
+                throw "Structural Customer relationship cascade conflict for '$($expected.SchemaName)': '$action' must be '$($expectedCascade[$action])'."
+            }
+        }
+    }
+
+    return $true
 }
 
 function Invoke-NativeExtensionReconciliation {
@@ -1789,26 +1957,15 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
         )
         $relationshipResponse = Invoke-DataverseRequest -Method GET -Path (
             "/EntityDefinitions(LogicalName='$escapedLogicalName')/ManyToOneRelationships?" +
-            "`$select=MetadataId,SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute"
+            "`$select=MetadataId,SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration"
         )
     }
 
-    $relationshipContract = @($Table.relationships | Where-Object {
-        $_.lookupColumn -eq $Column.logicalName -and
-        $_.authoring -eq 'CreateCustomerRelationships'
-    })
-    if ($relationshipContract.Count -ne 1) {
-        throw "Customer column '$($Column.logicalName)' must have one relationship contract."
-    }
-    $relationshipContract = $relationshipContract[0]
-    $expectedRelationships = @(
-        foreach ($target in $Column.lookup.targets) {
-            [pscustomobject]@{
-                SchemaName = "$($relationshipContract.schemaName)_$target"
-                ReferencedEntity = [string]$target
-            }
-        }
-    )
+    $component = "$($Table.logicalName)/$($Column.logicalName)"
+    $relationshipContract = Get-CustomerRelationshipContract -Table $Table `
+        -Column $Column
+    $expectedRelationships = @(Get-ExpectedCustomerRelationships `
+        -Table $Table -Column $Column)
 
     $attributeCandidates = @($attributeResponse.value | Where-Object {
         $_.LogicalName -eq $Column.logicalName -or
@@ -1836,31 +1993,22 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
     }
 
     if ($attributeCandidates.Count -ne 1) {
-        throw "Structural Customer lookup conflict for '$($Table.logicalName)/$($Column.logicalName)': expected one typed lookup attribute, found $($attributeCandidates.Count); automatic recovery requires no partial metadata."
+        throw "Structural Customer lookup conflict for '$component': expected one typed lookup attribute, found $($attributeCandidates.Count); automatic recovery requires no partial metadata."
     }
     $attribute = $attributeCandidates[0]
     if ($attribute.LogicalName -ne $Column.logicalName -or
         $attribute.SchemaName -ne $Column.schemaName) {
-        throw "Structural Customer lookup conflict for '$($Table.logicalName)/$($Column.logicalName)': expected logical/schema names '$($Column.logicalName)'/'$($Column.schemaName)', found '$($attribute.LogicalName)'/'$($attribute.SchemaName)'."
+        throw "Structural Customer lookup conflict for '$component': expected logical/schema names '$($Column.logicalName)'/'$($Column.schemaName)', found '$($attribute.LogicalName)'/'$($attribute.SchemaName)'."
     }
-    Test-AttributeCompatibility $attribute $Column $Table.logicalName
-
     if ($relationshipCandidates.Count -ne $expectedRelationships.Count) {
-        throw "Structural Customer relationship conflict for '$($Table.logicalName)/$($Column.logicalName)': expected $($expectedRelationships.Count) complete relationships, found $($relationshipCandidates.Count); automatic recovery cannot continue from partial metadata."
+        throw "Structural Customer relationship conflict for '$component': expected $($expectedRelationships.Count) complete relationships, found $($relationshipCandidates.Count); automatic recovery cannot continue from partial metadata."
     }
-    foreach ($expected in $expectedRelationships) {
-        $matches = @($relationshipCandidates | Where-Object {
-            $_.SchemaName -eq $expected.SchemaName
-        })
-        if ($matches.Count -ne 1) {
-            throw "Structural Customer relationship conflict for '$($Table.logicalName)/$($Column.logicalName)': relationship '$($expected.SchemaName)' is missing or ambiguous."
-        }
-        $actual = $matches[0]
-        if ($actual.ReferencedEntity -ne $expected.ReferencedEntity -or
-            $actual.ReferencingEntity -ne $Table.logicalName -or
-            $actual.ReferencingAttribute -ne $Column.logicalName) {
-            throw "Structural Customer relationship conflict for '$($Table.logicalName)/$($Column.logicalName)': relationship '$($expected.SchemaName)' has conflicting target or schema metadata."
-        }
+    if (-not (Test-CustomerRelationshipVisibility -Table $Table `
+                -Column $Column -Snapshot ([pscustomobject]@{
+                    Attributes = @($attribute)
+                    ManyToOneRelationships = @($relationshipCandidates)
+                }))) {
+        throw "Structural Customer relationship conflict for '$component': customer metadata is incomplete; automatic recovery cannot continue from partial metadata."
     }
     return $false
 }
@@ -2008,29 +2156,8 @@ function Invoke-TableReconciliation {
                     $requestedAttributeLogicalNames `
                 -Ready {
                     param($candidate)
-                    $attributeMatches = @($candidate.Attributes | Where-Object {
-                        $_.LogicalName -eq $customer.logicalName -or
-                        $_.SchemaName -eq $customer.schemaName
-                    })
-                    if ($attributeMatches.Count -ne 1) {
-                        return $false
-                    }
-                    $relationshipContract = @($Table.relationships |
-                        Where-Object {
-                            $_.lookupColumn -eq $customer.logicalName -and
-                            $_.authoring -eq 'CreateCustomerRelationships'
-                        })
-                    if ($relationshipContract.Count -ne 1) {
-                        return $false
-                    }
-                    $expectedSchemas = @($customer.lookup.targets |
-                        ForEach-Object {
-                            "$($relationshipContract[0].schemaName)_$_"
-                        })
-                    $actualRelationships = @($candidate.ManyToOneRelationships |
-                        Where-Object SchemaName -in $expectedSchemas)
-                    return $actualRelationships.Count -eq
-                        $expectedSchemas.Count
+                    Test-CustomerRelationshipVisibility -Table $Table `
+                        -Column $customer -Snapshot $candidate
                 }
             Invoke-ExistingCustomerRelationshipReconciliation -Table $Table `
                 -Column $customer -ExistingAttributes @($snapshot.Attributes) `

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -281,7 +281,8 @@ function Get-TableCreateRequest {
     }
 }
 
-function New-OrdinaryRelationshipMetadata {
+function Get-OrdinaryRelationshipLookupColumn {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)] $Table,
         [Parameter(Mandatory)] $Relationship
@@ -293,7 +294,35 @@ function New-OrdinaryRelationshipMetadata {
     if ($columns.Count -ne 1) {
         throw "Relationship '$($Relationship.schemaName)' must resolve one ordinary lookup column."
     }
-    $column = $columns[0]
+    return $columns[0]
+}
+
+function Get-ExpectedOrdinaryRelationshipCascade {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$ReferencedEntity)
+
+    return @{
+        Assign = 'NoCascade'
+        Delete = 'Restrict'
+        Merge = if ($ReferencedEntity -in @('account', 'contact')) {
+            'Cascade'
+        } else {
+            'NoCascade'
+        }
+        Reparent = 'NoCascade'
+        Share = 'NoCascade'
+        Unshare = 'NoCascade'
+    }
+}
+
+function New-OrdinaryRelationshipMetadata {
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Relationship
+    )
+
+    $column = Get-OrdinaryRelationshipLookupColumn -Table $Table `
+        -Relationship $Relationship
     $target = [string]$Relationship.referencedTables[0]
     return [ordered]@{
         '@odata.type' = 'Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata'
@@ -307,18 +336,8 @@ function New-OrdinaryRelationshipMetadata {
             Label = ConvertTo-LocalizedLabel $Relationship.metadata.label
             Order = 10000
         }
-        CascadeConfiguration = @{
-            Assign = 'NoCascade'
-            Delete = 'Restrict'
-            Merge = if ($target -in @('account', 'contact')) {
-                'Cascade'
-            } else {
-                'NoCascade'
-            }
-            Reparent = 'NoCascade'
-            Share = 'NoCascade'
-            Unshare = 'NoCascade'
-        }
+        CascadeConfiguration = Get-ExpectedOrdinaryRelationshipCascade `
+            -ReferencedEntity $target
         Lookup = [ordered]@{
             '@odata.type' = 'Microsoft.Dynamics.CRM.LookupAttributeMetadata'
             LogicalName = $column.logicalName
@@ -1175,6 +1194,99 @@ function Wait-TableMetadataSnapshot {
     }
 }
 
+function Test-OrdinaryRelationshipVisibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Relationship,
+        [Parameter(Mandatory)] $Snapshot
+    )
+
+    $component = "$($Table.logicalName)/$($Relationship.lookupColumn)"
+    $lookupMatches = @($Snapshot.Attributes | Where-Object {
+        $_.LogicalName -eq $Relationship.lookupColumn
+    })
+    if ($lookupMatches.Count -gt 1) {
+        throw "Duplicate physical attributes found for '$component'."
+    }
+
+    $relationshipMatches = @($Snapshot.ManyToOneRelationships | Where-Object {
+        $_.SchemaName -eq $Relationship.schemaName
+    })
+    if ($relationshipMatches.Count -gt 1) {
+        throw "Structural relationship conflict for '$($Relationship.schemaName)': expected one relationship metadata record, found $($relationshipMatches.Count)."
+    }
+
+    if ($lookupMatches.Count -ne 1 -or $relationshipMatches.Count -ne 1) {
+        return $false
+    }
+
+    $column = Get-OrdinaryRelationshipLookupColumn -Table $Table `
+        -Relationship $Relationship
+    $lookup = $lookupMatches[0]
+    $attributeType = [string]$lookup.AttributeType
+    if ([string]::IsNullOrWhiteSpace($attributeType)) {
+        return $false
+    }
+    if ($attributeType -ne 'Lookup') {
+        throw "Structural type conflict for '$component': expected Lookup, found $attributeType."
+    }
+    $actualTargets = @($lookup.Targets | Sort-Object)
+    if ($actualTargets.Count -eq 0) {
+        return $false
+    }
+    $expectedTargets = @($column.lookup.targets | Sort-Object)
+    if (($actualTargets -join ',') -ne ($expectedTargets -join ',')) {
+        throw "Structural target conflict for '$component'."
+    }
+
+    $expectedReferencedEntity = [string]$Relationship.referencedTables[0]
+    $actualRelationship = $relationshipMatches[0]
+    $referencedEntity = [string]$actualRelationship.ReferencedEntity
+    $referencingEntity = [string]$actualRelationship.ReferencingEntity
+    $referencingAttribute = [string]$actualRelationship.ReferencingAttribute
+    if ([string]::IsNullOrWhiteSpace($referencedEntity) -or
+        [string]::IsNullOrWhiteSpace($referencingEntity) -or
+        [string]::IsNullOrWhiteSpace($referencingAttribute)) {
+        return $false
+    }
+    if ($referencedEntity -ne $expectedReferencedEntity -or
+        $referencingEntity -ne $Table.logicalName -or
+        $referencingAttribute -ne $Relationship.lookupColumn) {
+        throw "Structural relationship target conflict for '$($Relationship.schemaName)'."
+    }
+
+    $expectedCascade = Get-ExpectedOrdinaryRelationshipCascade `
+        -ReferencedEntity $expectedReferencedEntity
+    foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
+        $actualValue = [string]$actualRelationship.CascadeConfiguration.$action
+        if ([string]::IsNullOrWhiteSpace($actualValue)) {
+            return $false
+        }
+        if ($actualValue -ne [string]$expectedCascade[$action]) {
+            throw "Structural relationship cascade conflict for '$($Relationship.schemaName)': '$action' must be '$($expectedCascade[$action])'."
+        }
+    }
+
+    return $true
+}
+
+function Wait-OrdinaryRelationshipVisibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Relationship
+    )
+
+    return Wait-TableMetadataSnapshot -Table $Table `
+        -Component "$($Table.logicalName)/$($Relationship.lookupColumn)" `
+        -Ready {
+            param($candidate)
+            Test-OrdinaryRelationshipVisibility -Table $Table `
+                -Relationship $Relationship -Snapshot $candidate
+        }
+}
+
 function Invoke-NativeExtensionReconciliation {
     param($Extension)
     $existing = Get-PicklistAttributeMetadata $Extension.table `
@@ -1526,18 +1638,8 @@ function Invoke-ExistingOrdinaryRelationshipReconciliation {
             $Relationship.lookupColumn) {
         throw "Structural relationship target conflict for '$($expected.SchemaName)'."
     }
-    $expectedCascade = @{
-        Assign = 'NoCascade'
-        Delete = 'Restrict'
-        Merge = if ($expected.ReferencedEntity -in @('account', 'contact')) {
-            'Cascade'
-        } else {
-            'NoCascade'
-        }
-        Reparent = 'NoCascade'
-        Share = 'NoCascade'
-        Unshare = 'NoCascade'
-    }
+    $expectedCascade = Get-ExpectedOrdinaryRelationshipCascade `
+        -ReferencedEntity $expected.ReferencedEntity
     foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
         if ([string]$actualRelationship.CascadeConfiguration.$action -ne
             [string]$expectedCascade[$action]) {
@@ -1581,6 +1683,12 @@ function Invoke-TableReconciliation {
         Publish-TableMetadata $Table
         $snapshot = Wait-TableMetadataSnapshot -Table $Table `
             -Component $Table.logicalName
+        foreach ($relationship in @($Table.relationships | Where-Object {
+            $_.authoring -eq 'InitialTableCreate'
+        })) {
+            $snapshot = Wait-OrdinaryRelationshipVisibility -Table $Table `
+                -Relationship $relationship
+        }
     }
 
     Assert-SolutionOwnership $snapshot $Table.solution $Table.logicalName
@@ -1634,21 +1742,8 @@ function Invoke-TableReconciliation {
         $lookupCreated = Invoke-ExistingOrdinaryRelationshipReconciliation `
             -Table $Table -Relationship $relationship -Snapshot $snapshot
         if ($lookupCreated) {
-            $snapshot = Wait-TableMetadataSnapshot -Table $Table `
-                -Component "$($Table.logicalName)/$($relationship.lookupColumn)" `
-                -Ready {
-                    param($candidate)
-                    $attributeMatches = @($candidate.Attributes | Where-Object {
-                        $_.LogicalName -eq $relationship.lookupColumn
-                    })
-                    $relationshipMatches = @(
-                        $candidate.ManyToOneRelationships | Where-Object {
-                            $_.SchemaName -eq $relationship.schemaName
-                        }
-                    )
-                    return $attributeMatches.Count -eq 1 -and
-                        $relationshipMatches.Count -eq 1
-                }
+            $snapshot = Wait-OrdinaryRelationshipVisibility -Table $Table `
+                -Relationship $relationship
             Invoke-ExistingOrdinaryRelationshipReconciliation -Table $Table `
                 -Relationship $relationship -Snapshot $snapshot | Out-Null
         }

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -90,6 +90,35 @@ function ConvertTo-ODataKeyString {
     return $Value.Replace("'", "''")
 }
 
+function Wait-DataverseCondition {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Component,
+        [Parameter(Mandatory)] [scriptblock]$Condition,
+        [int]$TimeoutSeconds = 180,
+        [int]$PollIntervalSeconds = 5
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ($true) {
+        $result = & $Condition
+        if ($null -ne $result) {
+            return $result
+        }
+
+        $now = Get-Date
+        if ($now -ge $deadline) {
+            throw "EventualConsistencyTimeout: component '$Component' did not converge within $TimeoutSeconds seconds."
+        }
+
+        $remainingSeconds = [int][Math]::Ceiling(($deadline - $now).TotalSeconds)
+        $sleepSeconds = [Math]::Min($PollIntervalSeconds, $remainingSeconds)
+        if ($sleepSeconds -gt 0) {
+            Start-Sleep -Seconds $sleepSeconds
+        }
+    }
+}
+
 function ConvertTo-LocalizedLabel {
     param([Parameter(Mandatory)] $Text)
     $labels = foreach ($language in $script:RequiredLanguages) {
@@ -1018,12 +1047,14 @@ function Get-TypedAttributeMetadata {
         DateOnly = 'DateTimeAttributeMetadata'
         DateTime = 'DateTimeAttributeMetadata'
         Lookup = 'LookupAttributeMetadata'
+        Customer = 'LookupAttributeMetadata'
     }[$Column.type]
     $derivedProperties = @{
         Text = 'MaxLength'
         DateOnly = 'Format,DateTimeBehavior'
         DateTime = 'Format,DateTimeBehavior'
         Lookup = 'Targets'
+        Customer = 'Targets'
     }[$Column.type]
     if (-not $type) {
         throw "Unsupported typed metadata query for '$($Column.type)' column '$($Column.logicalName)'."
@@ -1037,6 +1068,111 @@ function Get-TypedAttributeMetadata {
         "DisplayName,Description,$derivedProperties&" +
         "`$filter=LogicalName eq '$escapedAttributeName'"
     )
+}
+
+function Get-TableMetadataSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$LogicalName)
+
+    $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
+    $existing = Get-One (
+        "/EntityDefinitions?" +
+        "`$select=MetadataId,LogicalName,SchemaName,OwnershipType," +
+        "PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description,ObjectTypeCode&" +
+        "`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description)," +
+        "ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration)&" +
+        "`$filter=LogicalName eq '$escapedLogicalName'"
+    )
+    if ($null -eq $existing) { return $null }
+
+    $normalizedAttributes = foreach ($attribute in @($existing.Attributes)) {
+        $columnType = switch ([string]$attribute.AttributeType) {
+            'String' { 'Text' }
+            'Picklist' { 'GlobalChoice' }
+            'DateTime' { 'DateTime' }
+            'Lookup' { 'Lookup' }
+            'Customer' { 'Customer' }
+            default { $null }
+        }
+        if (-not $columnType) {
+            $attribute
+            continue
+        }
+
+        $typed = Get-TypedAttributeMetadata $LogicalName ([pscustomobject]@{
+            logicalName = $attribute.LogicalName
+            type = $columnType
+        })
+        $actual = @($typed)
+        if ($actual.Count -eq 1 -and $null -eq $actual[0]) {
+            $actual = @()
+        }
+        if ($actual.Count -eq 0) {
+            throw "Structural type conflict for '$LogicalName/$($attribute.LogicalName)': base metadata exists but typed metadata is unavailable."
+        }
+        if ($actual.Count -ne 1) {
+            throw "Structural metadata conflict for '$LogicalName/$($attribute.LogicalName)': typed metadata was ambiguous."
+        }
+        foreach ($property in 'MetadataId', 'LogicalName', 'SchemaName',
+            'AttributeType') {
+            if ($null -eq $attribute.$property -or
+                $null -eq $actual[0].$property -or
+                [string]$attribute.$property -ne
+                [string]$actual[0].$property) {
+                throw "Structural metadata conflict for '$LogicalName/$($attribute.LogicalName)': base and typed '$property' values differ or are incomplete."
+            }
+        }
+
+        $merged = [ordered]@{}
+        foreach ($property in $attribute.PSObject.Properties) {
+            if ($property.Name -notmatch '^@odata\.') {
+                $merged[$property.Name] = $property.Value
+            }
+        }
+        foreach ($property in $actual[0].PSObject.Properties) {
+            if ($property.Name -notmatch '^@odata\.' -and
+                $property.Name -ne 'value') {
+                $merged[$property.Name] = $property.Value
+            }
+        }
+        [pscustomobject]$merged
+    }
+
+    $snapshot = [ordered]@{}
+    foreach ($property in $existing.PSObject.Properties) {
+        if ($property.Name -eq 'Attributes') {
+            $snapshot[$property.Name] = @($normalizedAttributes)
+        } else {
+            $snapshot[$property.Name] = $property.Value
+        }
+    }
+    if ($snapshot.Keys -notcontains 'Attributes') {
+        $snapshot['Attributes'] = @()
+    }
+    return [pscustomobject]$snapshot
+}
+
+function Wait-TableMetadataSnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] [string]$Component,
+        [scriptblock]$Ready
+    )
+
+    return Wait-DataverseCondition -Component $Component -Condition {
+        try {
+            $snapshot = Get-TableMetadataSnapshot $Table.logicalName
+        } catch {
+            if ($_.Exception.Message -like '*typed metadata is unavailable*') {
+                return $null
+            }
+            throw
+        }
+        if ($null -eq $snapshot) { return $null }
+        if ($Ready -and -not (& $Ready $snapshot)) { return $null }
+        return $snapshot
+    }
 }
 
 function Invoke-NativeExtensionReconciliation {
@@ -1227,8 +1363,9 @@ function Invoke-TableChildren {
 
 function Resolve-TableObjectTypeCode {
     param([Parameter(Mandatory)] [string]$TableLogicalName)
+    $escapedLogicalName = ConvertTo-ODataKeyString $TableLogicalName
     $response = Invoke-DataverseRequest -Method GET -Path (
-        "/EntityDefinitions(LogicalName='$TableLogicalName')?`$select=LogicalName,ObjectTypeCode"
+        "/EntityDefinitions(LogicalName='$escapedLogicalName')?`$select=LogicalName,ObjectTypeCode"
     )
     $metadata = if ($response.ObjectTypeCode) { $response } else { @($response.value)[0] }
     if ($null -eq $metadata -or $null -eq $metadata.ObjectTypeCode) {
@@ -1241,19 +1378,34 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
     param(
         [Parameter(Mandatory)] $Table,
         [Parameter(Mandatory)] $Column,
-        [object[]]$ExistingAttributes = @()
+        [object[]]$ExistingAttributes = @(),
+        $Snapshot
     )
 
-    $escapedLogicalName = ConvertTo-ODataKeyString $Table.logicalName
-    $attributeResponse = Invoke-DataverseRequest -Method GET -Path (
-        "/EntityDefinitions(LogicalName='$escapedLogicalName')/Attributes/" +
-        "Microsoft.Dynamics.CRM.LookupAttributeMetadata?" +
-        "`$select=MetadataId,LogicalName,SchemaName,AttributeType,Targets"
-    )
-    $relationshipResponse = Invoke-DataverseRequest -Method GET -Path (
-        "/EntityDefinitions(LogicalName='$escapedLogicalName')/ManyToOneRelationships?" +
-        "`$select=MetadataId,SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute"
-    )
+    if ($Snapshot) {
+        if (@($ExistingAttributes).Count -eq 0) {
+            $ExistingAttributes = @($Snapshot.Attributes)
+        }
+        $attributeResponse = [pscustomobject]@{
+            value = @($Snapshot.Attributes | Where-Object {
+                $_.AttributeType -in @('Lookup', 'Customer')
+            })
+        }
+        $relationshipResponse = [pscustomobject]@{
+            value = @($Snapshot.ManyToOneRelationships)
+        }
+    } else {
+        $escapedLogicalName = ConvertTo-ODataKeyString $Table.logicalName
+        $attributeResponse = Invoke-DataverseRequest -Method GET -Path (
+            "/EntityDefinitions(LogicalName='$escapedLogicalName')/Attributes/" +
+            "Microsoft.Dynamics.CRM.LookupAttributeMetadata?" +
+            "`$select=MetadataId,LogicalName,SchemaName,AttributeType,Targets"
+        )
+        $relationshipResponse = Invoke-DataverseRequest -Method GET -Path (
+            "/EntityDefinitions(LogicalName='$escapedLogicalName')/ManyToOneRelationships?" +
+            "`$select=MetadataId,SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute"
+        )
+    }
 
     $relationshipContract = @($Table.relationships | Where-Object {
         $_.lookupColumn -eq $Column.logicalName -and
@@ -1294,7 +1446,7 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
         Invoke-PlannedRequest (Get-CustomerRelationshipRequest $Table $Column) |
             Out-Null
         Write-Output "$($Table.logicalName)/$($Column.logicalName): Created"
-        return
+        return $true
     }
 
     if ($attributeCandidates.Count -ne 1) {
@@ -1324,6 +1476,75 @@ function Invoke-ExistingCustomerRelationshipReconciliation {
             throw "Structural Customer relationship conflict for '$($Table.logicalName)/$($Column.logicalName)': relationship '$($expected.SchemaName)' has conflicting target or schema metadata."
         }
     }
+    return $false
+}
+
+function Invoke-ExistingOrdinaryRelationshipReconciliation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Relationship,
+        [Parameter(Mandatory)] $Snapshot
+    )
+
+    $expected = [pscustomobject]@{
+        SchemaName = $Relationship.schemaName
+        ReferencedEntity = [string]$Relationship.referencedTables[0]
+    }
+    $attributeCandidates = @($Snapshot.Attributes | Where-Object {
+        $_.LogicalName -eq $Relationship.lookupColumn
+    })
+    $actualRelationship = @($Snapshot.ManyToOneRelationships |
+        Where-Object SchemaName -eq $expected.SchemaName)
+    if ($actualRelationship.Count -eq 0 -and
+        $attributeCandidates.Count -eq 0) {
+        Invoke-PlannedRequest (
+            Get-OrdinaryRelationshipRequest $Table $Relationship
+        ) | Out-Null
+        Write-Output "$($Table.logicalName)/$($Relationship.lookupColumn): Created"
+        return $true
+    }
+    if ($actualRelationship.Count -ne 1 -or
+        $attributeCandidates.Count -ne 1) {
+        throw "Structural relationship conflict for '$($expected.SchemaName)': relationship and lookup metadata must both be wholly present or wholly absent."
+    }
+    $actualRelationship = $actualRelationship[0]
+    if ([string]::IsNullOrWhiteSpace(
+            [string]$actualRelationship.ReferencedEntity
+        ) -or
+        [string]$actualRelationship.ReferencedEntity -ne
+            $expected.ReferencedEntity -or
+        [string]::IsNullOrWhiteSpace(
+            [string]$actualRelationship.ReferencingEntity
+        ) -or
+        [string]$actualRelationship.ReferencingEntity -ne
+            $Table.logicalName -or
+        [string]::IsNullOrWhiteSpace(
+            [string]$actualRelationship.ReferencingAttribute
+        ) -or
+        [string]$actualRelationship.ReferencingAttribute -ne
+            $Relationship.lookupColumn) {
+        throw "Structural relationship target conflict for '$($expected.SchemaName)'."
+    }
+    $expectedCascade = @{
+        Assign = 'NoCascade'
+        Delete = 'Restrict'
+        Merge = if ($expected.ReferencedEntity -in @('account', 'contact')) {
+            'Cascade'
+        } else {
+            'NoCascade'
+        }
+        Reparent = 'NoCascade'
+        Share = 'NoCascade'
+        Unshare = 'NoCascade'
+    }
+    foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
+        if ([string]$actualRelationship.CascadeConfiguration.$action -ne
+            [string]$expectedCascade[$action]) {
+            throw "Structural relationship cascade conflict for '$($expected.SchemaName)': '$action' must be '$($expectedCascade[$action])'."
+        }
+    }
+    return $false
 }
 
 function Publish-TableMetadata {
@@ -1347,182 +1568,159 @@ function Publish-TableMetadata {
 
 function Invoke-TableReconciliation {
     param($Table)
-    $existing = Get-One "/EntityDefinitions?`$select=MetadataId,LogicalName,SchemaName,OwnershipType,PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description&`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description),ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration)&`$filter=LogicalName eq '$($Table.logicalName)'"
-    if ($null -eq $existing) {
+
+    $tableWasCreated = $false
+    $snapshot = Get-TableMetadataSnapshot $Table.logicalName
+    if ($null -eq $snapshot) {
         $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
         Invoke-PlannedRequest (
             Get-TableCreateRequest $Table $choiceMetadataIds
         ) | Out-Null
+        $tableWasCreated = $true
         Write-Output "$($Table.logicalName): Created"
         Publish-TableMetadata $Table
-
-        # Dataverse requires the global action for a polymorphic Customer lookup.
-        foreach ($customer in @($Table.columns | Where-Object type -eq 'Customer')) {
-            Invoke-PlannedRequest (Get-CustomerRelationshipRequest $Table $customer) | Out-Null
-            Write-Output "$($Table.logicalName)/$($customer.logicalName): Created"
-        }
-    } else {
-        Assert-SolutionOwnership $existing $Table.solution $Table.logicalName
-        if ([string]$existing.OwnershipType -and [string]$existing.OwnershipType -ne $Table.ownership) {
-            throw "Structural ownership conflict for '$($Table.logicalName)'."
-        }
-        Publish-TableMetadata $Table
-        $createdOrdinaryLookups = @{}
-        foreach ($customer in @($Table.columns | Where-Object type -eq 'Customer')) {
-            Invoke-ExistingCustomerRelationshipReconciliation $Table $customer `
-                -ExistingAttributes @($existing.Attributes)
-        }
-        foreach ($relationship in @($Table.relationships | Where-Object {
-            $_.authoring -ne 'CreateCustomerRelationships'
-        })) {
-            $expected = [pscustomobject]@{
-                SchemaName = $relationship.schemaName
-                ReferencedEntity = [string]$relationship.referencedTables[0]
-            }
-            $attributeCandidates = @($existing.Attributes | Where-Object {
-                $_.LogicalName -eq $relationship.lookupColumn
-            })
-            foreach ($wanted in @($expected)) {
-                $actualRelationship = @($existing.ManyToOneRelationships |
-                    Where-Object SchemaName -eq $wanted.SchemaName)
-                if ($actualRelationship.Count -eq 0 -and
-                    $attributeCandidates.Count -eq 0) {
-                    Invoke-PlannedRequest (
-                        Get-OrdinaryRelationshipRequest $Table $relationship
-                    ) | Out-Null
-                    $createdOrdinaryLookups[$relationship.lookupColumn] = $true
-                    Write-Output "$($Table.logicalName)/$($relationship.lookupColumn): Created"
-                    continue
-                }
-                if ($actualRelationship.Count -ne 1 -or
-                    $attributeCandidates.Count -ne 1) {
-                    throw "Structural relationship conflict for '$($wanted.SchemaName)': relationship and lookup metadata must both be wholly present or wholly absent."
-                }
-                $actualRelationship = $actualRelationship[0]
-                if ([string]::IsNullOrWhiteSpace(
-                        [string]$actualRelationship.ReferencedEntity
-                    ) -or
-                    [string]$actualRelationship.ReferencedEntity -ne
-                        $wanted.ReferencedEntity -or
-                    [string]::IsNullOrWhiteSpace(
-                        [string]$actualRelationship.ReferencingEntity
-                    ) -or
-                    [string]$actualRelationship.ReferencingEntity -ne
-                        $Table.logicalName -or
-                    [string]::IsNullOrWhiteSpace(
-                        [string]$actualRelationship.ReferencingAttribute
-                    ) -or
-                    [string]$actualRelationship.ReferencingAttribute -ne
-                        $relationship.lookupColumn) {
-                    throw "Structural relationship target conflict for '$($wanted.SchemaName)'."
-                }
-                $expectedCascade = @{
-                    Assign='NoCascade'; Delete='Restrict'
-                    Merge=$(if ($wanted.ReferencedEntity -in @('account', 'contact')) {
-                        'Cascade'
-                    } else {
-                        'NoCascade'
-                    })
-                    Reparent='NoCascade'; Share='NoCascade'; Unshare='NoCascade'
-                }
-                foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
-                    if ([string]$actualRelationship.CascadeConfiguration.$action -ne
-                        [string]$expectedCascade[$action]) {
-                        throw "Structural relationship cascade conflict for '$($wanted.SchemaName)': '$action' must be '$($expectedCascade[$action])'."
-                    }
-                }
-            }
-        }
-        if (Test-LocalizedMetadataChanged $existing $Table.metadata) {
-            if (-not $existing.MetadataId) {
-                throw "Cannot update localized metadata for '$($Table.logicalName)' without its metadata ID."
-            }
-            $path = "/EntityDefinitions($($existing.MetadataId))"
-            $complete = Get-CompleteMetadata $path Entity
-            Invoke-DataverseRequest -Method PUT -Path $path `
-                -Body (New-CompleteLocalizedMetadataUpdateBody $complete $Table.metadata Entity) `
-                -Headers (Get-MergeLabelHeaders $Table.solution) | Out-Null
-        }
-        foreach ($column in $Table.columns) {
-            if ($column.type -eq 'Customer') { continue }
-            if ($createdOrdinaryLookups.ContainsKey($column.logicalName)) { continue }
-            $base = @($existing.Attributes |
-                Where-Object LogicalName -eq $column.logicalName)
-            if ($base.Count -gt 1) {
-                throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
-            }
-            $needsTypedMetadata = $column.type -eq 'GlobalChoice' -or
-                ($base.Count -eq 1 -and (
-                    ($column.type -eq 'Text' -and $null -eq $base[0].MaxLength) -or
-                    ($column.type -in @('DateOnly', 'DateTime') -and
-                        ($null -eq $base[0].Format -or
-                            $null -eq $base[0].DateTimeBehavior)) -or
-                    ($column.type -eq 'Lookup' -and $null -eq $base[0].Targets)
-                ))
-            if ($needsTypedMetadata) {
-                $typed = Get-TypedAttributeMetadata $Table.logicalName $column
-                $actual = @($typed)
-                if ($actual.Count -eq 1 -and $null -eq $actual[0]) {
-                    $actual = @()
-                }
-                if ($base.Count -eq 1 -and $actual.Count -eq 0) {
-                    throw "Structural type conflict for '$($Table.logicalName)/$($column.logicalName)': base metadata exists but typed metadata is unavailable."
-                }
-                if ($base.Count -eq 1 -and $actual.Count -eq 1) {
-                    foreach ($property in 'MetadataId', 'LogicalName', 'SchemaName',
-                        'AttributeType') {
-                        if ($null -eq $base[0].$property -or
-                            $null -eq $actual[0].$property -or
-                            [string]$base[0].$property -ne
-                            [string]$actual[0].$property) {
-                            throw "Structural metadata conflict for '$($Table.logicalName)/$($column.logicalName)': base and typed '$property' values differ or are incomplete."
-                        }
-                    }
-                }
-            } else {
-                $actual = $base
-            }
-            if ($actual.Count -eq 0) {
-                if ($column.type -in @('Lookup', 'Customer')) {
-                    throw "Structural conflict: lookup '$($column.logicalName)' is missing from existing table '$($Table.logicalName)'; it will not be created or recreated."
-                }
-                $request = [pscustomobject]@{
-                    Method = 'POST'
-                    Path = "/EntityDefinitions(LogicalName='$($Table.logicalName)')/Attributes"
-                    Solution = $Table.solution
-                    Body = New-AttributeMetadata $column `
-                        -GlobalChoiceMetadataIds (
-                            Get-GlobalChoiceMetadataIds @($column)
-                        )
-                }
-                Invoke-PlannedRequest $request | Out-Null
-                Write-Output "$($Table.logicalName)/$($column.logicalName): Created"
-            } elseif ($actual.Count -eq 1) {
-                Test-AttributeCompatibility $actual[0] $column $Table.logicalName
-                if (Test-LocalizedMetadataChanged $actual[0] $column.metadata) {
-                    if (-not $actual[0].MetadataId) {
-                        throw "Cannot update localized metadata for '$($Table.logicalName)/$($column.logicalName)' without its metadata ID."
-                    }
-                    $typeName = switch ([string]$actual[0].AttributeType) {
-                        'String' { 'StringAttributeMetadata' }
-                        'DateTime' { 'DateTimeAttributeMetadata' }
-                        'Picklist' { 'PicklistAttributeMetadata' }
-                        default { throw "Cannot safely update attribute metadata for '$($column.logicalName)': unsupported typed endpoint." }
-                    }
-                    $path = "/EntityDefinitions(LogicalName='$($Table.logicalName)')/Attributes($($actual[0].MetadataId))/Microsoft.Dynamics.CRM.$typeName"
-                    $complete = Get-CompleteMetadata $path Attribute
-                    Invoke-DataverseRequest -Method PUT -Path $path `
-                        -Body (New-CompleteLocalizedMetadataUpdateBody $complete $column.metadata Attribute) `
-                        -Headers (Get-MergeLabelHeaders $Table.solution) | Out-Null
-                }
-            } else {
-                throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
-            }
-        }
-        Write-Output "$($Table.logicalName): Unchanged"
-        Publish-TableMetadata $Table
+        $snapshot = Wait-TableMetadataSnapshot -Table $Table `
+            -Component $Table.logicalName
     }
-    $objectTypeCode = Resolve-TableObjectTypeCode $Table.logicalName
+
+    Assert-SolutionOwnership $snapshot $Table.solution $Table.logicalName
+    if ([string]$snapshot.OwnershipType -and
+        [string]$snapshot.OwnershipType -ne $Table.ownership) {
+        throw "Structural ownership conflict for '$($Table.logicalName)'."
+    }
+
+    foreach ($customer in @($Table.columns | Where-Object type -eq 'Customer')) {
+        $customerCreated = Invoke-ExistingCustomerRelationshipReconciliation `
+            -Table $Table -Column $customer `
+            -ExistingAttributes @($snapshot.Attributes) -Snapshot $snapshot
+        if ($customerCreated) {
+            $snapshot = Wait-TableMetadataSnapshot -Table $Table `
+                -Component "$($Table.logicalName)/$($customer.logicalName)" `
+                -Ready {
+                    param($candidate)
+                    $attributeMatches = @($candidate.Attributes | Where-Object {
+                        $_.LogicalName -eq $customer.logicalName -or
+                        $_.SchemaName -eq $customer.schemaName
+                    })
+                    if ($attributeMatches.Count -ne 1) {
+                        return $false
+                    }
+                    $relationshipContract = @($Table.relationships |
+                        Where-Object {
+                            $_.lookupColumn -eq $customer.logicalName -and
+                            $_.authoring -eq 'CreateCustomerRelationships'
+                        })
+                    if ($relationshipContract.Count -ne 1) {
+                        return $false
+                    }
+                    $expectedSchemas = @($customer.lookup.targets |
+                        ForEach-Object {
+                            "$($relationshipContract[0].schemaName)_$_"
+                        })
+                    $actualRelationships = @($candidate.ManyToOneRelationships |
+                        Where-Object SchemaName -in $expectedSchemas)
+                    return $actualRelationships.Count -eq
+                        $expectedSchemas.Count
+                }
+            Invoke-ExistingCustomerRelationshipReconciliation -Table $Table `
+                -Column $customer -ExistingAttributes @($snapshot.Attributes) `
+                -Snapshot $snapshot | Out-Null
+        }
+    }
+
+    foreach ($relationship in @($Table.relationships | Where-Object {
+        $_.authoring -ne 'CreateCustomerRelationships'
+    })) {
+        $lookupCreated = Invoke-ExistingOrdinaryRelationshipReconciliation `
+            -Table $Table -Relationship $relationship -Snapshot $snapshot
+        if ($lookupCreated) {
+            $snapshot = Wait-TableMetadataSnapshot -Table $Table `
+                -Component "$($Table.logicalName)/$($relationship.lookupColumn)" `
+                -Ready {
+                    param($candidate)
+                    $attributeMatches = @($candidate.Attributes | Where-Object {
+                        $_.LogicalName -eq $relationship.lookupColumn
+                    })
+                    $relationshipMatches = @(
+                        $candidate.ManyToOneRelationships | Where-Object {
+                            $_.SchemaName -eq $relationship.schemaName
+                        }
+                    )
+                    return $attributeMatches.Count -eq 1 -and
+                        $relationshipMatches.Count -eq 1
+                }
+            Invoke-ExistingOrdinaryRelationshipReconciliation -Table $Table `
+                -Relationship $relationship -Snapshot $snapshot | Out-Null
+        }
+    }
+
+    if (Test-LocalizedMetadataChanged $snapshot $Table.metadata) {
+        if (-not $snapshot.MetadataId) {
+            throw "Cannot update localized metadata for '$($Table.logicalName)' without its metadata ID."
+        }
+        $path = "/EntityDefinitions($($snapshot.MetadataId))"
+        $complete = Get-CompleteMetadata $path Entity
+        Invoke-DataverseRequest -Method PUT -Path $path `
+            -Body (New-CompleteLocalizedMetadataUpdateBody $complete $Table.metadata Entity) `
+            -Headers (Get-MergeLabelHeaders $Table.solution) | Out-Null
+    }
+
+    foreach ($column in $Table.columns) {
+        if ($column.type -eq 'Customer') { continue }
+        $actual = @($snapshot.Attributes | Where-Object {
+            $_.LogicalName -eq $column.logicalName
+        })
+        if ($actual.Count -gt 1) {
+            throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
+        }
+        if ($actual.Count -eq 0) {
+            if ($column.type -in @('Lookup', 'Customer')) {
+                throw "Structural conflict: lookup '$($column.logicalName)' is missing from existing table '$($Table.logicalName)'; it will not be created or recreated."
+            }
+            $request = [pscustomobject]@{
+                Method = 'POST'
+                Path = "/EntityDefinitions(LogicalName='$($Table.logicalName)')/Attributes"
+                Solution = $Table.solution
+                Body = New-AttributeMetadata $column `
+                    -GlobalChoiceMetadataIds (
+                        Get-GlobalChoiceMetadataIds @($column)
+                    )
+            }
+            Invoke-PlannedRequest $request | Out-Null
+            Write-Output "$($Table.logicalName)/$($column.logicalName): Created"
+        } elseif ($actual.Count -eq 1) {
+            Test-AttributeCompatibility $actual[0] $column $Table.logicalName
+            if (Test-LocalizedMetadataChanged $actual[0] $column.metadata) {
+                if (-not $actual[0].MetadataId) {
+                    throw "Cannot update localized metadata for '$($Table.logicalName)/$($column.logicalName)' without its metadata ID."
+                }
+                $typeName = switch ([string]$actual[0].AttributeType) {
+                    'String' { 'StringAttributeMetadata' }
+                    'DateTime' { 'DateTimeAttributeMetadata' }
+                    'Picklist' { 'PicklistAttributeMetadata' }
+                    default { throw "Cannot safely update attribute metadata for '$($column.logicalName)': unsupported typed endpoint." }
+                }
+                $path = "/EntityDefinitions(LogicalName='$($Table.logicalName)')/Attributes($($actual[0].MetadataId))/Microsoft.Dynamics.CRM.$typeName"
+                $complete = Get-CompleteMetadata $path Attribute
+                Invoke-DataverseRequest -Method PUT -Path $path `
+                    -Body (New-CompleteLocalizedMetadataUpdateBody $complete $column.metadata Attribute) `
+                    -Headers (Get-MergeLabelHeaders $Table.solution) | Out-Null
+            }
+        } else {
+            throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
+        }
+    }
+
+    if (-not $tableWasCreated) {
+        Write-Output "$($Table.logicalName): Unchanged"
+    }
+    Publish-TableMetadata $Table
+
+    $objectTypeCode = if ($snapshot.ObjectTypeCode) {
+        [int]$snapshot.ObjectTypeCode
+    } else {
+        Resolve-TableObjectTypeCode $Table.logicalName
+    }
     Invoke-TableChildren $Table $objectTypeCode
 }
 

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -712,6 +712,52 @@ function Assert-InsuranceFoundationIntegrity {
     }
 }
 
+function Resolve-PythonJsonSchemaCommand {
+    [CmdletBinding()]
+    param()
+
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+    if ($null -eq $pythonCommand) {
+        throw (
+            "Python with the 'jsonschema' package is required for JSON Schema validation when Test-Json is unavailable."
+        )
+    }
+
+    foreach ($propertyName in @('Source', 'Path', 'Name')) {
+        $property = $pythonCommand.PSObject.Properties[$propertyName]
+        if ($null -eq $property) {
+            continue
+        }
+
+        $value = [string]$property.Value
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            return $value
+        }
+    }
+
+    throw (
+        "Python with the 'jsonschema' package is required for JSON Schema validation when Test-Json is unavailable."
+    )
+}
+
+function Assert-PythonJsonSchemaPrerequisite {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PythonCommand
+    )
+
+    $output = & $PythonCommand -c 'import jsonschema' 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $detail = ConvertTo-SafeCliDiagnosticLine -Value $output
+        throw (
+            'Python + jsonschema prerequisite check failed for JSON Schema ' +
+            "validation when Test-Json is unavailable. Output: $detail"
+        )
+    }
+}
+
 function Test-InsuranceFoundationContract {
     [CmdletBinding()]
     param([Parameter(Mandatory)] [string]$Path)
@@ -728,6 +774,8 @@ function Test-InsuranceFoundationContract {
                 throw 'JSON Schema validation returned false.'
             }
         } else {
+            $pythonCommand = Resolve-PythonJsonSchemaCommand
+            Assert-PythonJsonSchemaPrerequisite -PythonCommand $pythonCommand
             $validator = @'
 import json, sys
 from jsonschema import Draft202012Validator
@@ -739,7 +787,7 @@ Draft202012Validator.check_schema(schema)
 errors = list(Draft202012Validator(schema).iter_errors(instance))
 sys.exit(1 if errors else 0)
 '@
-            & python -c $validator $resolved $schemaPath
+            & $pythonCommand -c $validator $resolved $schemaPath
             if ($LASTEXITCODE -ne 0) {
                 throw 'Draft 2020-12 JSON Schema validation returned false.'
             }

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -102,13 +102,13 @@ function Wait-DataverseCondition {
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ($true) {
         $result = & $Condition
-        if ($null -ne $result) {
-            return $result
-        }
-
         $now = Get-Date
         if ($now -ge $deadline) {
             throw "EventualConsistencyTimeout: component '$Component' did not converge within $TimeoutSeconds seconds."
+        }
+
+        if ($null -ne $result) {
+            return $result
         }
 
         $remainingSeconds = [int][Math]::Ceiling(($deadline - $now).TotalSeconds)
@@ -1089,22 +1089,172 @@ function Get-TypedAttributeMetadata {
     )
 }
 
+function Get-UniqueMetadataStrings {
+    [CmdletBinding()]
+    param([string[]]$Values)
+
+    $unique = [System.Collections.Generic.List[string]]::new()
+    $seen = @{}
+    foreach ($value in @($Values)) {
+        $candidate = [string]$value
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if ($seen.ContainsKey($candidate)) { continue }
+        $seen[$candidate] = $true
+        $unique.Add($candidate) | Out-Null
+    }
+    return @($unique)
+}
+
+function Resolve-ContractColumnLogicalName {
+    [CmdletBinding()]
+    param(
+        $Table,
+        [string]$LogicalName,
+        [string]$SchemaName
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$LogicalName)) {
+        return [string]$LogicalName
+    }
+    if ($null -eq $Table -or
+        [string]::IsNullOrWhiteSpace([string]$SchemaName)) {
+        return $null
+    }
+
+    $matches = @($Table.columns | Where-Object {
+        $_.schemaName -eq $SchemaName
+    })
+    if ($matches.Count -gt 1) {
+        throw "Column schema '$SchemaName' was ambiguous in table '$($Table.logicalName)'."
+    }
+    if ($matches.Count -eq 1) {
+        return [string]$matches[0].logicalName
+    }
+    return $null
+}
+
+function Get-RequestSubmittedAttributeLogicalNames {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Request,
+        $Table
+    )
+
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    if ($null -eq $Request.Body) {
+        return @()
+    }
+
+    $candidates.Add(
+        (Resolve-ContractColumnLogicalName -Table $Table `
+            -LogicalName $Request.Body.PrimaryNameAttribute)
+    ) | Out-Null
+    foreach ($attribute in @($Request.Body.Attributes)) {
+        if ($null -eq $attribute) { continue }
+        $candidates.Add(
+            (Resolve-ContractColumnLogicalName -Table $Table `
+                -LogicalName $attribute.LogicalName `
+                -SchemaName $attribute.SchemaName)
+        ) | Out-Null
+    }
+    $requestLookup = $Request.Body.Lookup
+    if ($null -ne $requestLookup) {
+        $candidates.Add(
+            (Resolve-ContractColumnLogicalName -Table $Table `
+                -LogicalName $requestLookup.LogicalName `
+                -SchemaName $requestLookup.SchemaName)
+        ) | Out-Null
+    }
+    foreach ($relationship in @($Request.Body.OneToManyRelationships)) {
+        if ($null -eq $relationship) { continue }
+        $relationshipLookup = $relationship.Lookup
+        if ($null -eq $relationshipLookup) {
+            continue
+        }
+        $candidates.Add(
+            (Resolve-ContractColumnLogicalName -Table $Table `
+                -LogicalName $relationshipLookup.LogicalName `
+                -SchemaName $relationshipLookup.SchemaName)
+        ) | Out-Null
+    }
+
+    return Get-UniqueMetadataStrings -Values @($candidates)
+}
+
+function Get-RequestSubmittedRelationshipSchemas {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Request)
+
+    if ($null -eq $Request.Body) {
+        return @()
+    }
+
+    $schemas = foreach ($relationship in @($Request.Body.OneToManyRelationships)) {
+        if ($null -eq $relationship) { continue }
+        if ([string]::IsNullOrWhiteSpace([string]$relationship.SchemaName)) {
+            continue
+        }
+        [string]$relationship.SchemaName
+    }
+    return Get-UniqueMetadataStrings -Values @($schemas)
+}
+
+function Get-TableContractAttributeLogicalNames {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Table)
+
+    return Get-UniqueMetadataStrings -Values @(
+        $Table.columns | ForEach-Object { [string]$_.logicalName }
+    )
+}
+
 function Get-TableMetadataSnapshot {
     [CmdletBinding()]
-    param([Parameter(Mandatory)] [string]$LogicalName)
+    param(
+        [Parameter(Mandatory)] [string]$LogicalName,
+        [string[]]$RequestedAttributeLogicalNames
+    )
 
     $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
+    $requestedAttributeLogicalNames = @(Get-UniqueMetadataStrings `
+        -Values $RequestedAttributeLogicalNames)
+    $requestedAttributeLookup = @{}
+    foreach ($requestedAttributeLogicalName in $requestedAttributeLogicalNames) {
+        $requestedAttributeLookup[$requestedAttributeLogicalName] = $true
+    }
+    $attributeExpand = (
+        "Attributes(`$select=MetadataId,LogicalName,SchemaName," +
+        'AttributeType,DisplayName,Description'
+    )
+    if ($requestedAttributeLogicalNames.Count -gt 0) {
+        $attributeFilter = @(
+            $requestedAttributeLogicalNames | ForEach-Object {
+                "LogicalName eq '$(
+                    ConvertTo-ODataKeyString ([string]$_)
+                )'"
+            }
+        ) -join ' or '
+        $attributeExpand += ";`$filter=$attributeFilter"
+    }
+    $attributeExpand += ')'
     $existing = Get-One (
         "/EntityDefinitions?" +
         "`$select=MetadataId,LogicalName,SchemaName,OwnershipType," +
         "PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description,ObjectTypeCode&" +
-        "`$expand=Attributes(`$select=MetadataId,LogicalName,SchemaName,AttributeType,DisplayName,Description)," +
+        "`$expand=$attributeExpand," +
         "ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration)&" +
         "`$filter=LogicalName eq '$escapedLogicalName'"
     )
     if ($null -eq $existing) { return $null }
 
-    $normalizedAttributes = foreach ($attribute in @($existing.Attributes)) {
+    $baseAttributes = @($existing.Attributes)
+    if ($requestedAttributeLookup.Count -gt 0) {
+        $baseAttributes = @($baseAttributes | Where-Object {
+            $requestedAttributeLookup.ContainsKey([string]$_.LogicalName)
+        })
+    }
+
+    $normalizedAttributes = foreach ($attribute in $baseAttributes) {
         $columnType = switch ([string]$attribute.AttributeType) {
             'String' { 'Text' }
             'Picklist' { 'GlobalChoice' }
@@ -1176,12 +1326,15 @@ function Wait-TableMetadataSnapshot {
     param(
         [Parameter(Mandatory)] $Table,
         [Parameter(Mandatory)] [string]$Component,
-        [scriptblock]$Ready
+        [scriptblock]$Ready,
+        [string[]]$RequestedAttributeLogicalNames
     )
 
     return Wait-DataverseCondition -Component $Component -Condition {
         try {
-            $snapshot = Get-TableMetadataSnapshot $Table.logicalName
+            $snapshot = Get-TableMetadataSnapshot `
+                -LogicalName $Table.logicalName `
+                -RequestedAttributeLogicalNames $RequestedAttributeLogicalNames
         } catch {
             if ($_.Exception.Message -like '*typed metadata is unavailable*') {
                 return $null
@@ -1205,11 +1358,31 @@ function Get-InitialTableCreateOrdinaryRelationships {
 
 function Wait-InitialTableCreateTableSnapshot {
     [CmdletBinding()]
-    param([Parameter(Mandatory)] $Table)
-
-    $relationships = @(
-        Get-InitialTableCreateOrdinaryRelationships -Table $Table
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $TableCreateRequest,
+        [string[]]$RequestedAttributeLogicalNames
     )
+
+    $initialAttributeLogicalNames = @(
+        Get-RequestSubmittedAttributeLogicalNames `
+            -Request $TableCreateRequest -Table $Table
+    )
+    $relationshipSchemas = @(
+        Get-RequestSubmittedRelationshipSchemas -Request $TableCreateRequest
+    )
+    $relationships = foreach ($relationshipSchema in $relationshipSchemas) {
+        $matches = @($Table.relationships | Where-Object {
+            $_.schemaName -eq $relationshipSchema
+        })
+        if ($matches.Count -ne 1) {
+            throw (
+                "Initial create relationship '$relationshipSchema' must " +
+                "resolve one table relationship contract."
+            )
+        }
+        $matches[0]
+    }
     $component = if ($relationships.Count -eq 0) {
         $Table.logicalName
     } else {
@@ -1219,8 +1392,21 @@ function Wait-InitialTableCreateTableSnapshot {
     }
 
     return Wait-TableMetadataSnapshot -Table $Table `
-        -Component $component -Ready {
+        -Component $component `
+        -RequestedAttributeLogicalNames $RequestedAttributeLogicalNames `
+        -Ready {
             param($candidate)
+            foreach ($attributeLogicalName in $initialAttributeLogicalNames) {
+                $attributeMatches = @($candidate.Attributes | Where-Object {
+                    $_.LogicalName -eq $attributeLogicalName
+                })
+                if ($attributeMatches.Count -gt 1) {
+                    throw "Duplicate physical attributes found for '$($Table.logicalName)/$attributeLogicalName'."
+                }
+                if ($attributeMatches.Count -ne 1) {
+                    return $false
+                }
+            }
             foreach ($relationship in $relationships) {
                 if (-not (Test-OrdinaryRelationshipVisibility -Table $Table `
                             -Relationship $relationship -Snapshot $candidate)) {
@@ -1312,11 +1498,13 @@ function Wait-OrdinaryRelationshipVisibility {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] $Table,
-        [Parameter(Mandatory)] $Relationship
+        [Parameter(Mandatory)] $Relationship,
+        [string[]]$RequestedAttributeLogicalNames
     )
 
     return Wait-TableMetadataSnapshot -Table $Table `
         -Component "$($Table.logicalName)/$($Relationship.lookupColumn)" `
+        -RequestedAttributeLogicalNames $RequestedAttributeLogicalNames `
         -Ready {
             param($candidate)
             Test-OrdinaryRelationshipVisibility -Table $Table `
@@ -1718,16 +1906,36 @@ function Invoke-TableReconciliation {
     param($Table)
 
     $tableWasCreated = $false
-    $snapshot = Get-TableMetadataSnapshot $Table.logicalName
+    $requestedAttributeLogicalNames = @(
+        Get-TableContractAttributeLogicalNames -Table $Table
+    )
+    $initialTableCreateAttributeLogicalNames = @()
+    $snapshot = Get-TableMetadataSnapshot `
+        -LogicalName $Table.logicalName `
+        -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
     if ($null -eq $snapshot) {
         $choiceMetadataIds = Get-GlobalChoiceMetadataIds @($Table.columns)
+        $tableCreateRequest = Get-TableCreateRequest $Table $choiceMetadataIds
+        $initialTableCreateAttributeLogicalNames = @(
+            Get-RequestSubmittedAttributeLogicalNames `
+                -Request $tableCreateRequest -Table $Table
+        )
         Invoke-PlannedRequest (
-            Get-TableCreateRequest $Table $choiceMetadataIds
+            $tableCreateRequest
         ) | Out-Null
         $tableWasCreated = $true
         Write-Output "$($Table.logicalName): Created"
         Publish-TableMetadata $Table
-        $snapshot = Wait-InitialTableCreateTableSnapshot -Table $Table
+        $snapshot = Wait-InitialTableCreateTableSnapshot -Table $Table `
+            -TableCreateRequest $tableCreateRequest `
+            -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
+    }
+    $initialTableCreateAttributeLookup = @{}
+    foreach ($initialTableCreateAttributeLogicalName in
+        $initialTableCreateAttributeLogicalNames) {
+        $initialTableCreateAttributeLookup[
+            $initialTableCreateAttributeLogicalName
+        ] = $true
     }
 
     Assert-SolutionOwnership $snapshot $Table.solution $Table.logicalName
@@ -1743,6 +1951,8 @@ function Invoke-TableReconciliation {
         if ($customerCreated) {
             $snapshot = Wait-TableMetadataSnapshot -Table $Table `
                 -Component "$($Table.logicalName)/$($customer.logicalName)" `
+                -RequestedAttributeLogicalNames `
+                    $requestedAttributeLogicalNames `
                 -Ready {
                     param($candidate)
                     $attributeMatches = @($candidate.Attributes | Where-Object {
@@ -1786,7 +1996,9 @@ function Invoke-TableReconciliation {
             )
         if ($lookupCreated) {
             $snapshot = Wait-OrdinaryRelationshipVisibility -Table $Table `
-                -Relationship $relationship
+                -Relationship $relationship `
+                -RequestedAttributeLogicalNames `
+                    $requestedAttributeLogicalNames
             Invoke-ExistingOrdinaryRelationshipReconciliation -Table $Table `
                 -Relationship $relationship -Snapshot $snapshot | Out-Null
         }
@@ -1812,6 +2024,17 @@ function Invoke-TableReconciliation {
             throw "Duplicate physical attributes found for '$($Table.logicalName)/$($column.logicalName)'."
         }
         if ($actual.Count -eq 0) {
+            if ($tableWasCreated -and
+                $initialTableCreateAttributeLookup.ContainsKey(
+                    [string]$column.logicalName
+                )) {
+                throw (
+                    "Structural attribute conflict for " +
+                    "'$($Table.logicalName)/$($column.logicalName)': " +
+                    "current-run InitialTableCreate metadata is absent " +
+                    'after atomic readiness; recovery POST is forbidden.'
+                )
+            }
             if ($column.type -in @('Lookup', 'Customer')) {
                 throw "Structural conflict: lookup '$($column.logicalName)' is missing from existing table '$($Table.logicalName)'; it will not be created or recreated."
             }

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -1524,6 +1524,43 @@ function Wait-OrdinaryRelationshipVisibility {
         }
 }
 
+function Wait-NonLookupAttributeVisibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Table,
+        [Parameter(Mandatory)] $Column,
+        [string[]]$RequestedAttributeLogicalNames
+    )
+
+    if ($Column.type -in @('Lookup', 'Customer')) {
+        throw (
+            "Wait-NonLookupAttributeVisibility only supports non-lookup " +
+            "columns; '$($Column.logicalName)' was '$($Column.type)'."
+        )
+    }
+
+    return Wait-TableMetadataSnapshot -Table $Table `
+        -Component "$($Table.logicalName)/$($Column.logicalName)" `
+        -RequestedAttributeLogicalNames $RequestedAttributeLogicalNames `
+        -Ready {
+            param($candidate)
+
+            $actual = @($candidate.Attributes | Where-Object {
+                $_.LogicalName -eq $Column.logicalName
+            })
+            if ($actual.Count -gt 1) {
+                throw "Duplicate physical attributes found for '$($Table.logicalName)/$($Column.logicalName)'."
+            }
+            if ($actual.Count -ne 1) {
+                return $false
+            }
+
+            Test-AttributeCompatibility $actual[0] $Column `
+                $Table.logicalName
+            return $true
+        }
+}
+
 function Invoke-NativeExtensionReconciliation {
     param($Extension)
     $existing = Get-PicklistAttributeMetadata $Extension.table `
@@ -2065,6 +2102,12 @@ function Invoke-TableReconciliation {
             }
             Invoke-PlannedRequest $request | Out-Null
             Write-Output "$($Table.logicalName)/$($column.logicalName): Created"
+            if (-not $tableWasCreated) {
+                $snapshot = Wait-NonLookupAttributeVisibility -Table $Table `
+                    -Column $column `
+                    -RequestedAttributeLogicalNames `
+                        $requestedAttributeLogicalNames
+            }
         } elseif ($actual.Count -eq 1) {
             Test-AttributeCompatibility $actual[0] $column $Table.logicalName
             if (Test-LocalizedMetadataChanged $actual[0] $column.metadata) {

--- a/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
+++ b/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
@@ -2,35 +2,70 @@
 .SYNOPSIS
     Performs a read-only Dataverse authoring preflight for the insurance demo.
 .DESCRIPTION
-    Verifies that the current user has a proven schema-authoring role, the
-    required solutions are present, the reviewed custom roles exist, and the
-    contract languages are provisioned. All Dataverse transport is GET-only and
-    delegated to `az rest`.
+    Verifies reviewed solution ownership, the current user's proven
+    schema-authoring role, the required custom-role structure, and the contract
+    languages. All Dataverse transport is GET-only and delegated to `az rest`.
 #>
 [CmdletBinding()]
 param(
     [string]$EnvironmentUrl,
-    [string]$ContractPath
+    [string]$ContractPath,
+    [string]$ManifestPath = 'solution/manifest.json'
 )
 
 . (Join-Path $PSScriptRoot 'ConvertTo-SafeCliDiagnosticLine.ps1')
+. (Join-Path $PSScriptRoot 'Get-Manifest.ps1')
+. (Join-Path $PSScriptRoot 'Test-InsuranceSecurityRoles.ps1') `
+    -EnvironmentUrl $EnvironmentUrl `
+    -ContractPath $ContractPath
 
 $ErrorActionPreference = 'Stop'
 $script:SupportedAuthoringRoles = @('System Customizer', 'System Administrator')
+$script:InsuranceAuthoringPreflightDefaultManifestPath = 'solution/manifest.json'
+
+function Get-InsuranceAuthoringPreflightRepoRoot {
+    [CmdletBinding()]
+    param()
+
+    return (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+}
+
+function Resolve-InsuranceAuthoringPreflightPath {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$Path = $script:InsuranceAuthoringPreflightDefaultManifestPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $Path
+    }
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return Join-Path (Get-InsuranceAuthoringPreflightRepoRoot) $Path
+}
 
 function Get-InsuranceAuthoringPhaseState {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [bool]$SolutionsReady,
+        [bool]$HasContractConflict,
 
         [Parameter(Mandatory)]
         [bool]$SchemaFeasible,
 
         [Parameter(Mandatory)]
+        [bool]$SolutionsReady,
+
+        [Parameter(Mandatory)]
         [bool]$RolesReady
     )
 
+    if ($HasContractConflict) {
+        return 'ContractConflict'
+    }
     if (-not $SchemaFeasible) {
         return 'UnsupportedInTenant'
     }
@@ -105,33 +140,6 @@ function Get-MissingIntegerValues {
     return @($requiredValues | Where-Object { $_ -notin $actualValues })
 }
 
-function Get-MissingStringValues {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [object[]]$Required,
-
-        [AllowNull()]
-        [object[]]$Actual
-    )
-
-    $requiredValues = foreach ($item in @($Required)) {
-        if ($null -eq $item) {
-            continue
-        }
-
-        $text = [string]$item
-        if ([string]::IsNullOrWhiteSpace($text)) {
-            continue
-        }
-
-        $text.Trim()
-    }
-    $actualValues = @(Get-NormalizedStringValues -Value $Actual)
-
-    return @($requiredValues | Where-Object { $_ -notin $actualValues })
-}
-
 function Get-LanguagePreflightAction {
     [CmdletBinding()]
     param(
@@ -190,16 +198,6 @@ function Get-RequiredContractSolutions {
     return @($Contract.solutions | ForEach-Object { [string]$_ })
 }
 
-function Get-RequiredContractRoles {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        $Contract
-    )
-
-    return @($Contract.roles | ForEach-Object { [string]$_.name })
-}
-
 function Get-CurrentUserRolesPath {
     [CmdletBinding()]
     param(
@@ -221,22 +219,11 @@ function Get-RequiredSolutionsPath {
             "uniquename eq '$(ConvertTo-ODataStringLiteral -Value $_)'"
         }) -join ' or '
 
-    return "/solutions?`$select=uniquename&`$filter=$filter"
-}
-
-function Get-RequiredRolesPath {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string[]]$RoleName
+    return (
+        "/solutions?`$select=solutionid,uniquename&" +
+        "`$expand=publisherid(`$select=uniquename,customizationprefix,customizationoptionvalueprefix)&" +
+        "`$filter=$filter"
     )
-
-    $roleNameFilter = @($RoleName | ForEach-Object {
-            "name eq '$(ConvertTo-ODataStringLiteral -Value $_)'"
-        }) -join ' or '
-    $filter = "_parentrootroleid_value eq null and ($roleNameFilter)"
-
-    return "/roles?`$select=roleid,name&`$filter=$filter"
 }
 
 function Invoke-PreflightDataverseRequest {
@@ -313,6 +300,212 @@ function Get-ResponseValues {
     return @($values)
 }
 
+function Get-RequiredManifestPublisher {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Manifest
+    )
+
+    if ($null -eq $Manifest.publisher -or
+        [string]::IsNullOrWhiteSpace([string]$Manifest.publisher.uniqueName) -or
+        [string]::IsNullOrWhiteSpace([string]$Manifest.publisher.prefix) -or
+        $null -eq $Manifest.publisher.customizationOptionValuePrefix -or
+        [string]::IsNullOrWhiteSpace(
+            [string]$Manifest.publisher.customizationOptionValuePrefix
+        )) {
+        throw (
+            'solution/manifest.json must declare publisher.uniqueName, ' +
+            'publisher.prefix, and publisher.customizationOptionValuePrefix.'
+        )
+    }
+
+    return [pscustomobject]@{
+        UniqueName                     = [string]$Manifest.publisher.uniqueName
+        Prefix                         = [string]$Manifest.publisher.prefix
+        CustomizationOptionValuePrefix = [int]$Manifest.publisher.customizationOptionValuePrefix
+    }
+}
+
+function Get-InsuranceAuthoringSolutionConflictDetails {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionUniqueName,
+
+        [AllowNull()]
+        $Solution,
+
+        [Parameter(Mandatory)]
+        $ExpectedPublisher
+    )
+
+    $details = [System.Collections.Generic.List[string]]::new()
+    $publisher = $null
+    if ($null -ne $Solution) {
+        $publisher = $Solution.publisherid
+    }
+
+    if ($null -eq $publisher) {
+        [void]$details.Add('Expanded publisher metadata was not returned.')
+    }
+    else {
+        if ([string]$publisher.uniquename -cne [string]$ExpectedPublisher.UniqueName) {
+            [void]$details.Add(
+                "publisher.uniquename expected '$([string]$ExpectedPublisher.UniqueName)' but was '$([string]$publisher.uniquename)'."
+            )
+        }
+        if ([string]$publisher.customizationprefix -cne [string]$ExpectedPublisher.Prefix) {
+            [void]$details.Add(
+                "publisher.customizationprefix expected '$([string]$ExpectedPublisher.Prefix)' but was '$([string]$publisher.customizationprefix)'."
+            )
+        }
+        if ($publisher.PSObject.Properties.Name -notcontains 'customizationoptionvalueprefix') {
+            [void]$details.Add(
+                'publisher.customizationoptionvalueprefix was not returned.'
+            )
+        }
+        else {
+            $actualOptionValuePrefix = [int]$publisher.customizationoptionvalueprefix
+            $expectedOptionValuePrefix = [int]$ExpectedPublisher.CustomizationOptionValuePrefix
+            if ($actualOptionValuePrefix -ne $expectedOptionValuePrefix) {
+                [void]$details.Add(
+                    "publisher.customizationoptionvalueprefix expected '$expectedOptionValuePrefix' but was '$actualOptionValuePrefix'."
+                )
+            }
+        }
+    }
+
+    if ($details.Count -eq 0) {
+        return @()
+    }
+
+    return @(
+        "Solution '$SolutionUniqueName' publisher metadata does not match solution/manifest.json: $($details.ToArray() -join ' ')"
+    )
+}
+
+function Test-InsuranceAuthoringPreflightSolutions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract,
+
+        [Parameter(Mandatory)]
+        $Manifest
+    )
+
+    $requiredSolutions = @(Get-RequiredContractSolutions -Contract $Contract)
+    $expectedPublisher = Get-RequiredManifestPublisher -Manifest $Manifest
+    $response = Invoke-PreflightDataverseRequest -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-RequiredSolutionsPath -SolutionUniqueName $requiredSolutions)
+
+    $solutions = @()
+    if ($null -ne $response -and
+        $response.PSObject.Properties.Name -contains 'value') {
+        $solutions = @($response.value)
+    }
+
+    $missingSolutions = [System.Collections.Generic.List[string]]::new()
+    $solutionConflicts = [System.Collections.Generic.List[string]]::new()
+    foreach ($expectedSolutionUniqueName in $requiredSolutions) {
+        $matches = @($solutions | Where-Object {
+                [string]$_.uniquename -ceq [string]$expectedSolutionUniqueName
+            })
+
+        if ($matches.Count -eq 0) {
+            [void]$missingSolutions.Add([string]$expectedSolutionUniqueName)
+            continue
+        }
+        if ($matches.Count -gt 1) {
+            [void]$solutionConflicts.Add(
+                "Solution '$expectedSolutionUniqueName' returned $($matches.Count) records; expected exactly one reviewed solution."
+            )
+            continue
+        }
+
+        foreach ($detail in @(Get-InsuranceAuthoringSolutionConflictDetails `
+                    -SolutionUniqueName $expectedSolutionUniqueName `
+                    -Solution $matches[0] `
+                    -ExpectedPublisher $expectedPublisher)) {
+            [void]$solutionConflicts.Add([string]$detail)
+        }
+    }
+
+    $state = if ($solutionConflicts.Count -gt 0) {
+        'ContractConflict'
+    }
+    elseif ($missingSolutions.Count -gt 0) {
+        'Precondition'
+    }
+    else {
+        'Ready'
+    }
+
+    return [pscustomobject][ordered]@{
+        State             = $state
+        MissingSolutions  = @($missingSolutions.ToArray())
+        SolutionConflicts = @($solutionConflicts.ToArray())
+    }
+}
+
+function Get-InsuranceAuthoringMissingRoles {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$RoleResults = @()
+    )
+
+    $missingRoles = foreach ($result in @($RoleResults)) {
+        if ([string]$result.State -ne 'ManualPrerequisite') {
+            continue
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$result.Role)) {
+            continue
+        }
+
+        [string]$result.Role
+    }
+
+    return @(Get-NormalizedStringValues -Value $missingRoles)
+}
+
+function Get-InsuranceAuthoringRoleConflictDetails {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$RoleResults = @()
+    )
+
+    $details = [System.Collections.Generic.List[string]]::new()
+    foreach ($result in @($RoleResults)) {
+        if ([string]$result.State -ne 'ContractConflict') {
+            continue
+        }
+
+        $roleName = [string]$result.Role
+        $resultDetails = @($result.Details | Where-Object {
+                -not [string]::IsNullOrWhiteSpace([string]$_)
+            })
+        if ($resultDetails.Count -eq 0) {
+            [void]$details.Add(
+                "Role '$roleName' conflicts with the reviewed security-role contract."
+            )
+            continue
+        }
+
+        foreach ($detail in $resultDetails) {
+            [void]$details.Add("Role '$roleName': $detail")
+        }
+    }
+
+    return @($details.ToArray())
+}
+
 function Invoke-InsuranceAuthoringPreflight {
     [CmdletBinding()]
     param(
@@ -320,12 +513,53 @@ function Invoke-InsuranceAuthoringPreflight {
         [string]$EnvironmentUrl,
 
         [Parameter(Mandatory)]
-        $Contract
+        $Contract,
+
+        [Parameter(Mandatory)]
+        $Manifest
     )
 
-    $requiredSolutions = @(Get-RequiredContractSolutions -Contract $Contract)
     $requiredLanguages = @(Get-RequiredContractLanguages -Contract $Contract)
-    $requiredRoles = @(Get-RequiredContractRoles -Contract $Contract)
+    $solutionAssessment = Test-InsuranceAuthoringPreflightSolutions `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Contract $Contract `
+        -Manifest $Manifest
+
+    $roleVerification = Invoke-InsuranceSecurityRoleVerification `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Contract $Contract
+    $roleResults = @()
+    if ($null -ne $roleVerification -and
+        $roleVerification.PSObject.Properties.Name -contains 'Results') {
+        $roleResults = @($roleVerification.Results)
+    }
+
+    $missingRoles = @(Get-InsuranceAuthoringMissingRoles -RoleResults $roleResults)
+    $roleConflicts = @(Get-InsuranceAuthoringRoleConflictDetails -RoleResults $roleResults)
+    $missingSolutions = @($solutionAssessment.MissingSolutions)
+    $solutionConflicts = @($solutionAssessment.SolutionConflicts)
+    $solutionsReady = $missingSolutions.Count -eq 0
+    $rolesReady = $missingRoles.Count -eq 0 -and $roleConflicts.Count -eq 0
+    $hasContractConflict = $solutionConflicts.Count -gt 0 -or $roleConflicts.Count -gt 0
+
+    if ($hasContractConflict) {
+        return [pscustomobject][ordered]@{
+            State               = 'ContractConflict'
+            UserId              = $null
+            SchemaFeasible      = $null
+            SolutionsReady      = $solutionsReady
+            MissingSolutions    = @($missingSolutions)
+            SolutionConflicts   = @($solutionConflicts)
+            LanguagesReady      = $null
+            LanguageAction      = 'Skipped'
+            MissingLanguageLcid = @()
+            RolesReady          = $rolesReady
+            AssignedRoleNames   = @()
+            MissingRoles        = @($missingRoles)
+            RoleConflicts       = @($roleConflicts)
+            MutationOccurred    = $false
+        }
+    }
 
     $whoAmI = Invoke-PreflightDataverseRequest -Method GET `
         -EnvironmentUrl $EnvironmentUrl `
@@ -353,28 +587,6 @@ function Invoke-InsuranceAuthoringPreflight {
             $languagesResponse.RetrieveProvisionedLanguages
         ))
 
-    $solutionsResponse = Invoke-PreflightDataverseRequest -Method GET `
-        -EnvironmentUrl $EnvironmentUrl `
-        -Path (Get-RequiredSolutionsPath -SolutionUniqueName $requiredSolutions)
-    $availableSolutions = @(Get-NormalizedStringValues -Value (
-            Get-ResponseValues -Response $solutionsResponse -PropertyName 'uniquename'
-        ))
-    $missingSolutions = @(Get-MissingStringValues `
-            -Required $requiredSolutions `
-            -Actual $availableSolutions)
-    $solutionsReady = $missingSolutions.Count -eq 0
-
-    $rolesResponse = Invoke-PreflightDataverseRequest -Method GET `
-        -EnvironmentUrl $EnvironmentUrl `
-        -Path (Get-RequiredRolesPath -RoleName $requiredRoles)
-    $availableRoles = @(Get-NormalizedStringValues -Value (
-            Get-ResponseValues -Response $rolesResponse -PropertyName 'name'
-        ))
-    $missingRoles = @(Get-MissingStringValues `
-            -Required $requiredRoles `
-            -Actual $availableRoles)
-    $rolesReady = $missingRoles.Count -eq 0
-
     $missingLanguages = @(Get-MissingIntegerValues `
             -Required $requiredLanguages `
             -Actual $provisionedLanguages)
@@ -386,23 +598,26 @@ function Invoke-InsuranceAuthoringPreflight {
     $schemaFeasible = Test-DemoSchemaAuthoringCapability `
         -AssignedRoleNames $assignedRoleNames
     $state = Get-InsuranceAuthoringPhaseState `
-        -SolutionsReady $solutionsReady `
+        -HasContractConflict $false `
         -SchemaFeasible $schemaFeasible `
+        -SolutionsReady $solutionsReady `
         -RolesReady $rolesReady
 
     return [pscustomobject][ordered]@{
-        State                 = $state
-        UserId                = $userId
-        SchemaFeasible        = $schemaFeasible
-        SolutionsReady        = $solutionsReady
-        MissingSolutions      = @($missingSolutions)
-        LanguagesReady        = $languagesReady
-        LanguageAction        = $languageAction
-        MissingLanguageLcid   = @($missingLanguages)
-        RolesReady            = $rolesReady
-        AssignedRoleNames     = @($assignedRoleNames)
-        MissingRoles          = @($missingRoles)
-        MutationOccurred      = $false
+        State               = $state
+        UserId              = $userId
+        SchemaFeasible      = $schemaFeasible
+        SolutionsReady      = $solutionsReady
+        MissingSolutions    = @($missingSolutions)
+        SolutionConflicts   = @($solutionConflicts)
+        LanguagesReady      = $languagesReady
+        LanguageAction      = $languageAction
+        MissingLanguageLcid = @($missingLanguages)
+        RolesReady          = $rolesReady
+        AssignedRoleNames   = @($assignedRoleNames)
+        MissingRoles        = @($missingRoles)
+        RoleConflicts       = @($roleConflicts)
+        MutationOccurred    = $false
     }
 }
 
@@ -418,15 +633,26 @@ if ($MyInvocation.InvocationName -ne '.') {
             throw "ContractPath was not found: $ContractPath"
         }
 
+        $resolvedManifestPath = Resolve-InsuranceAuthoringPreflightPath `
+            -Path $ManifestPath
+        if ([string]::IsNullOrWhiteSpace($resolvedManifestPath)) {
+            throw 'ManifestPath is required.'
+        }
+
         $contract = Get-Content -LiteralPath $ContractPath -Raw -Encoding UTF8 |
             ConvertFrom-Json -ErrorAction Stop
+        $manifest = Get-Manifest -Path $resolvedManifestPath -Validate
         $result = Invoke-InsuranceAuthoringPreflight `
             -EnvironmentUrl $EnvironmentUrl `
-            -Contract $contract
-        $result | ConvertTo-Json -Depth 10
+            -Contract $contract `
+            -Manifest $manifest
+        $result | ConvertTo-Json -Depth 20
 
         if ($result.State -eq 'Ready') {
             exit 0
+        }
+        if ($result.State -eq 'ContractConflict') {
+            exit 3
         }
 
         exit 2

--- a/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
+++ b/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
@@ -13,6 +13,8 @@ param(
     [string]$ContractPath
 )
 
+. (Join-Path $PSScriptRoot 'ConvertTo-SafeCliDiagnosticLine.ps1')
+
 $ErrorActionPreference = 'Stop'
 $script:SupportedAuthoringRoles = @('System Customizer', 'System Administrator')
 
@@ -269,8 +271,8 @@ function Invoke-PreflightDataverseRequest {
     $output = & az @arguments 2>&1
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
-        $detail = ($output | Out-String).Trim()
-        throw "Dataverse preflight transport failed (GET $Path); az rest exited with code $exitCode. $detail"
+        $detail = ConvertTo-SafeCliDiagnosticLine -Value $output
+        throw "Dataverse preflight transport failed (GET $Path); az rest exited with code $exitCode. Output: $detail"
     }
 
     $text = ($output | Out-String).Trim()
@@ -405,26 +407,32 @@ function Invoke-InsuranceAuthoringPreflight {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
-        throw 'EnvironmentUrl is required.'
-    }
-    if ([string]::IsNullOrWhiteSpace($ContractPath)) {
-        throw 'ContractPath is required.'
-    }
-    if (-not (Test-Path -LiteralPath $ContractPath -PathType Leaf)) {
-        throw "ContractPath was not found: $ContractPath"
-    }
+    try {
+        if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
+            throw 'EnvironmentUrl is required.'
+        }
+        if ([string]::IsNullOrWhiteSpace($ContractPath)) {
+            throw 'ContractPath is required.'
+        }
+        if (-not (Test-Path -LiteralPath $ContractPath -PathType Leaf)) {
+            throw "ContractPath was not found: $ContractPath"
+        }
 
-    $contract = Get-Content -LiteralPath $ContractPath -Raw -Encoding UTF8 |
-        ConvertFrom-Json -ErrorAction Stop
-    $result = Invoke-InsuranceAuthoringPreflight `
-        -EnvironmentUrl $EnvironmentUrl `
-        -Contract $contract
-    $result | ConvertTo-Json -Depth 10
+        $contract = Get-Content -LiteralPath $ContractPath -Raw -Encoding UTF8 |
+            ConvertFrom-Json -ErrorAction Stop
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $contract
+        $result | ConvertTo-Json -Depth 10
 
-    if ($result.State -eq 'Ready') {
-        exit 0
+        if ($result.State -eq 'Ready') {
+            exit 0
+        }
+
+        exit 2
     }
-
-    exit 2
+    catch {
+        Write-SafeCliErrorLine -ErrorRecord $_
+        exit 1
+    }
 }

--- a/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
+++ b/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
@@ -1,0 +1,429 @@
+<#
+.SYNOPSIS
+    Performs a read-only Dataverse authoring preflight for the insurance demo.
+.DESCRIPTION
+    Verifies that the current user has a proven schema-authoring role, the
+    required solutions are present, the reviewed custom roles exist, and the
+    contract languages are provisioned. All Dataverse transport is GET-only and
+    delegated to `az rest`.
+#>
+[CmdletBinding()]
+param(
+    [string]$EnvironmentUrl,
+    [string]$ContractPath
+)
+
+$ErrorActionPreference = 'Stop'
+$script:SupportedAuthoringRoles = @('System Customizer', 'System Administrator')
+
+function Get-InsuranceAuthoringPhaseState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [bool]$SolutionsReady,
+
+        [Parameter(Mandatory)]
+        [bool]$SchemaFeasible,
+
+        [Parameter(Mandatory)]
+        [bool]$RolesReady
+    )
+
+    if (-not $SchemaFeasible) {
+        return 'UnsupportedInTenant'
+    }
+    if (-not $SolutionsReady) {
+        return 'Precondition'
+    }
+    if (-not $RolesReady) {
+        return 'ManualPrerequisite'
+    }
+    return 'Ready'
+}
+
+function Get-NormalizedIntegerValues {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value
+    )
+
+    $normalized = foreach ($item in @($Value)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $text = [string]$item
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        [int]$text
+    }
+
+    return @($normalized | Sort-Object -Unique)
+}
+
+function Get-NormalizedStringValues {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value
+    )
+
+    $normalized = foreach ($item in @($Value)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $text = [string]$item
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        $text.Trim()
+    }
+
+    return @($normalized | Sort-Object -Unique)
+}
+
+function Get-MissingIntegerValues {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Required,
+
+        [AllowNull()]
+        [object[]]$Actual
+    )
+
+    $requiredValues = @(Get-NormalizedIntegerValues -Value $Required)
+    $actualValues = @(Get-NormalizedIntegerValues -Value $Actual)
+
+    return @($requiredValues | Where-Object { $_ -notin $actualValues })
+}
+
+function Get-MissingStringValues {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Required,
+
+        [AllowNull()]
+        [object[]]$Actual
+    )
+
+    $requiredValues = foreach ($item in @($Required)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $text = [string]$item
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        $text.Trim()
+    }
+    $actualValues = @(Get-NormalizedStringValues -Value $Actual)
+
+    return @($requiredValues | Where-Object { $_ -notin $actualValues })
+}
+
+function Get-LanguagePreflightAction {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Required,
+
+        [AllowNull()]
+        [object[]]$Provisioned
+    )
+
+    $missing = @(Get-MissingIntegerValues -Required $Required -Actual $Provisioned)
+    if ($missing.Count -gt 0) {
+        return 'Reconcile'
+    }
+    return 'None'
+}
+
+function Test-DemoSchemaAuthoringCapability {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string[]]$AssignedRoleNames
+    )
+
+    $assigned = @(Get-NormalizedStringValues -Value $AssignedRoleNames)
+    return @($script:SupportedAuthoringRoles | Where-Object { $_ -in $assigned }).Count -gt 0
+}
+
+function ConvertTo-ODataStringLiteral {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    return $Value.Replace("'", "''")
+}
+
+function Get-RequiredContractLanguages {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    return @(Get-NormalizedIntegerValues -Value @($Contract.languages))
+}
+
+function Get-RequiredContractSolutions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    return @($Contract.solutions | ForEach-Object { [string]$_ })
+}
+
+function Get-RequiredContractRoles {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    return @($Contract.roles | ForEach-Object { [string]$_.name })
+}
+
+function Get-CurrentUserRolesPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$UserId
+    )
+
+    return "/systemusers($UserId)/systemuserroles_association?`$select=name"
+}
+
+function Get-RequiredSolutionsPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$SolutionUniqueName
+    )
+
+    $filter = @($SolutionUniqueName | ForEach-Object {
+            "uniquename eq '$(ConvertTo-ODataStringLiteral -Value $_)'"
+        }) -join ' or '
+
+    return "/solutions?`$select=uniquename&`$filter=$filter"
+}
+
+function Get-RequiredRolesPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$RoleName
+    )
+
+    $filter = @($RoleName | ForEach-Object {
+            "name eq '$(ConvertTo-ODataStringLiteral -Value $_)'"
+        }) -join ' or '
+
+    return "/roles?`$select=roleid,name&`$filter=$filter"
+}
+
+function Invoke-PreflightDataverseRequest {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('GET')]
+        [string]$Method = 'GET',
+
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $url = if ($Path -match '^https://') {
+        $Path
+    }
+    else {
+        "$baseUrl/api/data/v9.2$Path"
+    }
+
+    $arguments = @(
+        'rest',
+        '--method', 'get',
+        '--url', $url,
+        '--resource', "$baseUrl/",
+        '--only-show-errors'
+    )
+
+    $output = & az @arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $detail = ($output | Out-String).Trim()
+        throw "Dataverse preflight transport failed (GET $Path); az rest exited with code $exitCode. $detail"
+    }
+
+    $text = ($output | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    return $text | ConvertFrom-Json -ErrorAction Stop
+}
+
+function Get-ResponseValues {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Response,
+
+        [Parameter(Mandatory)]
+        [string]$PropertyName
+    )
+
+    if ($null -eq $Response) {
+        return @()
+    }
+
+    $values = foreach ($item in @($Response.value)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $property = $item.PSObject.Properties[$PropertyName]
+        if ($null -eq $property) {
+            continue
+        }
+
+        $property.Value
+    }
+
+    return @($values)
+}
+
+function Invoke-InsuranceAuthoringPreflight {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    $requiredSolutions = @(Get-RequiredContractSolutions -Contract $Contract)
+    $requiredLanguages = @(Get-RequiredContractLanguages -Contract $Contract)
+    $requiredRoles = @(Get-RequiredContractRoles -Contract $Contract)
+
+    $whoAmI = Invoke-PreflightDataverseRequest -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path '/WhoAmI'
+    $userId = [string]$whoAmI.UserId
+    if ([string]::IsNullOrWhiteSpace($userId)) {
+        throw 'WhoAmI returned no UserId.'
+    }
+
+    $assignedRolesResponse = Invoke-PreflightDataverseRequest -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-CurrentUserRolesPath -UserId $userId)
+    $assignedRoleNames = @(Get-NormalizedStringValues -Value (
+            Get-ResponseValues -Response $assignedRolesResponse -PropertyName 'name'
+        ))
+
+    $languagesResponse = Invoke-PreflightDataverseRequest -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path '/RetrieveProvisionedLanguages()'
+    if ($null -eq $languagesResponse -or
+        $languagesResponse.PSObject.Properties.Name -notcontains 'RetrieveProvisionedLanguages') {
+        throw 'RetrieveProvisionedLanguages returned no language collection.'
+    }
+    $provisionedLanguages = @(Get-NormalizedIntegerValues -Value @(
+            $languagesResponse.RetrieveProvisionedLanguages
+        ))
+
+    $solutionsResponse = Invoke-PreflightDataverseRequest -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-RequiredSolutionsPath -SolutionUniqueName $requiredSolutions)
+    $availableSolutions = @(Get-NormalizedStringValues -Value (
+            Get-ResponseValues -Response $solutionsResponse -PropertyName 'uniquename'
+        ))
+    $missingSolutions = @(Get-MissingStringValues `
+            -Required $requiredSolutions `
+            -Actual $availableSolutions)
+    $solutionsReady = $missingSolutions.Count -eq 0
+
+    $rolesResponse = Invoke-PreflightDataverseRequest -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-RequiredRolesPath -RoleName $requiredRoles)
+    $availableRoles = @(Get-NormalizedStringValues -Value (
+            Get-ResponseValues -Response $rolesResponse -PropertyName 'name'
+        ))
+    $missingRoles = @(Get-MissingStringValues `
+            -Required $requiredRoles `
+            -Actual $availableRoles)
+    $rolesReady = $missingRoles.Count -eq 0
+
+    $missingLanguages = @(Get-MissingIntegerValues `
+            -Required $requiredLanguages `
+            -Actual $provisionedLanguages)
+    $languageAction = Get-LanguagePreflightAction `
+        -Required $requiredLanguages `
+        -Provisioned $provisionedLanguages
+    $languagesReady = $missingLanguages.Count -eq 0
+
+    $schemaFeasible = Test-DemoSchemaAuthoringCapability `
+        -AssignedRoleNames $assignedRoleNames
+    $state = Get-InsuranceAuthoringPhaseState `
+        -SolutionsReady $solutionsReady `
+        -SchemaFeasible $schemaFeasible `
+        -RolesReady $rolesReady
+
+    return [pscustomobject][ordered]@{
+        State                 = $state
+        UserId                = $userId
+        SchemaFeasible        = $schemaFeasible
+        SolutionsReady        = $solutionsReady
+        MissingSolutions      = @($missingSolutions)
+        LanguagesReady        = $languagesReady
+        LanguageAction        = $languageAction
+        MissingLanguageLcid   = @($missingLanguages)
+        RolesReady            = $rolesReady
+        AssignedRoleNames     = @($assignedRoleNames)
+        MissingRoles          = @($missingRoles)
+        MutationOccurred      = $false
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
+        throw 'EnvironmentUrl is required.'
+    }
+    if ([string]::IsNullOrWhiteSpace($ContractPath)) {
+        throw 'ContractPath is required.'
+    }
+    if (-not (Test-Path -LiteralPath $ContractPath -PathType Leaf)) {
+        throw "ContractPath was not found: $ContractPath"
+    }
+
+    $contract = Get-Content -LiteralPath $ContractPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json -ErrorAction Stop
+    $result = Invoke-InsuranceAuthoringPreflight `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Contract $contract
+    $result | ConvertTo-Json -Depth 10
+
+    if ($result.State -eq 'Ready') {
+        exit 0
+    }
+
+    exit 2
+}

--- a/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
+++ b/scripts/solution/Test-InsuranceAuthoringPreflight.ps1
@@ -229,9 +229,10 @@ function Get-RequiredRolesPath {
         [string[]]$RoleName
     )
 
-    $filter = @($RoleName | ForEach-Object {
+    $roleNameFilter = @($RoleName | ForEach-Object {
             "name eq '$(ConvertTo-ODataStringLiteral -Value $_)'"
         }) -join ' or '
+    $filter = "_parentrootroleid_value eq null and ($roleNameFilter)"
 
     return "/roles?`$select=roleid,name&`$filter=$filter"
 }

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -409,20 +409,25 @@ function Add-ConvergenceStringsToList {
     }
 }
 
+function Get-ConvergenceErrorMessage {
+    [CmdletBinding()]
+    param($ErrorRecord)
+
+    if ($ErrorRecord -is [System.Management.Automation.ErrorRecord]) {
+        return [string]$ErrorRecord.Exception.Message
+    }
+    if ($ErrorRecord -is [System.Exception]) {
+        return [string]$ErrorRecord.Message
+    }
+
+    return [string]$ErrorRecord
+}
+
 function Test-ConvergenceTransportError {
     [CmdletBinding()]
     param($ErrorRecord)
 
-    $message = if ($ErrorRecord -is [System.Management.Automation.ErrorRecord]) {
-        [string]$ErrorRecord.Exception.Message
-    }
-    elseif ($ErrorRecord -is [System.Exception]) {
-        [string]$ErrorRecord.Message
-    }
-    else {
-        [string]$ErrorRecord
-    }
-
+    $message = Get-ConvergenceErrorMessage -ErrorRecord $ErrorRecord
     if ([string]::IsNullOrWhiteSpace($message)) {
         return $false
     }
@@ -430,6 +435,19 @@ function Test-ConvergenceTransportError {
     return $message -like 'Dataverse convergence transport failed*' -or
         $message -like 'Dataverse security-role verification failed*' -or
         $message -like 'Dataverse request failed*'
+}
+
+function Test-ConvergenceRetrieveLocLabelsUnsupportedError {
+    [CmdletBinding()]
+    param($ErrorRecord)
+
+    $message = Get-ConvergenceErrorMessage -ErrorRecord $ErrorRecord
+    if ([string]::IsNullOrWhiteSpace($message) -or
+        $message -notlike 'Dataverse convergence transport failed (GET /RetrieveLocLabels*') {
+        return $false
+    }
+
+    return $message -match '(?i)(400|404|BadRequest|Bad Request|Not Found|Resource not found|does not support|not supported|unsupported)'
 }
 
 function Get-ConvergenceLanguagesPath {
@@ -652,6 +670,37 @@ function Get-ConvergenceSystemFormPath {
     )
 }
 
+function Get-ConvergenceRetrieveLocLabelsPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EntityLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$IdProperty,
+
+        [Parameter(Mandatory)]
+        [string]$RecordId,
+
+        [Parameter(Mandatory)]
+        [string]$AttributeName
+    )
+
+    $resolvedRecordId = ([string]$RecordId).Trim('{}')
+    $entityMoniker = [ordered]@{
+        '@odata.type' = "Microsoft.Dynamics.CRM.$EntityLogicalName"
+        "$IdProperty" = $resolvedRecordId
+    } | ConvertTo-Json -Compress
+    $escapedEntityMoniker = [System.Uri]::EscapeDataString($entityMoniker)
+    $escapedAttributeName = ConvertTo-ODataKeyString $AttributeName
+    return (
+        '/RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?' +
+        "@p1=$escapedEntityMoniker&" +
+        "@p2='$escapedAttributeName'&" +
+        '@p3=true'
+    )
+}
+
 function Invoke-ConvergenceDataverseRequest {
     [CmdletBinding()]
     param(
@@ -752,6 +801,106 @@ function Invoke-InsuranceSecurityRoleDataverseRequest {
         -Method $Method `
         -EnvironmentUrl $EnvironmentUrl `
         -Path $Path
+}
+
+function Test-ConvergenceLocalizedRecordFields {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$EntityLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$IdProperty,
+
+        [Parameter(Mandatory)]
+        [string]$RecordId,
+
+        [Parameter(Mandatory)]
+        $LocalizedFields,
+
+        [Parameter(Mandatory)]
+        [string]$Component
+    )
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    $unsupported = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($field in @($LocalizedFields.Keys | Sort-Object)) {
+        $response = $null
+        try {
+            $response = Invoke-ConvergenceDataverseRequest `
+                -Method GET `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Path (Get-ConvergenceRetrieveLocLabelsPath `
+                    -EntityLogicalName $EntityLogicalName `
+                    -IdProperty $IdProperty `
+                    -RecordId $RecordId `
+                    -AttributeName ([string]$field))
+        }
+        catch {
+            if (Test-ConvergenceRetrieveLocLabelsUnsupportedError $_) {
+                [void]$unsupported.Add(
+                    "RetrieveLocLabels GET for '$EntityLogicalName.$field' on '$Component' is unavailable for GET-only localized convergence verification in this tenant. $(
+                        Get-ConvergenceErrorMessage -ErrorRecord $_
+                    )"
+                )
+                continue
+            }
+
+            if (Test-ConvergenceTransportError $_) {
+                throw
+            }
+
+            [void]$details.Add((Get-ConvergenceErrorMessage -ErrorRecord $_))
+            continue
+        }
+
+        if ($null -eq $response -or
+            $response.PSObject.Properties.Name -notcontains 'Label' -or
+            $null -eq $response.Label) {
+            [void]$unsupported.Add(
+                "RetrieveLocLabels GET for '$EntityLogicalName.$field' on '$Component' returned no Label payload; GET-only localized convergence verification cannot prove the required translations in this tenant."
+            )
+            continue
+        }
+
+        foreach ($language in @($script:RequiredLanguages)) {
+            $expected = [string]$LocalizedFields[$field].$language
+            $actual = Get-ConvergenceLocalizedLabel `
+                -LocalizedValue $response.Label `
+                -LanguageCode $language
+            if ($actual -cne $expected) {
+                [void]$differences.Add([pscustomobject][ordered]@{
+                        Property = [string]$field
+                        Language = [string]$language
+                        Expected = $expected
+                        Actual   = $actual
+                    })
+            }
+        }
+    }
+
+    $state = 'Ready'
+    if ($differences.Count -gt 0 -or $details.Count -gt 0) {
+        $state = 'ContractConflict'
+    }
+    elseif ($unsupported.Count -gt 0) {
+        $state = 'UnsupportedInTenant'
+    }
+
+    return [pscustomobject]@{
+        State       = $state
+        Differences = @($differences)
+        Details     = @(
+            Get-UniqueConvergenceStrings -Value (
+                @($details) + @($unsupported)
+            )
+        )
+    }
 }
 
 function Get-PicklistAttributeMetadata {
@@ -1642,6 +1791,7 @@ function Test-InsuranceFoundationView {
 
     $differences = [System.Collections.Generic.List[object]]::new()
     $details = [System.Collections.Generic.List[string]]::new()
+    $unsupportedDetails = [System.Collections.Generic.List[string]]::new()
     try {
         Assert-ConvergenceSolutionOwnership `
             -Existing $actual `
@@ -1652,19 +1802,27 @@ function Test-InsuranceFoundationView {
         [void]$details.Add($_.Exception.Message)
     }
 
-    if ([string]$actual.name -cne $expectedName) {
-        [void]$differences.Add([pscustomobject]@{
-                Property = 'Name'
-                Expected = $expectedName
-                Actual   = [string]$actual.name
-            })
-    }
-    if ([string]$actual.description -cne [string]$View.metadata.description.'1033') {
-        [void]$differences.Add([pscustomobject]@{
-                Property = 'Description'
-                Expected = [string]$View.metadata.description.'1033'
-                Actual   = [string]$actual.description
-            })
+    $localizedFields = Test-ConvergenceLocalizedRecordFields `
+        -EnvironmentUrl $EnvironmentUrl `
+        -EntityLogicalName 'savedquery' `
+        -IdProperty 'savedqueryid' `
+        -RecordId ([string]$actual.savedqueryid) `
+        -LocalizedFields $expectedRequest.LocalizedFields `
+        -Component $component
+    switch ([string]$localizedFields.State) {
+        'ContractConflict' {
+            foreach ($difference in @($localizedFields.Differences)) {
+                [void]$differences.Add($difference)
+            }
+            Add-ConvergenceStringsToList `
+                -List $details `
+                -Values @($localizedFields.Details)
+        }
+        'UnsupportedInTenant' {
+            Add-ConvergenceStringsToList `
+                -List $unsupportedDetails `
+                -Values @($localizedFields.Details)
+        }
     }
 
     try {
@@ -1690,15 +1848,27 @@ function Test-InsuranceFoundationView {
     Add-ConvergenceStringsToList `
         -List $details `
         -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
-    if ($differences.Count -eq 0 -and $details.Count -eq 0) {
+    $allDetails = [System.Collections.Generic.List[string]]::new()
+    Add-ConvergenceStringsToList -List $allDetails -Values @($details)
+    Add-ConvergenceStringsToList -List $allDetails -Values @($unsupportedDetails)
+    if ($differences.Count -eq 0 -and
+        $details.Count -eq 0 -and
+        $unsupportedDetails.Count -eq 0) {
         return New-ConvergenceResult -Component $component -State 'Ready'
     }
 
     return New-ConvergenceResult `
         -Component $component `
-        -State 'ContractConflict' `
+        -State $(if ($differences.Count -eq 0 -and
+                $details.Count -eq 0 -and
+                $unsupportedDetails.Count -gt 0) {
+                'UnsupportedInTenant'
+            }
+            else {
+                'ContractConflict'
+            }) `
         -Differences @($differences) `
-        -Details @($details)
+        -Details @($allDetails)
 }
 
 function Test-InsuranceFoundationForm {
@@ -1745,6 +1915,7 @@ function Test-InsuranceFoundationForm {
 
     $differences = [System.Collections.Generic.List[object]]::new()
     $details = [System.Collections.Generic.List[string]]::new()
+    $unsupportedDetails = [System.Collections.Generic.List[string]]::new()
     try {
         Assert-ConvergenceSolutionOwnership `
             -Existing $actual `
@@ -1755,19 +1926,27 @@ function Test-InsuranceFoundationForm {
         [void]$details.Add($_.Exception.Message)
     }
 
-    if ([string]$actual.name -cne $expectedName) {
-        [void]$differences.Add([pscustomobject]@{
-                Property = 'Name'
-                Expected = $expectedName
-                Actual   = [string]$actual.name
-            })
-    }
-    if ([string]$actual.description -cne [string]$Form.metadata.description.'1033') {
-        [void]$differences.Add([pscustomobject]@{
-                Property = 'Description'
-                Expected = [string]$Form.metadata.description.'1033'
-                Actual   = [string]$actual.description
-            })
+    $localizedFields = Test-ConvergenceLocalizedRecordFields `
+        -EnvironmentUrl $EnvironmentUrl `
+        -EntityLogicalName 'systemform' `
+        -IdProperty 'formid' `
+        -RecordId ([string]$actual.formid) `
+        -LocalizedFields $expectedRequest.LocalizedFields `
+        -Component $component
+    switch ([string]$localizedFields.State) {
+        'ContractConflict' {
+            foreach ($difference in @($localizedFields.Differences)) {
+                [void]$differences.Add($difference)
+            }
+            Add-ConvergenceStringsToList `
+                -List $details `
+                -Values @($localizedFields.Details)
+        }
+        'UnsupportedInTenant' {
+            Add-ConvergenceStringsToList `
+                -List $unsupportedDetails `
+                -Values @($localizedFields.Details)
+        }
     }
 
     try {
@@ -1789,15 +1968,27 @@ function Test-InsuranceFoundationForm {
     Add-ConvergenceStringsToList `
         -List $details `
         -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
-    if ($differences.Count -eq 0 -and $details.Count -eq 0) {
+    $allDetails = [System.Collections.Generic.List[string]]::new()
+    Add-ConvergenceStringsToList -List $allDetails -Values @($details)
+    Add-ConvergenceStringsToList -List $allDetails -Values @($unsupportedDetails)
+    if ($differences.Count -eq 0 -and
+        $details.Count -eq 0 -and
+        $unsupportedDetails.Count -eq 0) {
         return New-ConvergenceResult -Component $component -State 'Ready'
     }
 
     return New-ConvergenceResult `
         -Component $component `
-        -State 'ContractConflict' `
+        -State $(if ($differences.Count -eq 0 -and
+                $details.Count -eq 0 -and
+                $unsupportedDetails.Count -gt 0) {
+                'UnsupportedInTenant'
+            }
+            else {
+                'ContractConflict'
+            }) `
         -Differences @($differences) `
-        -Details @($details)
+        -Details @($allDetails)
 }
 
 function Test-InsuranceFoundationTable {

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -1517,6 +1517,61 @@ function Get-ConvergenceReviewedSolutionLookup {
     }
 }
 
+function Get-ConvergenceRoleExpectedReviewedMembership {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Role,
+
+        [Parameter(Mandatory)]
+        [object[]]$ReviewedSolutions
+    )
+
+    $declaredSolutions = @(Get-UniqueConvergenceStrings -Value @($Role.solution))
+    return @($declaredSolutions | Where-Object {
+            Test-ConvergenceContainsExactString `
+                -Value @($ReviewedSolutions) `
+                -Expected ([string]$_)
+        })
+}
+
+function Get-ConvergenceRoleActualReviewedMembership {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Membership,
+
+        [Parameter(Mandatory)]
+        [object[]]$ReviewedSolutions
+    )
+
+    $solutionNames = @(Get-UniqueConvergenceStrings -Value @($Membership.value | ForEach-Object {
+                if ($_.solutionid) {
+                    [string]$_.solutionid.uniquename
+                }
+            }))
+    return @($ReviewedSolutions | Where-Object {
+            Test-ConvergenceContainsExactString `
+                -Value $solutionNames `
+                -Expected ([string]$_)
+        })
+}
+
+function Get-ConvergenceRoleReviewedMembershipDisplayText {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$SolutionUniqueNames
+    )
+
+    $resolved = @(Get-UniqueConvergenceStrings -Value $SolutionUniqueNames)
+    if ($resolved.Count -eq 0) {
+        return '<none>'
+    }
+
+    return ($resolved -join ', ')
+}
+
 function Test-InsuranceFoundationManifestAlignment {
     [CmdletBinding()]
     param(
@@ -3288,35 +3343,63 @@ function Test-InsuranceFoundationUnexpectedMetadata {
             continue
         }
 
-        $solutionNames = @(Get-UniqueConvergenceStrings -Value @($membership.value | ForEach-Object {
-                    if ($_.solutionid) {
-                        [string]$_.solutionid.uniquename
-                    }
-                }))
-        $reviewedMembership = @($Contract.solutions | Where-Object {
-                Test-ConvergenceContainsExactString `
-                    -Value $solutionNames `
-                    -Expected ([string]$_)
+        $reviewedMembership = @(Get-ConvergenceRoleActualReviewedMembership `
+                -Membership $membership `
+                -ReviewedSolutions @($Contract.solutions))
+        $declaredRoleMatches = @($Contract.roles | Where-Object {
+                [string]$_.name -ceq $roleName
             })
-        if ($reviewedMembership.Count -eq 0) {
+
+        if ($declaredRoleMatches.Count -eq 0) {
+            if ($reviewedMembership.Count -eq 0) {
+                continue
+            }
+
+            foreach ($reviewedSolutionUniqueName in @($reviewedMembership)) {
+                [void]$unexpected.Add("$reviewedSolutionUniqueName/role/$roleName")
+                [void]$details.Add(
+                    "Unexpected root role '$roleName' is owned by solution '$reviewedSolutionUniqueName' but is not listed in the contract."
+                )
+            }
+
             continue
         }
 
-        $declaredRoleSolutions = @($Contract.solutions | Where-Object {
-                Test-ConvergenceContainsExactString `
-                    -Value @($expectedInventory.RolesBySolution[[string]$_]) `
-                    -Expected $roleName
-            })
-        if ($declaredRoleSolutions.Count -gt 0) {
-            continue
+        $declaredRole = $declaredRoleMatches[0]
+        $expectedReviewedMembership = @(Get-ConvergenceRoleExpectedReviewedMembership `
+                -Role $declaredRole `
+                -ReviewedSolutions @($Contract.solutions))
+        $expectedReviewedMembershipDisplay = Get-ConvergenceRoleReviewedMembershipDisplayText `
+            -SolutionUniqueNames @($expectedReviewedMembership)
+        $actualReviewedMembershipDisplay = Get-ConvergenceRoleReviewedMembershipDisplayText `
+            -SolutionUniqueNames @($reviewedMembership)
+
+        foreach ($expectedSolutionUniqueName in @($expectedReviewedMembership)) {
+            if (Test-ConvergenceContainsExactString `
+                    -Value @($reviewedMembership) `
+                    -Expected $expectedSolutionUniqueName) {
+                continue
+            }
+
+            [void]$details.Add(
+                "Declared root role '$roleName' is missing reviewed solution membership '$expectedSolutionUniqueName'; expected reviewed solution membership: $expectedReviewedMembershipDisplay; actual reviewed solution membership: $actualReviewedMembershipDisplay."
+            )
         }
 
         foreach ($reviewedSolutionUniqueName in @($reviewedMembership)) {
+            if (Test-ConvergenceContainsExactString `
+                    -Value @($expectedReviewedMembership) `
+                    -Expected $reviewedSolutionUniqueName) {
+                continue
+            }
+
             [void]$unexpected.Add("$reviewedSolutionUniqueName/role/$roleName")
             [void]$details.Add(
-                "Unexpected root role '$roleName' is owned by solution '$reviewedSolutionUniqueName' but is not listed in the contract."
+                "Declared root role '$roleName' has unexpected reviewed solution membership '$reviewedSolutionUniqueName'; expected reviewed solution membership: $expectedReviewedMembershipDisplay; actual reviewed solution membership: $actualReviewedMembershipDisplay."
             )
         }
+
+        continue
     }
 
     foreach ($tableLogicalName in @($expectedInventory.ReviewedTables)) {

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -15,13 +15,6 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$script:ConvergenceStatePriority = @{
-    Ready              = 0
-    ManualPrerequisite = 1
-    Precondition       = 2
-    UnsupportedInTenant = 3
-    ContractConflict   = 4
-}
 
 function Get-ConvergenceRepoRoot {
     [CmdletBinding()]
@@ -106,20 +99,6 @@ function Get-ContractTableSchemaName {
     }
 
     return [string]$tables[0].schemaName
-}
-
-function Get-ConvergenceStatePriority {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$State
-    )
-
-    if (-not $script:ConvergenceStatePriority.ContainsKey($State)) {
-        throw "Unsupported convergence state '$State'."
-    }
-
-    return [int]$script:ConvergenceStatePriority[$State]
 }
 
 function Get-UniqueConvergenceStrings {
@@ -235,12 +214,7 @@ function New-ConvergenceSummary {
 
     $state = 'Ready'
     if ($blocking.Count -gt 0) {
-        $state = @(
-            $blocking |
-                Sort-Object `
-                    @{ Expression = { -1 * (Get-ConvergenceStatePriority -State ([string]$_.State)) } }, `
-                    @{ Expression = { [string]$_.Component } }
-        )[0].State
+        $state = [string]$blocking[0].State
     }
 
     return [pscustomobject][ordered]@{
@@ -447,7 +421,22 @@ function Test-ConvergenceRetrieveLocLabelsUnsupportedError {
         return $false
     }
 
-    return $message -match '(?i)(400|404|BadRequest|Bad Request|Not Found|Resource not found|does not support|not supported|unsupported)'
+    $unsupportedPatterns = @(
+        '(?i)(?:does not support|not supported|unsupported).*(?:GET|HTTP|method|action|function|operation|request|resource|endpoint|RetrieveLocLabels)',
+        '(?i)(?:GET|HTTP|method|action|function|operation|request|resource|endpoint|RetrieveLocLabels).*(?:does not support|not supported|unsupported)',
+        "(?i)could not find an action named\s+['""]?RetrieveLocLabels['""]?",
+        "(?i)resource not found for (?:the )?segment\s+['""]?RetrieveLocLabels['""]?",
+        '(?i)no http resource was found that matches the request uri',
+        '(?i)no route data was found for this request'
+    )
+
+    foreach ($pattern in $unsupportedPatterns) {
+        if ($message -match $pattern) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 function Get-ConvergenceLanguagesPath {
@@ -670,6 +659,45 @@ function Get-ConvergenceSystemFormPath {
     )
 }
 
+function Get-ConvergenceRetrieveLocLabelsEntityMoniker {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EntityLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$IdProperty,
+
+        [Parameter(Mandatory)]
+        [string]$RecordId
+    )
+
+    $resolvedRecordId = ([string]$RecordId).Trim('{}')
+    $entitySetName = switch ([string]$EntityLogicalName) {
+        'savedquery' {
+            if ([string]$IdProperty -cne 'savedqueryid') {
+                throw "RetrieveLocLabels entity moniker for '$EntityLogicalName' requires id property 'savedqueryid'."
+            }
+
+            'savedqueries'
+        }
+        'systemform' {
+            if ([string]$IdProperty -cne 'formid') {
+                throw "RetrieveLocLabels entity moniker for '$EntityLogicalName' requires id property 'formid'."
+            }
+
+            'systemforms'
+        }
+        default {
+            throw "Unsupported RetrieveLocLabels entity moniker '$EntityLogicalName'."
+        }
+    }
+
+    return ([ordered]@{
+            '@odata.id' = "$entitySetName($resolvedRecordId)"
+        } | ConvertTo-Json -Compress)
+}
+
 function Get-ConvergenceRetrieveLocLabelsPath {
     [CmdletBinding()]
     param(
@@ -686,11 +714,10 @@ function Get-ConvergenceRetrieveLocLabelsPath {
         [string]$AttributeName
     )
 
-    $resolvedRecordId = ([string]$RecordId).Trim('{}')
-    $entityMoniker = [ordered]@{
-        '@odata.type' = "Microsoft.Dynamics.CRM.$EntityLogicalName"
-        "$IdProperty" = $resolvedRecordId
-    } | ConvertTo-Json -Compress
+    $entityMoniker = Get-ConvergenceRetrieveLocLabelsEntityMoniker `
+        -EntityLogicalName $EntityLogicalName `
+        -IdProperty $IdProperty `
+        -RecordId $RecordId
     $escapedEntityMoniker = [System.Uri]::EscapeDataString($entityMoniker)
     $escapedAttributeName = ConvertTo-ODataKeyString $AttributeName
     return (

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -1,0 +1,2157 @@
+<#
+.SYNOPSIS
+    Performs a read-only full convergence verification of Insurance Foundation.
+.DESCRIPTION
+    Validates the reviewed contract and repo conventions locally, then performs
+    GET-only Dataverse v9.2 reads against the environment resource to verify
+    required languages, solution ownership, shared choices, native extensions,
+    custom tables, reviewed child metadata, and reviewed security roles before
+    package export. Safe to dot-source for testing.
+#>
+[CmdletBinding()]
+param(
+    [string]$EnvironmentUrl,
+    [string]$ContractPath
+)
+
+$ErrorActionPreference = 'Stop'
+$script:ConvergenceStatePriority = @{
+    Ready              = 0
+    ManualPrerequisite = 1
+    Precondition       = 2
+    UnsupportedInTenant = 3
+    ContractConflict   = 4
+}
+
+function Get-ConvergenceRepoRoot {
+    [CmdletBinding()]
+    param()
+
+    return (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+}
+
+function Get-ConvergenceDefaultContractPath {
+    [CmdletBinding()]
+    param()
+
+    return Join-Path (Get-ConvergenceRepoRoot) 'solution/schema/insurance-foundation.json'
+}
+
+function Get-ConvergenceManifestPath {
+    [CmdletBinding()]
+    param()
+
+    return Join-Path (Get-ConvergenceRepoRoot) 'solution/manifest.json'
+}
+
+$script:ConvergenceDependencyEnvironmentUrl = if (
+    [string]::IsNullOrWhiteSpace($EnvironmentUrl)
+) {
+    'https://unit.crm.dynamics.com'
+}
+else {
+    $EnvironmentUrl
+}
+$script:ConvergenceDependencyContractPath = if (
+    [string]::IsNullOrWhiteSpace($ContractPath)
+) {
+    Get-ConvergenceDefaultContractPath
+}
+else {
+    $ContractPath
+}
+
+. (Join-Path $PSScriptRoot 'Publish-InsuranceFoundation.ps1') `
+    -EnvironmentUrl $script:ConvergenceDependencyEnvironmentUrl `
+    -ContractPath $script:ConvergenceDependencyContractPath
+. (Join-Path $PSScriptRoot 'Test-InsuranceSecurityRoles.ps1') `
+    -EnvironmentUrl $script:ConvergenceDependencyEnvironmentUrl `
+    -ContractPath $script:ConvergenceDependencyContractPath
+. (Join-Path $PSScriptRoot 'Get-Manifest.ps1')
+
+function Set-ConvergenceRuntimeContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [string]$ContractPath
+    )
+
+    $script:DataverseBaseUrl = $EnvironmentUrl.TrimEnd('/')
+    if (-not [string]::IsNullOrWhiteSpace($ContractPath)) {
+        $script:ContractFile = $ContractPath
+    }
+}
+
+function Get-ContractTableSchemaName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogicalName,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    switch ($LogicalName) {
+        'account' { return 'Account' }
+        'contact' { return 'Contact' }
+    }
+
+    $tables = @($Contract.tables | Where-Object logicalName -eq $LogicalName)
+    if ($tables.Count -ne 1 -or
+        [string]::IsNullOrWhiteSpace([string]$tables[0].schemaName)) {
+        throw "Cannot resolve the contract schema name for table '$LogicalName'."
+    }
+
+    return [string]$tables[0].schemaName
+}
+
+function Get-ConvergenceStatePriority {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$State
+    )
+
+    if (-not $script:ConvergenceStatePriority.ContainsKey($State)) {
+        throw "Unsupported convergence state '$State'."
+    }
+
+    return [int]$script:ConvergenceStatePriority[$State]
+}
+
+function Get-UniqueConvergenceStrings {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value
+    )
+
+    $items = [System.Collections.Generic.List[string]]::new()
+    $seen = @{}
+    foreach ($entry in @($Value)) {
+        if ($null -eq $entry) {
+            continue
+        }
+
+        $text = [string]$entry
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        if ($seen.ContainsKey($text)) {
+            continue
+        }
+
+        $seen[$text] = $true
+        [void]$items.Add($text)
+    }
+
+    return @($items)
+}
+
+function Get-UniqueConvergenceDifferenceObjects {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value
+    )
+
+    $items = [System.Collections.Generic.List[object]]::new()
+    $seen = @{}
+    foreach ($entry in @($Value)) {
+        if ($null -eq $entry) {
+            continue
+        }
+
+        $key = $entry | ConvertTo-Json -Depth 30 -Compress
+        if ($seen.ContainsKey($key)) {
+            continue
+        }
+
+        $seen[$key] = $true
+        [void]$items.Add($entry)
+    }
+
+    return @($items)
+}
+
+function New-ConvergenceResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Component,
+
+        [Parameter(Mandatory)]
+        [ValidateSet(
+            'Ready',
+            'ManualPrerequisite',
+            'Precondition',
+            'UnsupportedInTenant',
+            'ContractConflict'
+        )]
+        [string]$State,
+
+        [AllowNull()]
+        [object[]]$Missing = @(),
+
+        [AllowNull()]
+        [object[]]$Unexpected = @(),
+
+        [AllowNull()]
+        [object[]]$Differences = @(),
+
+        [AllowNull()]
+        [object[]]$Details = @(),
+
+        [AllowNull()]
+        [object[]]$Children = @()
+    )
+
+    return [pscustomobject][ordered]@{
+        Component   = $Component
+        State       = $State
+        Missing     = @(Get-UniqueConvergenceStrings -Value $Missing)
+        Unexpected  = @(Get-UniqueConvergenceStrings -Value $Unexpected)
+        Differences = @(Get-UniqueConvergenceDifferenceObjects -Value $Differences)
+        Details     = @(Get-UniqueConvergenceStrings -Value $Details)
+        Children    = @($Children)
+    }
+}
+
+function New-ConvergenceSummary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Results
+    )
+
+    $resolvedResults = @($Results)
+    $blocking = @($resolvedResults | Where-Object {
+            [string]$_.State -ne 'Ready'
+        })
+
+    $state = 'Ready'
+    if ($blocking.Count -gt 0) {
+        $state = @(
+            $blocking |
+                Sort-Object `
+                    @{ Expression = { -1 * (Get-ConvergenceStatePriority -State ([string]$_.State)) } }, `
+                    @{ Expression = { [string]$_.Component } }
+        )[0].State
+    }
+
+    return [pscustomobject][ordered]@{
+        State              = $state
+        BlockingComponents = @($blocking | ForEach-Object { [string]$_.Component })
+        MutationOccurred   = $false
+        Results            = $resolvedResults
+    }
+}
+
+function Get-ConvergenceManagedPropertyValue {
+    [CmdletBinding()]
+    param($Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [bool]) {
+        return [bool]$Value
+    }
+
+    if ($Value -is [System.Collections.IDictionary] -and
+        $Value.Contains('Value')) {
+        return [bool]$Value['Value']
+    }
+
+    if ($Value.PSObject -and
+        $Value.PSObject.Properties.Name -contains 'Value') {
+        return [bool]$Value.Value
+    }
+
+    return [bool]$Value
+}
+
+function Get-ConvergenceRequiredLevelValue {
+    [CmdletBinding()]
+    param($Attribute)
+
+    if ($null -eq $Attribute) {
+        return $null
+    }
+
+    $requiredLevel = $Attribute.RequiredLevel
+    if ($null -eq $requiredLevel) {
+        return $null
+    }
+
+    if ($requiredLevel -is [System.Collections.IDictionary] -and
+        $requiredLevel.Contains('Value')) {
+        return [string]$requiredLevel['Value']
+    }
+
+    if ($requiredLevel.PSObject -and
+        $requiredLevel.PSObject.Properties.Name -contains 'Value') {
+        return [string]$requiredLevel.Value
+    }
+
+    return [string]$requiredLevel
+}
+
+function Get-ConvergenceLocalizedLabel {
+    [CmdletBinding()]
+    param(
+        $LocalizedValue,
+
+        [Parameter(Mandatory)]
+        [string]$LanguageCode
+    )
+
+    if ($null -eq $LocalizedValue) {
+        return $null
+    }
+
+    $labels = @($LocalizedValue.LocalizedLabels | Where-Object {
+            [int]$_.LanguageCode -eq [int]$LanguageCode
+        })
+    if ($labels.Count -ne 1) {
+        return $null
+    }
+
+    return [string]$labels[0].Label
+}
+
+function Get-ConvergenceLocalizedMetadataDifferences {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Existing,
+
+        [Parameter(Mandatory)]
+        $Metadata
+    )
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    foreach ($pair in @(
+            @{ ActualProperty = 'DisplayName'; ContractProperty = 'label' },
+            @{ ActualProperty = 'Description'; ContractProperty = 'description' }
+        )) {
+        foreach ($language in @($script:RequiredLanguages)) {
+            $expected = [string]$Metadata.($pair.ContractProperty).$language
+            $actual = Get-ConvergenceLocalizedLabel `
+                -LocalizedValue $Existing.($pair.ActualProperty) `
+                -LanguageCode $language
+            if ($actual -cne $expected) {
+                [void]$differences.Add([pscustomobject][ordered]@{
+                        Property = $pair.ActualProperty
+                        Language = [string]$language
+                        Expected = $expected
+                        Actual   = $actual
+                    })
+            }
+        }
+    }
+
+    return @($differences)
+}
+
+function Get-ConvergenceDifferenceDetails {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Differences = @()
+    )
+
+    $details = foreach ($difference in @($Differences)) {
+        if ($null -eq $difference) {
+            continue
+        }
+
+        $parts = [System.Collections.Generic.List[string]]::new()
+        foreach ($propertyName in @('Property', 'Language', 'Code', 'Expected', 'Actual')) {
+            $property = $difference.PSObject.Properties[$propertyName]
+            if ($null -eq $property) {
+                continue
+            }
+
+            $value = $property.Value
+            if ($null -eq $value -or [string]::IsNullOrWhiteSpace([string]$value)) {
+                continue
+            }
+
+            [void]$parts.Add("$propertyName=$value")
+        }
+
+        if ($parts.Count -gt 0) {
+            $parts -join '; '
+        }
+    }
+
+    return @(Get-UniqueConvergenceStrings -Value $details)
+}
+
+function Add-ConvergenceStringsToList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $List,
+
+        [AllowNull()]
+        [object[]]$Values = @()
+    )
+
+    foreach ($value in @(Get-UniqueConvergenceStrings -Value $Values)) {
+        [void]$List.Add([string]$value)
+    }
+}
+
+function Test-ConvergenceTransportError {
+    [CmdletBinding()]
+    param($ErrorRecord)
+
+    $message = if ($ErrorRecord -is [System.Management.Automation.ErrorRecord]) {
+        [string]$ErrorRecord.Exception.Message
+    }
+    elseif ($ErrorRecord -is [System.Exception]) {
+        [string]$ErrorRecord.Message
+    }
+    else {
+        [string]$ErrorRecord
+    }
+
+    if ([string]::IsNullOrWhiteSpace($message)) {
+        return $false
+    }
+
+    return $message -like 'Dataverse convergence transport failed*' -or
+        $message -like 'Dataverse security-role verification failed*' -or
+        $message -like 'Dataverse request failed*'
+}
+
+function Get-ConvergenceLanguagesPath {
+    [CmdletBinding()]
+    param()
+
+    return '/RetrieveProvisionedLanguages()'
+}
+
+function Get-ConvergenceSolutionsPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$SolutionUniqueName
+    )
+
+    $filter = @($SolutionUniqueName | ForEach-Object {
+            "uniquename eq '$(
+                ConvertTo-ODataKeyString ([string]$_)
+            )'"
+        }) -join ' or '
+
+    return (
+        "/solutions?`$select=solutionid,uniquename&" +
+        "`$expand=publisherid(`$select=uniquename,customizationprefix,customizationoptionvalueprefix)&" +
+        "`$filter=$filter"
+    )
+}
+
+function Get-ConvergenceSolutionMembershipPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ComponentId
+    )
+
+    $resolvedComponentId = ([string]$ComponentId).Trim('{}')
+    return (
+        "/solutioncomponents?`$select=solutioncomponentid&" +
+        "`$filter=objectid eq $resolvedComponentId&" +
+        "`$expand=solutionid(`$select=uniquename)"
+    )
+}
+
+function Get-ConvergenceGlobalChoicePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ChoiceLogicalName
+    )
+
+    $escapedChoiceName = ConvertTo-ODataKeyString $ChoiceLogicalName
+    return (
+        "/GlobalOptionSetDefinitions(Name='$escapedChoiceName')/" +
+        'Microsoft.Dynamics.CRM.OptionSetMetadata'
+    )
+}
+
+function Get-ConvergencePicklistAttributePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$AttributeLogicalName
+    )
+
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    $escapedAttributeName = ConvertTo-ODataKeyString $AttributeLogicalName
+    return (
+        "/EntityDefinitions(LogicalName='$escapedTableName')/Attributes/" +
+        'Microsoft.Dynamics.CRM.PicklistAttributeMetadata?' +
+        "`$select=MetadataId,LogicalName,SchemaName,AttributeType," +
+        'DisplayName,Description,RequiredLevel,IsAuditEnabled&' +
+        "`$expand=GlobalOptionSet(`$select=Name)&" +
+        "`$filter=LogicalName eq '$escapedAttributeName'"
+    )
+}
+
+function Get-ConvergenceTypedAttributePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        $Column
+    )
+
+    if ([string]$Column.type -eq 'GlobalChoice') {
+        return Get-ConvergencePicklistAttributePath `
+            -TableLogicalName $TableLogicalName `
+            -AttributeLogicalName ([string]$Column.logicalName)
+    }
+
+    $typeName = @{
+        Text     = 'StringAttributeMetadata'
+        DateOnly = 'DateTimeAttributeMetadata'
+        DateTime = 'DateTimeAttributeMetadata'
+        Lookup   = 'LookupAttributeMetadata'
+        Customer = 'LookupAttributeMetadata'
+    }[[string]$Column.type]
+    $derivedProperties = @{
+        Text     = 'MaxLength'
+        DateOnly = 'Format,DateTimeBehavior'
+        DateTime = 'Format,DateTimeBehavior'
+        Lookup   = 'Targets'
+        Customer = 'Targets'
+    }[[string]$Column.type]
+
+    if ([string]::IsNullOrWhiteSpace($typeName)) {
+        throw "Unsupported typed metadata query for '$($Column.type)' column '$($Column.logicalName)'."
+    }
+
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    $escapedAttributeName = ConvertTo-ODataKeyString ([string]$Column.logicalName)
+    return (
+        "/EntityDefinitions(LogicalName='$escapedTableName')/Attributes/" +
+        "Microsoft.Dynamics.CRM.$typeName?" +
+        "`$select=MetadataId,LogicalName,SchemaName,AttributeType," +
+        "DisplayName,Description,RequiredLevel,IsAuditEnabled,$derivedProperties&" +
+        "`$filter=LogicalName eq '$escapedAttributeName'"
+    )
+}
+
+function Get-ConvergenceTableMetadataPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogicalName,
+
+        [string[]]$RequestedAttributeLogicalNames
+    )
+
+    $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
+    $requestedAttributeLogicalNames = @(Get-UniqueMetadataStrings `
+            -Values $RequestedAttributeLogicalNames)
+
+    $attributeExpand = (
+        "Attributes(`$select=MetadataId,LogicalName,SchemaName," +
+        'AttributeType,DisplayName,Description'
+    )
+    if ($requestedAttributeLogicalNames.Count -gt 0) {
+        $attributeFilter = @(
+            $requestedAttributeLogicalNames | ForEach-Object {
+                "LogicalName eq '$(
+                    ConvertTo-ODataKeyString ([string]$_)
+                )'"
+            }
+        ) -join ' or '
+        $attributeExpand += ";`$filter=$attributeFilter"
+    }
+    $attributeExpand += ')'
+
+    return (
+        '/EntityDefinitions?' +
+        "`$select=MetadataId,LogicalName,SchemaName,OwnershipType," +
+        'PrimaryNameAttribute,IsAuditEnabled,DisplayName,Description,ObjectTypeCode&' +
+        "`$expand=$attributeExpand," +
+        "ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration)&" +
+        "`$filter=LogicalName eq '$escapedLogicalName'"
+    )
+}
+
+function Get-ConvergenceKeyPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$SchemaName
+    )
+
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    $escapedSchemaName = ConvertTo-ODataKeyString $SchemaName
+    return (
+        "/EntityDefinitions(LogicalName='$escapedTableName')/Keys?" +
+        "`$select=MetadataId,SchemaName,KeyAttributes&" +
+        "`$filter=SchemaName eq '$escapedSchemaName'"
+    )
+}
+
+function Get-ConvergenceSavedQueryPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    $escapedLabel = ConvertTo-ODataKeyString $Label
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    return (
+        '/savedqueries?' +
+        "`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml&" +
+        "`$filter=name eq '$escapedLabel' and returnedtypecode eq '$escapedTableName'"
+    )
+}
+
+function Get-ConvergenceSystemFormPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    $escapedLabel = ConvertTo-ODataKeyString $Label
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    return (
+        '/systemforms?' +
+        "`$select=formid,name,description,objecttypecode,type,formxml&" +
+        "`$filter=name eq '$escapedLabel' and objecttypecode eq '$escapedTableName' and type eq 2"
+    )
+}
+
+function Invoke-ConvergenceDataverseRequest {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('GET')]
+        [string]$Method = 'GET',
+
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [hashtable]$Headers = @{}
+    )
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $url = if ($Path -match '^https://') {
+        $Path
+    }
+    else {
+        "$baseUrl/api/data/v9.2$Path"
+    }
+
+    $arguments = @(
+        'rest',
+        '--method', 'get',
+        '--url', $url,
+        '--resource', "$baseUrl/",
+        '--only-show-errors'
+    )
+
+    if ($Headers.Count -gt 0) {
+        $arguments += '--headers'
+        foreach ($headerName in @($Headers.Keys | Sort-Object)) {
+            $arguments += "$headerName=$($Headers[$headerName])"
+        }
+    }
+
+    $output = & az @arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $detail = ($output | Out-String).Trim()
+        throw "Dataverse convergence transport failed (GET $Path); az rest exited with code $exitCode. $detail"
+    }
+
+    $text = ($output | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    return $text | ConvertFrom-Json -ErrorAction Stop
+}
+
+function Invoke-DataverseRequest {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('GET')]
+        [string]$Method = 'GET',
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [AllowNull()]
+        [object]$Body,
+
+        [hashtable]$Headers = @{}
+    )
+
+    if ($null -ne $Body) {
+        throw "Convergence gate is GET-only; body submission is not allowed for '$Method $Path'."
+    }
+
+    if ([string]::IsNullOrWhiteSpace($script:DataverseBaseUrl)) {
+        throw 'Dataverse base URL was not initialized for convergence verification.'
+    }
+
+    return Invoke-ConvergenceDataverseRequest `
+        -Method $Method `
+        -EnvironmentUrl $script:DataverseBaseUrl `
+        -Path $Path `
+        -Headers $Headers
+}
+
+function Invoke-InsuranceSecurityRoleDataverseRequest {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('GET')]
+        [string]$Method = 'GET',
+
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    return Invoke-ConvergenceDataverseRequest `
+        -Method $Method `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path $Path
+}
+
+function Get-PicklistAttributeMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$AttributeLogicalName
+    )
+
+    return Get-One (
+        Get-ConvergencePicklistAttributePath `
+            -TableLogicalName $TableLogicalName `
+            -AttributeLogicalName $AttributeLogicalName
+    )
+}
+
+function Get-TypedAttributeMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        $Column
+    )
+
+    return Get-One (
+        Get-ConvergenceTypedAttributePath `
+            -TableLogicalName $TableLogicalName `
+            -Column $Column
+    )
+}
+
+function Assert-ConvergenceSolutionOwnership {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Existing,
+
+        [Parameter(Mandatory)]
+        [string]$Expected,
+
+        [Parameter(Mandatory)]
+        [string]$Component
+    )
+
+    if ($Existing.PSObject.Properties.Name -contains 'formid') {
+        if ($Existing.PSObject.Properties.Name -contains 'SolutionUniqueName' -and
+            $Existing.SolutionUniqueName -and
+            [string]$Existing.SolutionUniqueName -ne $Expected) {
+            throw "Structural ownership conflict for '$Component': expected '$Expected', found '$($Existing.SolutionUniqueName)'."
+        }
+
+        $componentId = ([string]$Existing.formid).Trim('{}')
+        if (-not [string]::IsNullOrWhiteSpace($componentId)) {
+            $membership = Invoke-DataverseRequest -Method GET -Path (
+                Get-ConvergenceSolutionMembershipPath -ComponentId $componentId
+            )
+            $solutionNames = @($membership.value | ForEach-Object {
+                    if ($_.solutionid) { [string]$_.solutionid.uniquename }
+                })
+            if ($Expected -notin $solutionNames) {
+                throw "Structural ownership conflict for '$Component': component is not in '$Expected'."
+            }
+        }
+
+        if ($Existing._solutionid_value) {
+            $solutionId = ([string]$Existing._solutionid_value).Trim('{}')
+            $solution = Get-One (
+                "/solutions?`$select=uniquename&`$filter=solutionid eq $solutionId"
+            )
+            if ($null -eq $solution -or
+                [string]$solution.uniquename -ne $Expected) {
+                throw "Structural ownership conflict for '$Component': expected '$Expected'."
+            }
+        }
+
+        return
+    }
+
+    Assert-SolutionOwnership $Existing $Expected $Component
+}
+
+function Test-InsuranceFoundationManifestAlignment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Contract,
+
+        [Parameter(Mandatory)]
+        $Manifest
+    )
+
+    $missingSolutions = @()
+    $manifestSolutions = @($Manifest.solutions | ForEach-Object {
+            [string]$_.uniqueName
+        })
+    foreach ($solutionUniqueName in @($Contract.solutions)) {
+        if ([string]$solutionUniqueName -notin $manifestSolutions) {
+            $missingSolutions += [string]$solutionUniqueName
+        }
+    }
+
+    $details = [System.Collections.Generic.List[string]]::new()
+    if ($missingSolutions.Count -gt 0) {
+        [void]$details.Add(
+            "Contract solutions are absent from solution/manifest.json: $($missingSolutions -join ', ')."
+        )
+    }
+
+    if ($null -eq $Manifest.publisher -or
+        [string]::IsNullOrWhiteSpace([string]$Manifest.publisher.uniqueName) -or
+        [string]::IsNullOrWhiteSpace([string]$Manifest.publisher.prefix)) {
+        [void]$details.Add(
+            'solution/manifest.json must declare publisher.uniqueName and publisher.prefix.'
+        )
+    }
+
+    if ($details.Count -eq 0) {
+        return New-ConvergenceResult -Component 'manifest' -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component 'manifest' `
+        -State 'ContractConflict' `
+        -Missing $missingSolutions `
+        -Details @($details)
+}
+
+function Test-InsuranceFoundationLanguages {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $response = Invoke-ConvergenceDataverseRequest `
+        -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-ConvergenceLanguagesPath)
+    if ($null -eq $response -or
+        $response.PSObject.Properties.Name -notcontains 'RetrieveProvisionedLanguages') {
+        return New-ConvergenceResult `
+            -Component 'languages' `
+            -State 'Precondition' `
+            -Details @('RetrieveProvisionedLanguages returned no language collection.')
+    }
+
+    $provisioned = @($response.RetrieveProvisionedLanguages | ForEach-Object {
+            [string]$_
+        })
+    $missing = @($Contract.languages | Where-Object {
+            [string]$_ -notin $provisioned
+        })
+    if ($missing.Count -gt 0) {
+        return New-ConvergenceResult `
+            -Component 'languages' `
+            -State 'Precondition' `
+            -Missing $missing `
+            -Details @(
+                "Required Dataverse languages are not yet provisioned: $($missing -join ', ')."
+            )
+    }
+
+    return New-ConvergenceResult -Component 'languages' -State 'Ready'
+}
+
+function Test-InsuranceFoundationSolutions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract,
+
+        [Parameter(Mandatory)]
+        $Manifest
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $response = Invoke-ConvergenceDataverseRequest `
+        -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-ConvergenceSolutionsPath -SolutionUniqueName @($Contract.solutions))
+    $solutions = @($response.value)
+    $missing = @()
+    $differences = [System.Collections.Generic.List[object]]::new()
+    foreach ($expectedSolution in @($Contract.solutions)) {
+        $matches = @($solutions | Where-Object {
+                [string]$_.uniquename -ceq [string]$expectedSolution
+            })
+        if ($matches.Count -eq 0) {
+            $missing += [string]$expectedSolution
+            continue
+        }
+        if ($matches.Count -gt 1) {
+            [void]$differences.Add([pscustomobject]@{
+                    Property = 'DuplicateSolution'
+                    Expected = [string]$expectedSolution
+                    Actual   = $matches.Count
+                })
+            continue
+        }
+
+        $solution = $matches[0]
+        $publisher = $solution.publisherid
+        if ($null -eq $publisher) {
+            [void]$differences.Add([pscustomobject]@{
+                    Property = 'Publisher'
+                    Expected = [string]$Manifest.publisher.uniqueName
+                    Actual   = $null
+                })
+            continue
+        }
+
+        if ([string]$publisher.uniquename -cne [string]$Manifest.publisher.uniqueName) {
+            [void]$differences.Add([pscustomobject]@{
+                    Property = "$expectedSolution.PublisherUniqueName"
+                    Expected = [string]$Manifest.publisher.uniqueName
+                    Actual   = [string]$publisher.uniquename
+                })
+        }
+        if ([string]$publisher.customizationprefix -cne [string]$Manifest.publisher.prefix) {
+            [void]$differences.Add([pscustomobject]@{
+                    Property = "$expectedSolution.CustomizationPrefix"
+                    Expected = [string]$Manifest.publisher.prefix
+                    Actual   = [string]$publisher.customizationprefix
+                })
+        }
+        if ($publisher.PSObject.Properties.Name -contains 'customizationoptionvalueprefix') {
+            $actualOptionValuePrefix = [int]$publisher.customizationoptionvalueprefix
+            $expectedOptionValuePrefix = [int]$Manifest.publisher.customizationOptionValuePrefix
+            if ($actualOptionValuePrefix -ne $expectedOptionValuePrefix) {
+                [void]$differences.Add([pscustomobject]@{
+                        Property = "$expectedSolution.CustomizationOptionValuePrefix"
+                        Expected = $expectedOptionValuePrefix
+                        Actual   = $actualOptionValuePrefix
+                    })
+            }
+        }
+    }
+
+    if ($differences.Count -gt 0) {
+        return New-ConvergenceResult `
+            -Component 'solutions' `
+            -State 'ContractConflict' `
+            -Missing $missing `
+            -Differences @($differences) `
+            -Details (Get-ConvergenceDifferenceDetails -Differences @($differences))
+    }
+
+    if ($missing.Count -gt 0) {
+        return New-ConvergenceResult `
+            -Component 'solutions' `
+            -State 'Precondition' `
+            -Missing $missing `
+            -Details @(
+                "Required solutions are missing from the environment: $($missing -join ', ')."
+            )
+    }
+
+    return New-ConvergenceResult -Component 'solutions' -State 'Ready'
+}
+
+function Compare-InsuranceFoundationChoiceOptions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Choice,
+
+        [AllowNull()]
+        [object[]]$ActualOptions = @()
+    )
+
+    $expectedOptions = @{}
+    $expectedValue = 100000000
+    foreach ($option in @($Choice.options)) {
+        $expectedOptions[[string]$expectedValue] = [pscustomobject]@{
+            Code     = [string]$option.code
+            Metadata = $option.metadata
+        }
+        $expectedValue++
+    }
+
+    $actualByValue = @{}
+    $duplicates = [System.Collections.Generic.List[object]]::new()
+    foreach ($actualOption in @($ActualOptions)) {
+        if ($null -eq $actualOption) {
+            continue
+        }
+
+        $value = [string]$actualOption.Value
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            [void]$duplicates.Add([pscustomobject]@{
+                    Property = 'OptionValue'
+                    Expected = 'Non-empty'
+                    Actual   = $null
+                })
+            continue
+        }
+
+        if ($actualByValue.ContainsKey($value)) {
+            [void]$duplicates.Add([pscustomobject]@{
+                    Property = 'DuplicateOptionValue'
+                    Expected = $value
+                    Actual   = $value
+                })
+            continue
+        }
+
+        $actualByValue[$value] = $actualOption
+    }
+
+    $missing = [System.Collections.Generic.List[string]]::new()
+    $unexpected = [System.Collections.Generic.List[string]]::new()
+    $differences = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($value in @($expectedOptions.Keys | Sort-Object)) {
+        if (-not $actualByValue.ContainsKey($value)) {
+            [void]$missing.Add("$($expectedOptions[$value].Code)($value)")
+            continue
+        }
+
+        $actualOption = $actualByValue[$value]
+        foreach ($pair in @(
+                @{ Property = 'Label'; Contract = 'label' },
+                @{ Property = 'Description'; Contract = 'description' }
+            )) {
+            foreach ($language in @($script:RequiredLanguages)) {
+                $expectedText = [string]$expectedOptions[$value].Metadata.($pair.Contract).$language
+                $actualText = Get-ConvergenceLocalizedLabel `
+                    -LocalizedValue $actualOption.($pair.Property) `
+                    -LanguageCode $language
+                if ($actualText -cne $expectedText) {
+                    [void]$differences.Add([pscustomobject][ordered]@{
+                            Property = $pair.Property
+                            Language = [string]$language
+                            Code     = [string]$expectedOptions[$value].Code
+                            Expected = $expectedText
+                            Actual   = $actualText
+                        })
+                }
+            }
+        }
+    }
+
+    foreach ($value in @($actualByValue.Keys | Sort-Object)) {
+        if (-not $expectedOptions.ContainsKey($value)) {
+            [void]$unexpected.Add([string]$value)
+        }
+    }
+
+    foreach ($duplicate in @($duplicates)) {
+        [void]$differences.Add($duplicate)
+    }
+
+    return [pscustomobject]@{
+        Missing     = @($missing)
+        Unexpected  = @($unexpected)
+        Differences = @($differences)
+    }
+}
+
+function Test-InsuranceFoundationChoice {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Choice
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $component = [string]$Choice.logicalName
+    try {
+        $actual = Get-GlobalOptionSet -Name $Choice.logicalName
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+    if ($null -eq $actual) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Missing @($Choice.logicalName) `
+            -Details @("Global choice '$($Choice.logicalName)' was not found.")
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    try {
+        Assert-ConvergenceSolutionOwnership `
+            -Existing $actual `
+            -Expected ([string]$Choice.solution) `
+            -Component $component
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    if ([string]$actual.Name -cne [string]$Choice.logicalName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'Name'
+                Expected = [string]$Choice.logicalName
+                Actual   = [string]$actual.Name
+            })
+    }
+    if (-not [bool]$actual.IsGlobal) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'IsGlobal'
+                Expected = $true
+                Actual   = [bool]$actual.IsGlobal
+            })
+    }
+    if ($actual.PSObject.Properties.Name -contains 'OptionSetType' -and
+        [string]$actual.OptionSetType -ne 'Picklist') {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'OptionSetType'
+                Expected = 'Picklist'
+                Actual   = [string]$actual.OptionSetType
+            })
+    }
+
+    if (Test-LocalizedMetadataChanged -Existing $actual -Metadata $Choice.metadata) {
+        foreach ($difference in @(Get-ConvergenceLocalizedMetadataDifferences `
+                    -Existing $actual `
+                    -Metadata $Choice.metadata)) {
+            [void]$differences.Add($difference)
+        }
+    }
+
+    $optionComparison = Compare-InsuranceFoundationChoiceOptions `
+        -Choice $Choice `
+        -ActualOptions @($actual.Options)
+    foreach ($difference in @($optionComparison.Differences)) {
+        [void]$differences.Add($difference)
+    }
+
+    Add-ConvergenceStringsToList `
+        -List $details `
+        -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
+    if ($optionComparison.Unexpected.Count -gt 0) {
+        [void]$details.Add(
+            "Unexpected option values exist for '$($Choice.logicalName)': $(@($optionComparison.Unexpected) -join ', ')."
+        )
+    }
+
+    if ($differences.Count -eq 0 -and
+        $optionComparison.Missing.Count -eq 0 -and
+        $optionComparison.Unexpected.Count -eq 0 -and
+        $details.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Missing @($optionComparison.Missing) `
+        -Unexpected @($optionComparison.Unexpected) `
+        -Differences @($differences) `
+        -Details @($details)
+}
+
+function Test-InsuranceFoundationNativeExtension {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Extension
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $component = "$($Extension.table)/$($Extension.logicalName)"
+    try {
+        $actual = Get-TypedAttributeMetadata `
+            -TableLogicalName $Extension.table `
+            -Column $Extension
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+    if ($null -eq $actual) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Missing @($Extension.logicalName) `
+            -Details @("Native extension '$component' was not found.")
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    try {
+        Assert-ConvergenceSolutionOwnership `
+            -Existing $actual `
+            -Expected ([string]$Extension.solution) `
+            -Component $component
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    if ([string]$actual.LogicalName -cne [string]$Extension.logicalName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'LogicalName'
+                Expected = [string]$Extension.logicalName
+                Actual   = [string]$actual.LogicalName
+            })
+    }
+    if ([string]$actual.SchemaName -cne [string]$Extension.schemaName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'SchemaName'
+                Expected = [string]$Extension.schemaName
+                Actual   = [string]$actual.SchemaName
+            })
+    }
+
+    try {
+        Test-AttributeCompatibility `
+            -Existing $actual `
+            -Column $Extension `
+            -Owner $Extension.table
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    $expectedRequiredLevel = (ConvertTo-RequiredLevel ([bool]$Extension.required)).Value
+    $actualRequiredLevel = Get-ConvergenceRequiredLevelValue -Attribute $actual
+    if ($actualRequiredLevel -cne $expectedRequiredLevel) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'RequiredLevel'
+                Expected = $expectedRequiredLevel
+                Actual   = $actualRequiredLevel
+            })
+    }
+
+    $expectedAudit = [bool]$Extension.auditing
+    $actualAudit = Get-ConvergenceManagedPropertyValue -Value $actual.IsAuditEnabled
+    if ($actualAudit -ne $expectedAudit) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'IsAuditEnabled'
+                Expected = $expectedAudit
+                Actual   = $actualAudit
+            })
+    }
+
+    if (Test-LocalizedMetadataChanged -Existing $actual -Metadata $Extension.metadata) {
+        foreach ($difference in @(Get-ConvergenceLocalizedMetadataDifferences `
+                    -Existing $actual `
+                    -Metadata $Extension.metadata)) {
+            [void]$differences.Add($difference)
+        }
+    }
+
+    Add-ConvergenceStringsToList `
+        -List $details `
+        -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
+    if ($differences.Count -eq 0 -and $details.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Differences @($differences) `
+        -Details @($details)
+}
+
+function Get-ConvergenceSnapshotAttribute {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Snapshot,
+
+        [Parameter(Mandatory)]
+        [string]$LogicalName
+    )
+
+    return @($Snapshot.Attributes | Where-Object {
+            [string]$_.LogicalName -ceq $LogicalName
+        })
+}
+
+function Test-InsuranceFoundationTableColumn {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Table,
+
+        [Parameter(Mandatory)]
+        $Column,
+
+        [Parameter(Mandatory)]
+        $Snapshot
+    )
+
+    $component = "$($Table.logicalName)/column/$($Column.logicalName)"
+    $matches = @(Get-ConvergenceSnapshotAttribute -Snapshot $Snapshot -LogicalName $Column.logicalName)
+    if ($matches.Count -eq 0) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Missing @($Column.logicalName) `
+            -Details @("Column '$($Column.logicalName)' is missing from '$($Table.logicalName)'.")
+    }
+    if ($matches.Count -gt 1) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @("Duplicate physical attributes found for '$($Table.logicalName)/$($Column.logicalName)'.")
+    }
+
+    $actual = $matches[0]
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+
+    if ([string]$actual.SchemaName -cne [string]$Column.schemaName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'SchemaName'
+                Expected = [string]$Column.schemaName
+                Actual   = [string]$actual.SchemaName
+            })
+    }
+
+    try {
+        Test-AttributeCompatibility `
+            -Existing $actual `
+            -Column $Column `
+            -Owner $Table.logicalName
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    $expectedRequiredLevel = (ConvertTo-RequiredLevel ([bool]$Column.required)).Value
+    $actualRequiredLevel = Get-ConvergenceRequiredLevelValue -Attribute $actual
+    if ($actualRequiredLevel -cne $expectedRequiredLevel) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'RequiredLevel'
+                Expected = $expectedRequiredLevel
+                Actual   = $actualRequiredLevel
+            })
+    }
+
+    $expectedAudit = [bool]$Column.auditing
+    $actualAudit = Get-ConvergenceManagedPropertyValue -Value $actual.IsAuditEnabled
+    if ($actualAudit -ne $expectedAudit) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'IsAuditEnabled'
+                Expected = $expectedAudit
+                Actual   = $actualAudit
+            })
+    }
+
+    if (Test-LocalizedMetadataChanged -Existing $actual -Metadata $Column.metadata) {
+        foreach ($difference in @(Get-ConvergenceLocalizedMetadataDifferences `
+                    -Existing $actual `
+                    -Metadata $Column.metadata)) {
+            [void]$differences.Add($difference)
+        }
+    }
+
+    Add-ConvergenceStringsToList `
+        -List $details `
+        -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
+    if ($differences.Count -eq 0 -and $details.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Differences @($differences) `
+        -Details @($details)
+}
+
+function Test-InsuranceFoundationOrdinaryRelationship {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Table,
+
+        [Parameter(Mandatory)]
+        $Relationship,
+
+        [Parameter(Mandatory)]
+        $Snapshot
+    )
+
+    $component = "$($Table.logicalName)/relationship/$($Relationship.schemaName)"
+    try {
+        if (-not (Test-OrdinaryRelationshipVisibility `
+                    -Table $Table `
+                    -Relationship $Relationship `
+                    -Snapshot $Snapshot)) {
+            return New-ConvergenceResult `
+                -Component $component `
+                -State 'ContractConflict' `
+                -Details @("Relationship '$($Relationship.schemaName)' is missing or incomplete.")
+        }
+    }
+    catch {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+
+    return New-ConvergenceResult -Component $component -State 'Ready'
+}
+
+function Test-InsuranceFoundationCustomerRelationship {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Table,
+
+        [Parameter(Mandatory)]
+        $Column,
+
+        [Parameter(Mandatory)]
+        $Snapshot
+    )
+
+    $component = "$($Table.logicalName)/relationship/$($Column.logicalName)"
+    try {
+        if (-not (Test-CustomerRelationshipVisibility `
+                    -Table $Table `
+                    -Column $Column `
+                    -Snapshot $Snapshot)) {
+            return New-ConvergenceResult `
+                -Component $component `
+                -State 'ContractConflict' `
+                -Details @("Customer relationship '$($Column.logicalName)' is missing or incomplete.")
+        }
+    }
+    catch {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+
+    return New-ConvergenceResult -Component $component -State 'Ready'
+}
+
+function Test-InsuranceFoundationAlternateKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Table,
+
+        [Parameter(Mandatory)]
+        $Key
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $component = "$($Table.logicalName)/key/$($Key.schemaName)"
+    try {
+        $actual = Get-One (
+            Get-ConvergenceKeyPath `
+                -TableLogicalName $Table.logicalName `
+                -SchemaName $Key.schemaName
+        )
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+    if ($null -eq $actual) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Missing @($Key.schemaName) `
+            -Details @("Alternate key '$($Key.schemaName)' was not found.")
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    if ([string]$actual.SchemaName -cne [string]$Key.schemaName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'SchemaName'
+                Expected = [string]$Key.schemaName
+                Actual   = [string]$actual.SchemaName
+            })
+    }
+
+    $actualColumns = @($actual.KeyAttributes | Sort-Object)
+    $expectedColumns = @($Key.columns | Sort-Object)
+    if (($actualColumns -join ',') -cne ($expectedColumns -join ',')) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'KeyAttributes'
+                Expected = ($expectedColumns -join ',')
+                Actual   = ($actualColumns -join ',')
+            })
+    }
+
+    if ($differences.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Differences @($differences) `
+        -Details (Get-ConvergenceDifferenceDetails -Differences @($differences))
+}
+
+function Test-InsuranceFoundationView {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Table,
+
+        [Parameter(Mandatory)]
+        $View,
+
+        [Parameter(Mandatory)]
+        [int]$ObjectTypeCode
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $component = "$($Table.logicalName)/view/$($View.name)"
+    $expectedRequest = New-ViewRequest -Table $Table -View $View -ObjectTypeCode $ObjectTypeCode
+    $expectedName = [string]$View.metadata.label.'1033'
+    try {
+        $actual = Get-One (
+            Get-ConvergenceSavedQueryPath `
+                -TableLogicalName $Table.logicalName `
+                -Label $expectedName
+        )
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+    if ($null -eq $actual) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Missing @($View.name) `
+            -Details @("View '$($View.name)' was not found.")
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    try {
+        Assert-ConvergenceSolutionOwnership `
+            -Existing $actual `
+            -Expected ([string]$Table.solution) `
+            -Component $component
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    if ([string]$actual.name -cne $expectedName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'Name'
+                Expected = $expectedName
+                Actual   = [string]$actual.name
+            })
+    }
+    if ([string]$actual.description -cne [string]$View.metadata.description.'1033') {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'Description'
+                Expected = [string]$View.metadata.description.'1033'
+                Actual   = [string]$actual.description
+            })
+    }
+
+    try {
+        if ($actual.returnedtypecode -and
+            [string]$actual.returnedtypecode -ne [string]$Table.logicalName) {
+            throw "Structural view target conflict for '$($View.name)'."
+        }
+        Assert-XmlCompatible `
+            -Existing $actual `
+            -Request $expectedRequest `
+            -Property 'fetchxml' `
+            -Component $View.name
+        Assert-XmlCompatible `
+            -Existing $actual `
+            -Request $expectedRequest `
+            -Property 'layoutxml' `
+            -Component $View.name
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    Add-ConvergenceStringsToList `
+        -List $details `
+        -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
+    if ($differences.Count -eq 0 -and $details.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Differences @($differences) `
+        -Details @($details)
+}
+
+function Test-InsuranceFoundationForm {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Table,
+
+        [Parameter(Mandatory)]
+        $Form
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $component = "$($Table.logicalName)/form/$($Form.name)"
+    $expectedRequest = New-FormRequest -Table $Table -Form $Form
+    $expectedName = [string]$Form.metadata.label.'1033'
+    try {
+        $actual = Get-One (
+            Get-ConvergenceSystemFormPath `
+                -TableLogicalName $Table.logicalName `
+                -Label $expectedName
+        )
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+    if ($null -eq $actual) {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Missing @($Form.name) `
+            -Details @("Form '$($Form.name)' was not found.")
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    try {
+        Assert-ConvergenceSolutionOwnership `
+            -Existing $actual `
+            -Expected ([string]$Table.solution) `
+            -Component $component
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    if ([string]$actual.name -cne $expectedName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'Name'
+                Expected = $expectedName
+                Actual   = [string]$actual.name
+            })
+    }
+    if ([string]$actual.description -cne [string]$Form.metadata.description.'1033') {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'Description'
+                Expected = [string]$Form.metadata.description.'1033'
+                Actual   = [string]$actual.description
+            })
+    }
+
+    try {
+        if (($actual.objecttypecode -and
+                [string]$actual.objecttypecode -ne [string]$Table.logicalName) -or
+            ($actual.type -ne $null -and [int]$actual.type -ne 2)) {
+            throw "Structural form target conflict for '$($Form.name)'."
+        }
+        Assert-XmlCompatible `
+            -Existing $actual `
+            -Request $expectedRequest `
+            -Property 'formxml' `
+            -Component $Form.name
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    Add-ConvergenceStringsToList `
+        -List $details `
+        -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
+    if ($differences.Count -eq 0 -and $details.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Differences @($differences) `
+        -Details @($details)
+}
+
+function Test-InsuranceFoundationTable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Table
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $requestedAttributeLogicalNames = @(
+        Get-TableContractAttributeLogicalNames -Table $Table
+    )
+    try {
+        $snapshot = Get-TableMetadataSnapshot `
+            -LogicalName $Table.logicalName `
+            -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+        return New-ConvergenceResult `
+            -Component ([string]$Table.logicalName) `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+    if ($null -eq $snapshot) {
+        return New-ConvergenceResult `
+            -Component ([string]$Table.logicalName) `
+            -State 'ContractConflict' `
+            -Missing @($Table.logicalName) `
+            -Details @("Custom table '$($Table.logicalName)' was not found.")
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    try {
+        Assert-ConvergenceSolutionOwnership `
+            -Existing $snapshot `
+            -Expected ([string]$Table.solution) `
+            -Component ([string]$Table.logicalName)
+    }
+    catch {
+        [void]$details.Add($_.Exception.Message)
+    }
+
+    if ([string]$snapshot.SchemaName -cne [string]$Table.schemaName) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'SchemaName'
+                Expected = [string]$Table.schemaName
+                Actual   = [string]$snapshot.SchemaName
+            })
+    }
+    if ([string]$snapshot.OwnershipType -cne [string]$Table.ownership) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'OwnershipType'
+                Expected = [string]$Table.ownership
+                Actual   = [string]$snapshot.OwnershipType
+            })
+    }
+    if ([string]$snapshot.PrimaryNameAttribute -cne 'crmshow_name') {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'PrimaryNameAttribute'
+                Expected = 'crmshow_name'
+                Actual   = [string]$snapshot.PrimaryNameAttribute
+            })
+    }
+
+    $expectedAudit = [bool]$Table.auditing
+    $actualAudit = Get-ConvergenceManagedPropertyValue -Value $snapshot.IsAuditEnabled
+    if ($actualAudit -ne $expectedAudit) {
+        [void]$differences.Add([pscustomobject]@{
+                Property = 'IsAuditEnabled'
+                Expected = $expectedAudit
+                Actual   = $actualAudit
+            })
+    }
+
+    if (Test-LocalizedMetadataChanged -Existing $snapshot -Metadata $Table.metadata) {
+        foreach ($difference in @(Get-ConvergenceLocalizedMetadataDifferences `
+                    -Existing $snapshot `
+                    -Metadata $Table.metadata)) {
+            [void]$differences.Add($difference)
+        }
+    }
+
+    $objectTypeCode = if ($snapshot.ObjectTypeCode) {
+        [int]$snapshot.ObjectTypeCode
+    }
+    else {
+        Resolve-TableObjectTypeCode -TableLogicalName $Table.logicalName
+    }
+
+    $children = [System.Collections.Generic.List[object]]::new()
+    foreach ($column in @($Table.columns)) {
+        [void]$children.Add(
+            (Test-InsuranceFoundationTableColumn `
+                -Table $Table `
+                -Column $column `
+                -Snapshot $snapshot)
+        )
+    }
+    foreach ($relationship in @($Table.relationships | Where-Object {
+                $_.authoring -ne 'CreateCustomerRelationships'
+            })) {
+        [void]$children.Add(
+            (Test-InsuranceFoundationOrdinaryRelationship `
+                -Table $Table `
+                -Relationship $relationship `
+                -Snapshot $snapshot)
+        )
+    }
+    foreach ($customerColumn in @($Table.columns | Where-Object {
+                $_.type -eq 'Customer'
+            })) {
+        [void]$children.Add(
+            (Test-InsuranceFoundationCustomerRelationship `
+                -Table $Table `
+                -Column $customerColumn `
+                -Snapshot $snapshot)
+        )
+    }
+    foreach ($key in @($Table.alternateKeys)) {
+        [void]$children.Add(
+            (Test-InsuranceFoundationAlternateKey `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Table $Table `
+                -Key $key)
+        )
+    }
+    foreach ($rule in @($Table.businessRules)) {
+        $reportView = [pscustomobject]@{
+            name     = "$($rule.name)report"
+            purpose  = 'InvalidDateReporting'
+            columns  = @(
+                if ($Table.logicalName -eq 'crmshow_policyprojection') {
+                    'crmshow_name'
+                    'crmshow_effectivefrom'
+                    'crmshow_effectiveto'
+                }
+                else {
+                    'crmshow_name'
+                    'crmshow_validfrom'
+                    'crmshow_validto'
+                }
+            )
+            metadata = $rule.metadata
+        }
+        [void]$children.Add(
+            (Test-InsuranceFoundationView `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Table $Table `
+                -View $reportView `
+                -ObjectTypeCode $objectTypeCode)
+        )
+    }
+    foreach ($view in @($Table.views)) {
+        [void]$children.Add(
+            (Test-InsuranceFoundationView `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Table $Table `
+                -View $view `
+                -ObjectTypeCode $objectTypeCode)
+        )
+    }
+    foreach ($form in @($Table.forms)) {
+        [void]$children.Add(
+            (Test-InsuranceFoundationForm `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Table $Table `
+                -Form $form)
+        )
+    }
+
+    $blockingChildren = @($children | Where-Object {
+            [string]$_.State -ne 'Ready'
+        })
+    if ($blockingChildren.Count -gt 0) {
+        [void]$details.Add(
+            "Blocking child components: $(@($blockingChildren.Component) -join ', ')."
+        )
+    }
+
+    Add-ConvergenceStringsToList `
+        -List $details `
+        -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
+    if ($differences.Count -eq 0 -and $details.Count -eq 0 -and $blockingChildren.Count -eq 0) {
+        return New-ConvergenceResult `
+            -Component ([string]$Table.logicalName) `
+            -State 'Ready' `
+            -Children @($children)
+    }
+
+    return New-ConvergenceResult `
+        -Component ([string]$Table.logicalName) `
+        -State 'ContractConflict' `
+        -Differences @($differences) `
+        -Details @($details) `
+        -Children @($children)
+}
+
+function Test-InsuranceFoundationRoles {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $verification = Invoke-InsuranceSecurityRoleVerification `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Contract $Contract
+    $details = [System.Collections.Generic.List[string]]::new()
+    foreach ($result in @($verification.Results | Where-Object {
+                [string]$_.State -ne 'Ready'
+            })) {
+        foreach ($detail in @($result.Details)) {
+            [void]$details.Add($detail)
+        }
+    }
+
+    return New-ConvergenceResult `
+        -Component 'roles' `
+        -State ([string]$verification.State) `
+        -Details @($details) `
+        -Children @($verification.Results)
+}
+
+function Invoke-InsuranceFoundationConvergence {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$ContractPath
+    )
+
+    Set-ConvergenceRuntimeContext `
+        -EnvironmentUrl $EnvironmentUrl `
+        -ContractPath $ContractPath
+
+    $contract = $null
+    try {
+        $contract = Test-InsuranceFoundationContract -Path $ContractPath
+    }
+    catch {
+        return New-ConvergenceSummary -Results @(
+            (New-ConvergenceResult `
+                -Component 'contract' `
+                -State 'ContractConflict' `
+                -Details @($_.Exception.Message))
+        )
+    }
+
+    $manifest = $null
+    try {
+        $manifest = Get-Manifest -Path (Get-ConvergenceManifestPath) -Validate
+    }
+    catch {
+        return New-ConvergenceSummary -Results @(
+            (New-ConvergenceResult `
+                -Component 'manifest' `
+                -State 'ContractConflict' `
+                -Details @($_.Exception.Message))
+        )
+    }
+
+    $manifestAlignment = Test-InsuranceFoundationManifestAlignment `
+        -Contract $contract `
+        -Manifest $manifest
+    if ([string]$manifestAlignment.State -ne 'Ready') {
+        return New-ConvergenceSummary -Results @($manifestAlignment)
+    }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    [void]$results.Add(
+        (Test-InsuranceFoundationLanguages `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $contract)
+    )
+    [void]$results.Add(
+        (Test-InsuranceFoundationSolutions `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $contract `
+            -Manifest $manifest)
+    )
+    foreach ($choice in @($contract.choices)) {
+        [void]$results.Add(
+            (Test-InsuranceFoundationChoice `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Choice $choice)
+        )
+    }
+    foreach ($extension in @($contract.nativeExtensions)) {
+        [void]$results.Add(
+            (Test-InsuranceFoundationNativeExtension `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Extension $extension)
+        )
+    }
+    foreach ($table in @($contract.tables)) {
+        [void]$results.Add(
+            (Test-InsuranceFoundationTable `
+                -EnvironmentUrl $EnvironmentUrl `
+                -Table $table)
+        )
+    }
+    [void]$results.Add(
+        (Test-InsuranceFoundationRoles `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $contract)
+    )
+
+    return New-ConvergenceSummary -Results @($results)
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
+            throw 'EnvironmentUrl is required.'
+        }
+        if ([string]::IsNullOrWhiteSpace($ContractPath)) {
+            throw 'ContractPath is required.'
+        }
+        if (-not (Test-Path -LiteralPath $ContractPath -PathType Leaf)) {
+            throw "ContractPath was not found: $ContractPath"
+        }
+
+        $result = Invoke-InsuranceFoundationConvergence `
+            -EnvironmentUrl $EnvironmentUrl `
+            -ContractPath $ContractPath
+        $result | ConvertTo-Json -Depth 50
+
+        switch ([string]$result.State) {
+            'Ready' { exit 0 }
+            'ManualPrerequisite' { exit 2 }
+            'Precondition' { exit 2 }
+            'UnsupportedInTenant' { exit 2 }
+            'ContractConflict' { exit 3 }
+            default { exit 1 }
+        }
+    }
+    catch {
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -14,6 +14,8 @@ param(
     [string]$ContractPath
 )
 
+. (Join-Path $PSScriptRoot 'ConvertTo-SafeCliDiagnosticLine.ps1')
+
 $ErrorActionPreference = 'Stop'
 $script:ConvergenceBlockingStatePriority = @(
     'ContractConflict',
@@ -996,8 +998,8 @@ function Invoke-ConvergenceDataverseRequest {
     $output = & az @arguments 2>&1
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
-        $detail = ($output | Out-String).Trim()
-        throw "Dataverse convergence transport failed (GET $Path); az rest exited with code $exitCode. $detail"
+        $detail = ConvertTo-SafeCliDiagnosticLine -Value $output
+        throw "Dataverse convergence transport failed (GET $Path); az rest exited with code $exitCode. Output: $detail"
     }
 
     $text = ($output | Out-String).Trim()
@@ -3650,7 +3652,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
     }
     catch {
-        Write-Error $_
+        Write-SafeCliErrorLine -ErrorRecord $_
         exit 1
     }
 }

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -15,6 +15,12 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+$script:ConvergenceBlockingStatePriority = @(
+    'ContractConflict',
+    'UnsupportedInTenant',
+    'Precondition',
+    'ManualPrerequisite'
+)
 
 function Get-ConvergenceRepoRoot {
     [CmdletBinding()]
@@ -231,6 +237,15 @@ function Get-ConvergenceBlockingState {
             $null -ne $_ -and [string]$_.State -ne 'Ready'
         })
     if ($blocking.Count -gt 0) {
+        $blockingStates = @($blocking | ForEach-Object { [string]$_.State })
+        foreach ($state in @($script:ConvergenceBlockingStatePriority)) {
+            if (Test-ConvergenceContainsExactString `
+                    -Value $blockingStates `
+                    -Expected $state) {
+                return $state
+            }
+        }
+
         return [string]$blocking[0].State
     }
 
@@ -585,7 +600,7 @@ function Get-ConvergenceSolutionInventoryPath {
         }) -join ' or '
 
     return (
-        "/solutioncomponents?`$select=objectid,componenttype&" +
+        "/solutioncomponents?`$select=solutioncomponentid,objectid,componenttype,rootcomponentbehavior,_rootsolutioncomponentid_value&" +
         "`$filter=_solutionid_value eq $resolvedSolutionId and ($typeFilter)"
     )
 }
@@ -2826,6 +2841,110 @@ function Test-ConvergenceReviewedOrPrefixedTable {
     )
 }
 
+function Get-ConvergenceSolutionComponentInventoryId {
+    [CmdletBinding()]
+    param($SolutionComponent)
+
+    if ($null -eq $SolutionComponent) {
+        return $null
+    }
+
+    foreach ($propertyName in @('solutioncomponentid', 'SolutionComponentId', 'objectid')) {
+        if ($SolutionComponent.PSObject.Properties.Name -notcontains $propertyName) {
+            continue
+        }
+
+        $candidate = ([string]$SolutionComponent.$propertyName).Trim('{}')
+        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function Get-ConvergenceRootSolutionComponentInventoryId {
+    [CmdletBinding()]
+    param($SolutionComponent)
+
+    if ($null -eq $SolutionComponent) {
+        return $null
+    }
+
+    $candidateValues = [System.Collections.Generic.List[object]]::new()
+    if ($SolutionComponent.PSObject.Properties.Name -contains '_rootsolutioncomponentid_value') {
+        [void]$candidateValues.Add($SolutionComponent._rootsolutioncomponentid_value)
+    }
+    if ($SolutionComponent.PSObject.Properties.Name -contains 'rootsolutioncomponentid') {
+        [void]$candidateValues.Add($SolutionComponent.rootsolutioncomponentid)
+    }
+
+    foreach ($candidate in @($candidateValues)) {
+        if ($null -eq $candidate) {
+            continue
+        }
+
+        if ($candidate -is [string]) {
+            $resolved = ([string]$candidate).Trim('{}')
+            if (-not [string]::IsNullOrWhiteSpace($resolved)) {
+                return $resolved
+            }
+
+            continue
+        }
+
+        foreach ($propertyName in @('solutioncomponentid', 'SolutionComponentId')) {
+            if ($candidate.PSObject.Properties.Name -notcontains $propertyName) {
+                continue
+            }
+
+            $resolved = ([string]$candidate.$propertyName).Trim('{}')
+            if (-not [string]::IsNullOrWhiteSpace($resolved)) {
+                return $resolved
+            }
+        }
+    }
+
+    return $null
+}
+
+function Test-ConvergenceTransitiveTableRootChildSolutionComponent {
+    [CmdletBinding()]
+    param(
+        $SolutionComponent,
+
+        [Parameter(Mandatory)]
+        [hashtable]$SolutionComponentsById
+    )
+
+    if ($null -eq $SolutionComponent) {
+        return $false
+    }
+
+    $solutionComponentId = Get-ConvergenceSolutionComponentInventoryId `
+        -SolutionComponent $SolutionComponent
+    $rootSolutionComponentId = Get-ConvergenceRootSolutionComponentInventoryId `
+        -SolutionComponent $SolutionComponent
+    if ([string]::IsNullOrWhiteSpace($rootSolutionComponentId)) {
+        return $false
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($solutionComponentId) -and
+        $rootSolutionComponentId -ceq $solutionComponentId) {
+        return $false
+    }
+
+    if (-not $SolutionComponentsById.ContainsKey($rootSolutionComponentId)) {
+        return $false
+    }
+
+    $rootSolutionComponent = $SolutionComponentsById[$rootSolutionComponentId]
+    return (
+        $null -ne $rootSolutionComponent -and
+        [int]$rootSolutionComponent.componenttype -eq 1
+    )
+}
+
 function Test-InsuranceFoundationUnexpectedMetadata {
     [CmdletBinding()]
     param(
@@ -2905,12 +3024,32 @@ function Test-InsuranceFoundationUnexpectedMetadata {
                 -Details @($_.Exception.Message)
         }
 
-        foreach ($entry in @($inventory.value | Sort-Object componenttype, objectid)) {
+        $inventoryEntries = @($inventory.value)
+        $solutionComponentsById = @{}
+        foreach ($inventoryEntry in @($inventoryEntries)) {
+            $inventoryId = Get-ConvergenceSolutionComponentInventoryId `
+                -SolutionComponent $inventoryEntry
+            if ([string]::IsNullOrWhiteSpace($inventoryId) -or
+                $solutionComponentsById.ContainsKey($inventoryId)) {
+                continue
+            }
+
+            $solutionComponentsById[$inventoryId] = $inventoryEntry
+        }
+
+        foreach ($entry in @($inventoryEntries | Sort-Object componenttype, objectid)) {
             $objectId = [string]$entry.objectid
             if ([string]::IsNullOrWhiteSpace($objectId)) {
                 [void]$details.Add(
                     "Reverse inventory entry in solution '$solutionUniqueName' returned no object ID for component type '$($entry.componenttype)'."
                 )
+                continue
+            }
+
+            if (([int]$entry.componenttype -eq 26 -or [int]$entry.componenttype -eq 60) -and
+                (Test-ConvergenceTransitiveTableRootChildSolutionComponent `
+                    -SolutionComponent $entry `
+                    -SolutionComponentsById $solutionComponentsById)) {
                 continue
             }
 
@@ -3149,23 +3288,33 @@ function Test-InsuranceFoundationUnexpectedMetadata {
             continue
         }
 
-        $solutionNames = @($membership.value | ForEach-Object {
-                if ($_.solutionid) {
-                    [string]$_.solutionid.uniquename
-                }
-            })
-        if (-not (Test-ConvergenceContainsExactString `
+        $solutionNames = @(Get-UniqueConvergenceStrings -Value @($membership.value | ForEach-Object {
+                    if ($_.solutionid) {
+                        [string]$_.solutionid.uniquename
+                    }
+                }))
+        $reviewedMembership = @($Contract.solutions | Where-Object {
+                Test-ConvergenceContainsExactString `
                     -Value $solutionNames `
-                    -Expected 'crmshow_Foundation')) {
+                    -Expected ([string]$_)
+            })
+        if ($reviewedMembership.Count -eq 0) {
             continue
         }
 
-        if (-not (Test-ConvergenceContainsExactString `
-                    -Value @($expectedInventory.RolesBySolution['crmshow_Foundation']) `
-                    -Expected $roleName)) {
-            [void]$unexpected.Add("crmshow_Foundation/role/$roleName")
+        $declaredRoleSolutions = @($Contract.solutions | Where-Object {
+                Test-ConvergenceContainsExactString `
+                    -Value @($expectedInventory.RolesBySolution[[string]$_]) `
+                    -Expected $roleName
+            })
+        if ($declaredRoleSolutions.Count -gt 0) {
+            continue
+        }
+
+        foreach ($reviewedSolutionUniqueName in @($reviewedMembership)) {
+            [void]$unexpected.Add("$reviewedSolutionUniqueName/role/$roleName")
             [void]$details.Add(
-                "Unexpected root role '$roleName' is owned by solution 'crmshow_Foundation' but is not listed in the contract."
+                "Unexpected root role '$roleName' is owned by solution '$reviewedSolutionUniqueName' but is not listed in the contract."
             )
         }
     }

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -157,6 +157,86 @@ function Get-UniqueConvergenceDifferenceObjects {
     return @($items)
 }
 
+function Test-ConvergenceContainsExactString {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value,
+
+        [Parameter(Mandatory)]
+        [string]$Expected
+    )
+
+    return @($Value | Where-Object {
+            [string]$_ -ceq $Expected
+        }).Count -gt 0
+}
+
+function Add-ConvergenceStringToMapList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Map,
+
+        [Parameter(Mandatory)]
+        [string]$Key,
+
+        [AllowNull()]
+        [string]$Value
+    )
+
+    if (-not $Map.ContainsKey($Key)) {
+        $Map[$Key] = @()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return
+    }
+
+    if (-not (Test-ConvergenceContainsExactString `
+                -Value @($Map[$Key]) `
+                -Expected $Value)) {
+        $Map[$Key] = @(@($Map[$Key]) + $Value)
+    }
+}
+
+function Test-ConvergenceStartsWithPrefix {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string]$Value,
+
+        [Parameter(Mandatory)]
+        [string]$Prefix
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value) -or
+        [string]::IsNullOrWhiteSpace($Prefix)) {
+        return $false
+    }
+
+    return $Value.StartsWith($Prefix, [System.StringComparison]::Ordinal)
+}
+
+function Get-ConvergenceBlockingState {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Results = @(),
+
+        [string]$Default = 'Ready'
+    )
+
+    $blocking = @($Results | Where-Object {
+            $null -ne $_ -and [string]$_.State -ne 'Ready'
+        })
+    if ($blocking.Count -gt 0) {
+        return [string]$blocking[0].State
+    }
+
+    return $Default
+}
+
 function New-ConvergenceResult {
     [CmdletBinding()]
     param(
@@ -212,10 +292,7 @@ function New-ConvergenceSummary {
             [string]$_.State -ne 'Ready'
         })
 
-    $state = 'Ready'
-    if ($blocking.Count -gt 0) {
-        $state = [string]$blocking[0].State
-    }
+    $state = Get-ConvergenceBlockingState -Results @($resolvedResults)
 
     return [pscustomobject][ordered]@{
         State              = $state
@@ -416,8 +493,7 @@ function Test-ConvergenceRetrieveLocLabelsUnsupportedError {
     param($ErrorRecord)
 
     $message = Get-ConvergenceErrorMessage -ErrorRecord $ErrorRecord
-    if ([string]::IsNullOrWhiteSpace($message) -or
-        $message -notlike 'Dataverse convergence transport failed (GET /RetrieveLocLabels*') {
+    if ([string]::IsNullOrWhiteSpace($message)) {
         return $false
     }
 
@@ -481,6 +557,39 @@ function Get-ConvergenceSolutionMembershipPath {
     )
 }
 
+function Get-ConvergenceReverseInventoryComponentTypes {
+    [CmdletBinding()]
+    param()
+
+    return @(1, 9, 26, 60)
+}
+
+function Get-ConvergenceSolutionInventoryPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SolutionId,
+
+        [Parameter(Mandatory)]
+        [int[]]$ComponentType
+    )
+
+    $resolvedSolutionId = ([string]$SolutionId).Trim('{}')
+    $requestedTypes = @($ComponentType | Sort-Object -Unique)
+    if ($requestedTypes.Count -eq 0) {
+        throw 'At least one solution component type is required for reverse inventory.'
+    }
+
+    $typeFilter = @($requestedTypes | ForEach-Object {
+            "componenttype eq $([int]$_)"
+        }) -join ' or '
+
+    return (
+        "/solutioncomponents?`$select=objectid,componenttype&" +
+        "`$filter=_solutionid_value eq $resolvedSolutionId and ($typeFilter)"
+    )
+}
+
 function Get-ConvergenceGlobalChoicePath {
     [CmdletBinding()]
     param(
@@ -492,6 +601,20 @@ function Get-ConvergenceGlobalChoicePath {
     return (
         "/GlobalOptionSetDefinitions(Name='$escapedChoiceName')/" +
         'Microsoft.Dynamics.CRM.OptionSetMetadata'
+    )
+}
+
+function Get-ConvergenceGlobalChoiceByMetadataIdPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$MetadataId
+    )
+
+    $resolvedMetadataId = ([string]$MetadataId).Trim('{}')
+    return (
+        "/GlobalOptionSetDefinitions($resolvedMetadataId)/" +
+        "Microsoft.Dynamics.CRM.OptionSetMetadata?`$select=MetadataId,Name,IsGlobal,OptionSetType"
     )
 }
 
@@ -602,6 +725,17 @@ function Get-ConvergenceTableMetadataPath {
     )
 }
 
+function Get-ConvergenceEntityByMetadataIdPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$MetadataId
+    )
+
+    $resolvedMetadataId = ([string]$MetadataId).Trim('{}')
+    return "/EntityDefinitions($resolvedMetadataId)?`$select=MetadataId,LogicalName,SchemaName"
+}
+
 function Get-ConvergenceKeyPath {
     [CmdletBinding()]
     param(
@@ -618,6 +752,31 @@ function Get-ConvergenceKeyPath {
         "/EntityDefinitions(LogicalName='$escapedTableName')/Keys?" +
         "`$select=MetadataId,SchemaName,KeyAttributes&" +
         "`$filter=SchemaName eq '$escapedSchemaName'"
+    )
+}
+
+function Get-ConvergenceTableUnexpectedChildrenPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$PublisherPrefix
+    )
+
+    $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
+    $escapedPrefix = ConvertTo-ODataKeyString $PublisherPrefix
+
+    return (
+        "/EntityDefinitions(LogicalName='$escapedLogicalName')?" +
+        "`$select=MetadataId,LogicalName,SchemaName,PrimaryIdAttribute&" +
+        "`$expand=" +
+        "Attributes(`$select=LogicalName,SchemaName,AttributeType,AttributeOf;" +
+        "`$filter=startswith(LogicalName,'$escapedPrefix') or startswith(SchemaName,'$escapedPrefix'))," +
+        "ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute;" +
+        "`$filter=startswith(SchemaName,'$escapedPrefix') or startswith(ReferencingAttribute,'$escapedPrefix'))," +
+        "Keys(`$select=SchemaName,KeyAttributes;`$filter=startswith(SchemaName,'$escapedPrefix'))"
     )
 }
 
@@ -640,6 +799,20 @@ function Get-ConvergenceSavedQueryPath {
     )
 }
 
+function Get-ConvergenceSavedQueryByIdPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SavedQueryId
+    )
+
+    $resolvedSavedQueryId = ([string]$SavedQueryId).Trim('{}')
+    return (
+        "/savedqueries($resolvedSavedQueryId)?" +
+        "`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml"
+    )
+}
+
 function Get-ConvergenceSystemFormPath {
     [CmdletBinding()]
     param(
@@ -657,6 +830,45 @@ function Get-ConvergenceSystemFormPath {
         "`$select=formid,name,description,objecttypecode,type,formxml&" +
         "`$filter=name eq '$escapedLabel' and objecttypecode eq '$escapedTableName' and type eq 2"
     )
+}
+
+function Get-ConvergenceSystemFormByIdPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FormId
+    )
+
+    $resolvedFormId = ([string]$FormId).Trim('{}')
+    return (
+        "/systemforms($resolvedFormId)?" +
+        "`$select=formid,name,description,objecttypecode,type,formxml"
+    )
+}
+
+function Get-ConvergenceRootInsuranceRolesPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RolePrefix
+    )
+
+    $escapedRolePrefix = ConvertTo-ODataKeyString $RolePrefix
+    return (
+        "/roles?`$select=roleid,name,_parentrootroleid_value&" +
+        "`$filter=_parentrootroleid_value eq null and startswith(name,'$escapedRolePrefix')"
+    )
+}
+
+function Get-ConvergenceRoleByIdPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RoleId
+    )
+
+    $resolvedRoleId = ([string]$RoleId).Trim('{}')
+    return "/roles($resolvedRoleId)?`$select=roleid,name,_parentrootroleid_value"
 }
 
 function Get-ConvergenceRetrieveLocLabelsEntityMoniker {
@@ -1012,6 +1224,282 @@ function Assert-ConvergenceSolutionOwnership {
     }
 
     Assert-SolutionOwnership $Existing $Expected $Component
+}
+
+function Get-ConvergencePublisherLogicalPrefix {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Manifest
+    )
+
+    if ($null -eq $Manifest.publisher -or
+        [string]::IsNullOrWhiteSpace([string]$Manifest.publisher.prefix)) {
+        throw 'solution/manifest.json must declare publisher.prefix for reverse inventory scoping.'
+    }
+
+    $publisherPrefix = [string]$Manifest.publisher.prefix
+    if ($publisherPrefix.EndsWith('_', [System.StringComparison]::Ordinal)) {
+        return $publisherPrefix
+    }
+
+    return "$publisherPrefix" + '_'
+}
+
+function Get-ConvergenceViewInventoryKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    return "$TableLogicalName|$Name"
+}
+
+function Get-ConvergenceFormInventoryKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TableLogicalName,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [int]$Type = 2
+    )
+
+    return "$TableLogicalName|$Type|$Name"
+}
+
+function Get-ConvergenceReviewedTableLogicalNames {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    $tables = [System.Collections.Generic.List[string]]::new()
+    foreach ($extension in @($Contract.nativeExtensions)) {
+        $logicalName = [string]$extension.table
+        if (-not (Test-ConvergenceContainsExactString `
+                    -Value @($tables) `
+                    -Expected $logicalName)) {
+            [void]$tables.Add($logicalName)
+        }
+    }
+    foreach ($table in @($Contract.tables)) {
+        $logicalName = [string]$table.logicalName
+        if (-not (Test-ConvergenceContainsExactString `
+                    -Value @($tables) `
+                    -Expected $logicalName)) {
+            [void]$tables.Add($logicalName)
+        }
+    }
+
+    return @($tables)
+}
+
+function Get-ConvergenceExpectedInventory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    $choicesBySolution = @{}
+    $tablesBySolution = @{}
+    $rolesBySolution = @{}
+    $viewsBySolution = @{}
+    $formsBySolution = @{}
+    foreach ($solutionUniqueName in @($Contract.solutions)) {
+        $choicesBySolution[[string]$solutionUniqueName] = @()
+        $tablesBySolution[[string]$solutionUniqueName] = @()
+        $rolesBySolution[[string]$solutionUniqueName] = @()
+        $viewsBySolution[[string]$solutionUniqueName] = @()
+        $formsBySolution[[string]$solutionUniqueName] = @()
+    }
+
+    foreach ($choice in @($Contract.choices)) {
+        Add-ConvergenceStringToMapList `
+            -Map $choicesBySolution `
+            -Key ([string]$choice.solution) `
+            -Value ([string]$choice.logicalName)
+    }
+
+    foreach ($role in @($Contract.roles)) {
+        Add-ConvergenceStringToMapList `
+            -Map $rolesBySolution `
+            -Key ([string]$role.solution) `
+            -Value ([string]$role.name)
+    }
+
+    foreach ($table in @($Contract.tables)) {
+        Add-ConvergenceStringToMapList `
+            -Map $tablesBySolution `
+            -Key ([string]$table.solution) `
+            -Value ([string]$table.logicalName)
+
+        foreach ($rule in @($table.businessRules)) {
+            Add-ConvergenceStringToMapList `
+                -Map $viewsBySolution `
+                -Key ([string]$table.solution) `
+                -Value (Get-ConvergenceViewInventoryKey `
+                    -TableLogicalName ([string]$table.logicalName) `
+                    -Name ([string]$rule.metadata.label.'1033'))
+        }
+
+        foreach ($view in @($table.views)) {
+            Add-ConvergenceStringToMapList `
+                -Map $viewsBySolution `
+                -Key ([string]$table.solution) `
+                -Value (Get-ConvergenceViewInventoryKey `
+                    -TableLogicalName ([string]$table.logicalName) `
+                    -Name ([string]$view.metadata.label.'1033'))
+        }
+
+        foreach ($form in @($table.forms)) {
+            Add-ConvergenceStringToMapList `
+                -Map $formsBySolution `
+                -Key ([string]$table.solution) `
+                -Value (Get-ConvergenceFormInventoryKey `
+                    -TableLogicalName ([string]$table.logicalName) `
+                    -Name ([string]$form.metadata.label.'1033'))
+        }
+    }
+
+    $columnsByTable = @{}
+    foreach ($tableLogicalName in @(Get-ConvergenceReviewedTableLogicalNames -Contract $Contract)) {
+        $columnsByTable[$tableLogicalName] = @()
+    }
+    foreach ($extension in @($Contract.nativeExtensions)) {
+        Add-ConvergenceStringToMapList `
+            -Map $columnsByTable `
+            -Key ([string]$extension.table) `
+            -Value ([string]$extension.logicalName)
+    }
+    foreach ($table in @($Contract.tables)) {
+        foreach ($column in @($table.columns)) {
+            Add-ConvergenceStringToMapList `
+                -Map $columnsByTable `
+                -Key ([string]$table.logicalName) `
+                -Value ([string]$column.logicalName)
+        }
+    }
+
+    $relationshipsByTable = @{}
+    $keysByTable = @{}
+    foreach ($tableLogicalName in @(Get-ConvergenceReviewedTableLogicalNames -Contract $Contract)) {
+        $relationshipsByTable[$tableLogicalName] = @()
+        $keysByTable[$tableLogicalName] = @()
+    }
+    foreach ($table in @($Contract.tables)) {
+        foreach ($relationship in @($table.relationships)) {
+            if ([string]$relationship.authoring -eq 'CreateCustomerRelationships') {
+                $column = @($table.columns | Where-Object {
+                        [string]$_.logicalName -ceq [string]$relationship.lookupColumn
+                    })
+                if ($column.Count -ne 1) {
+                    throw "Customer relationship '$($relationship.schemaName)' could not resolve lookup column '$($relationship.lookupColumn)' in '$($table.logicalName)'."
+                }
+
+                foreach ($expected in @(Get-ExpectedCustomerRelationships `
+                            -Table $table `
+                            -Column $column[0])) {
+                    Add-ConvergenceStringToMapList `
+                        -Map $relationshipsByTable `
+                        -Key ([string]$table.logicalName) `
+                        -Value ([string]$expected.SchemaName)
+                }
+                continue
+            }
+
+            Add-ConvergenceStringToMapList `
+                -Map $relationshipsByTable `
+                -Key ([string]$table.logicalName) `
+                -Value ([string]$relationship.schemaName)
+        }
+
+        foreach ($key in @($table.alternateKeys)) {
+            Add-ConvergenceStringToMapList `
+                -Map $keysByTable `
+                -Key ([string]$table.logicalName) `
+                -Value ([string]$key.schemaName)
+        }
+    }
+
+    return [pscustomobject]@{
+        ChoicesBySolution = $choicesBySolution
+        TablesBySolution  = $tablesBySolution
+        RolesBySolution   = $rolesBySolution
+        ViewsBySolution   = $viewsBySolution
+        FormsBySolution   = $formsBySolution
+        ColumnsByTable    = $columnsByTable
+        RelationshipsByTable = $relationshipsByTable
+        KeysByTable       = $keysByTable
+        ReviewedTables    = @(Get-ConvergenceReviewedTableLogicalNames -Contract $Contract)
+    }
+}
+
+function Get-ConvergenceReviewedSolutionLookup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $response = Invoke-ConvergenceDataverseRequest `
+        -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-ConvergenceSolutionsPath -SolutionUniqueName @($Contract.solutions))
+    $solutions = @($response.value)
+    $lookup = @{}
+    $missing = [System.Collections.Generic.List[string]]::new()
+    $duplicates = [System.Collections.Generic.List[string]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    foreach ($expectedSolution in @($Contract.solutions)) {
+        $matches = @($solutions | Where-Object {
+                [string]$_.uniquename -ceq [string]$expectedSolution
+            })
+        if ($matches.Count -eq 0) {
+            [void]$missing.Add([string]$expectedSolution)
+            continue
+        }
+        if ($matches.Count -gt 1) {
+            [void]$duplicates.Add([string]$expectedSolution)
+            continue
+        }
+
+        $lookup[[string]$expectedSolution] = $matches[0]
+    }
+
+    $state = 'Ready'
+    if ($duplicates.Count -gt 0) {
+        $state = 'ContractConflict'
+        [void]$details.Add(
+            "Reverse inventory resolved duplicate reviewed solutions: $(@($duplicates) -join ', ')."
+        )
+    }
+    elseif ($missing.Count -gt 0) {
+        $state = 'Precondition'
+        [void]$details.Add(
+            "Reverse inventory requires reviewed solutions that are missing from the environment: $(@($missing) -join ', ')."
+        )
+    }
+
+    return [pscustomobject]@{
+        State   = $state
+        Missing = @($missing)
+        Details = @($details)
+        Lookup  = $lookup
+    }
 }
 
 function Test-InsuranceFoundationManifestAlignment {
@@ -2198,12 +2686,6 @@ function Test-InsuranceFoundationTable {
     $blockingChildren = @($children | Where-Object {
             [string]$_.State -ne 'Ready'
         })
-    if ($blockingChildren.Count -gt 0) {
-        [void]$details.Add(
-            "Blocking child components: $(@($blockingChildren.Component) -join ', ')."
-        )
-    }
-
     Add-ConvergenceStringsToList `
         -List $details `
         -Values @(Get-ConvergenceDifferenceDetails -Differences @($differences))
@@ -2214,12 +2696,571 @@ function Test-InsuranceFoundationTable {
             -Children @($children)
     }
 
+    $allDetails = [System.Collections.Generic.List[string]]::new()
+    Add-ConvergenceStringsToList -List $allDetails -Values @($details)
+    if ($blockingChildren.Count -gt 0) {
+        [void]$allDetails.Add(
+            "Blocking child components: $(@($blockingChildren.Component) -join ', ')."
+        )
+    }
+
+    $state = if ($differences.Count -gt 0 -or $details.Count -gt 0) {
+        'ContractConflict'
+    }
+    else {
+        Get-ConvergenceBlockingState -Results @($blockingChildren)
+    }
+
     return New-ConvergenceResult `
         -Component ([string]$Table.logicalName) `
-        -State 'ContractConflict' `
+        -State $state `
         -Differences @($differences) `
-        -Details @($details) `
+        -Details @($allDetails) `
         -Children @($children)
+}
+
+function Test-ConvergenceUnexpectedAttributeCandidate {
+    [CmdletBinding()]
+    param(
+        $Attribute,
+
+        [string]$PrimaryIdAttribute,
+
+        [Parameter(Mandatory)]
+        [string]$PublisherPrefix
+    )
+
+    if ($null -eq $Attribute) {
+        return $false
+    }
+
+    $logicalName = [string]$Attribute.LogicalName
+    $schemaName = [string]$Attribute.SchemaName
+    if (-not (Test-ConvergenceStartsWithPrefix `
+                -Value $logicalName `
+                -Prefix $PublisherPrefix) -and
+        -not (Test-ConvergenceStartsWithPrefix `
+                -Value $schemaName `
+                -Prefix $PublisherPrefix)) {
+        return $false
+    }
+
+    if ($Attribute.PSObject.Properties.Name -contains 'AttributeOf' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Attribute.AttributeOf)) {
+        return $false
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($PrimaryIdAttribute) -and
+        $logicalName -ceq $PrimaryIdAttribute) {
+        return $false
+    }
+
+    return $true
+}
+
+function Test-ConvergenceUnexpectedRelationshipCandidate {
+    [CmdletBinding()]
+    param(
+        $Relationship,
+
+        [Parameter(Mandatory)]
+        [string]$PublisherPrefix
+    )
+
+    if ($null -eq $Relationship) {
+        return $false
+    }
+
+    return (
+        (Test-ConvergenceStartsWithPrefix `
+            -Value ([string]$Relationship.SchemaName) `
+            -Prefix $PublisherPrefix) -or
+        (Test-ConvergenceStartsWithPrefix `
+            -Value ([string]$Relationship.ReferencingAttribute) `
+            -Prefix $PublisherPrefix)
+    )
+}
+
+function Test-ConvergenceUnexpectedKeyCandidate {
+    [CmdletBinding()]
+    param(
+        $Key,
+
+        [Parameter(Mandatory)]
+        [string]$PublisherPrefix
+    )
+
+    if ($null -eq $Key) {
+        return $false
+    }
+
+    return Test-ConvergenceStartsWithPrefix `
+        -Value ([string]$Key.SchemaName) `
+        -Prefix $PublisherPrefix
+}
+
+function Test-ConvergenceReviewedOrPrefixedTable {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [string]$LogicalName,
+
+        [Parameter(Mandatory)]
+        [string[]]$ReviewedTables,
+
+        [Parameter(Mandatory)]
+        [string]$PublisherPrefix
+    )
+
+    if ([string]::IsNullOrWhiteSpace($LogicalName)) {
+        return $false
+    }
+
+    return (
+        (Test-ConvergenceContainsExactString `
+            -Value $ReviewedTables `
+            -Expected $LogicalName) -or
+        (Test-ConvergenceStartsWithPrefix `
+            -Value $LogicalName `
+            -Prefix $PublisherPrefix)
+    )
+}
+
+function Test-InsuranceFoundationUnexpectedMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract,
+
+        [Parameter(Mandatory)]
+        $Manifest
+    )
+
+    Set-ConvergenceRuntimeContext -EnvironmentUrl $EnvironmentUrl
+
+    $component = 'unexpectedMetadata'
+    $rolePrefix = 'CRM Showcase Insurance '
+    $unexpected = [System.Collections.Generic.List[string]]::new()
+    $details = [System.Collections.Generic.List[string]]::new()
+    $publisherPrefix = $null
+    $expectedInventory = $null
+    try {
+        $publisherPrefix = Get-ConvergencePublisherLogicalPrefix -Manifest $Manifest
+        $expectedInventory = Get-ConvergenceExpectedInventory -Contract $Contract
+    }
+    catch {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+
+    $solutionLookup = $null
+    try {
+        $solutionLookup = Get-ConvergenceReviewedSolutionLookup `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $Contract
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+
+    if ([string]$solutionLookup.State -ne 'Ready') {
+        return New-ConvergenceResult `
+            -Component $component `
+            -State ([string]$solutionLookup.State) `
+            -Missing @($solutionLookup.Missing) `
+            -Details @($solutionLookup.Details)
+    }
+
+    foreach ($solutionUniqueName in @($Contract.solutions)) {
+        $solution = $solutionLookup.Lookup[[string]$solutionUniqueName]
+        $solutionId = [string]$solution.solutionid
+        $inventory = $null
+        try {
+            $inventory = Invoke-DataverseRequest `
+                -Method GET `
+                -Path (Get-ConvergenceSolutionInventoryPath `
+                    -SolutionId $solutionId `
+                    -ComponentType (Get-ConvergenceReverseInventoryComponentTypes))
+        }
+        catch {
+            if (Test-ConvergenceTransportError $_) {
+                throw
+            }
+
+            return New-ConvergenceResult `
+                -Component $component `
+                -State 'ContractConflict' `
+                -Details @($_.Exception.Message)
+        }
+
+        foreach ($entry in @($inventory.value | Sort-Object componenttype, objectid)) {
+            $objectId = [string]$entry.objectid
+            if ([string]::IsNullOrWhiteSpace($objectId)) {
+                [void]$details.Add(
+                    "Reverse inventory entry in solution '$solutionUniqueName' returned no object ID for component type '$($entry.componenttype)'."
+                )
+                continue
+            }
+
+            switch ([int]$entry.componenttype) {
+                1 {
+                    $entity = $null
+                    try {
+                        $entity = Invoke-DataverseRequest `
+                            -Method GET `
+                            -Path (Get-ConvergenceEntityByMetadataIdPath `
+                                -MetadataId $objectId)
+                    }
+                    catch {
+                        if (Test-ConvergenceTransportError $_) {
+                            throw
+                        }
+
+                        [void]$details.Add($_.Exception.Message)
+                        continue
+                    }
+
+                    if ($null -eq $entity) {
+                        [void]$details.Add(
+                            "Reverse inventory could not resolve custom table metadata '$objectId' in solution '$solutionUniqueName'."
+                        )
+                        continue
+                    }
+
+                    $logicalName = [string]$entity.LogicalName
+                    if (-not (Test-ConvergenceStartsWithPrefix `
+                                -Value $logicalName `
+                                -Prefix $publisherPrefix)) {
+                        continue
+                    }
+
+                    if (-not (Test-ConvergenceContainsExactString `
+                                -Value @($expectedInventory.TablesBySolution[$solutionUniqueName]) `
+                                -Expected $logicalName)) {
+                        [void]$unexpected.Add("$solutionUniqueName/table/$logicalName")
+                        [void]$details.Add(
+                            "Unexpected custom table '$logicalName' is owned by solution '$solutionUniqueName' but is not listed in the contract."
+                        )
+                    }
+                }
+                9 {
+                    $choice = $null
+                    try {
+                        $choice = Invoke-DataverseRequest `
+                            -Method GET `
+                            -Path (Get-ConvergenceGlobalChoiceByMetadataIdPath `
+                                -MetadataId $objectId)
+                    }
+                    catch {
+                        if (Test-ConvergenceTransportError $_) {
+                            throw
+                        }
+
+                        [void]$details.Add($_.Exception.Message)
+                        continue
+                    }
+
+                    if ($null -eq $choice) {
+                        [void]$details.Add(
+                            "Reverse inventory could not resolve global choice metadata '$objectId' in solution '$solutionUniqueName'."
+                        )
+                        continue
+                    }
+
+                    $logicalName = [string]$choice.Name
+                    if (-not [bool]$choice.IsGlobal -or
+                        -not (Test-ConvergenceStartsWithPrefix `
+                                -Value $logicalName `
+                                -Prefix $publisherPrefix)) {
+                        continue
+                    }
+
+                    if (-not (Test-ConvergenceContainsExactString `
+                                -Value @($expectedInventory.ChoicesBySolution[$solutionUniqueName]) `
+                                -Expected $logicalName)) {
+                        [void]$unexpected.Add("$solutionUniqueName/choice/$logicalName")
+                        [void]$details.Add(
+                            "Unexpected global choice '$logicalName' is owned by solution '$solutionUniqueName' but is not listed in the contract."
+                        )
+                    }
+                }
+                26 {
+                    $view = $null
+                    try {
+                        $view = Invoke-DataverseRequest `
+                            -Method GET `
+                            -Path (Get-ConvergenceSavedQueryByIdPath `
+                                -SavedQueryId $objectId)
+                    }
+                    catch {
+                        if (Test-ConvergenceTransportError $_) {
+                            throw
+                        }
+
+                        [void]$details.Add($_.Exception.Message)
+                        continue
+                    }
+
+                    if ($null -eq $view) {
+                        [void]$details.Add(
+                            "Reverse inventory could not resolve view '$objectId' in solution '$solutionUniqueName'."
+                        )
+                        continue
+                    }
+
+                    $tableLogicalName = [string]$view.returnedtypecode
+                    if (-not (Test-ConvergenceReviewedOrPrefixedTable `
+                                -LogicalName $tableLogicalName `
+                                -ReviewedTables @($expectedInventory.ReviewedTables) `
+                                -PublisherPrefix $publisherPrefix)) {
+                        continue
+                    }
+
+                    $viewKey = Get-ConvergenceViewInventoryKey `
+                        -TableLogicalName $tableLogicalName `
+                        -Name ([string]$view.name)
+                    if (-not (Test-ConvergenceContainsExactString `
+                                -Value @($expectedInventory.ViewsBySolution[$solutionUniqueName]) `
+                                -Expected $viewKey)) {
+                        [void]$unexpected.Add(
+                            "$solutionUniqueName/view/$tableLogicalName/$([string]$view.name)"
+                        )
+                        [void]$details.Add(
+                            "Unexpected solution-owned view '$([string]$view.name)' targeting '$tableLogicalName' is owned by solution '$solutionUniqueName' but is not listed in the contract."
+                        )
+                    }
+                }
+                60 {
+                    $form = $null
+                    try {
+                        $form = Invoke-DataverseRequest `
+                            -Method GET `
+                            -Path (Get-ConvergenceSystemFormByIdPath `
+                                -FormId $objectId)
+                    }
+                    catch {
+                        if (Test-ConvergenceTransportError $_) {
+                            throw
+                        }
+
+                        [void]$details.Add($_.Exception.Message)
+                        continue
+                    }
+
+                    if ($null -eq $form) {
+                        [void]$details.Add(
+                            "Reverse inventory could not resolve form '$objectId' in solution '$solutionUniqueName'."
+                        )
+                        continue
+                    }
+
+                    $tableLogicalName = [string]$form.objecttypecode
+                    if (-not (Test-ConvergenceReviewedOrPrefixedTable `
+                                -LogicalName $tableLogicalName `
+                                -ReviewedTables @($expectedInventory.ReviewedTables) `
+                                -PublisherPrefix $publisherPrefix)) {
+                        continue
+                    }
+
+                    $formType = if ($null -eq $form.type) {
+                        -1
+                    }
+                    else {
+                        [int]$form.type
+                    }
+                    $formKey = Get-ConvergenceFormInventoryKey `
+                        -TableLogicalName $tableLogicalName `
+                        -Name ([string]$form.name) `
+                        -Type $formType
+                    if (-not (Test-ConvergenceContainsExactString `
+                                -Value @($expectedInventory.FormsBySolution[$solutionUniqueName]) `
+                                -Expected $formKey)) {
+                        [void]$unexpected.Add(
+                            "$solutionUniqueName/form/$tableLogicalName/$([string]$form.name)"
+                        )
+                        [void]$details.Add(
+                            "Unexpected solution-owned form '$([string]$form.name)' targeting '$tableLogicalName' is owned by solution '$solutionUniqueName' but is not listed in the contract."
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    $rootRoles = $null
+    try {
+        $rootRoles = Invoke-DataverseRequest `
+            -Method GET `
+            -Path (Get-ConvergenceRootInsuranceRolesPath `
+                -RolePrefix $rolePrefix)
+    }
+    catch {
+        if (Test-ConvergenceTransportError $_) {
+            throw
+        }
+
+        return New-ConvergenceResult `
+            -Component $component `
+            -State 'ContractConflict' `
+            -Details @($_.Exception.Message)
+    }
+
+    foreach ($role in @($rootRoles.value | Sort-Object name, roleid)) {
+        $roleName = [string]$role.name
+        if (-not (Test-ConvergenceStartsWithPrefix `
+                    -Value $roleName `
+                    -Prefix $rolePrefix)) {
+            continue
+        }
+
+        $roleId = [string]$role.roleid
+        if ([string]::IsNullOrWhiteSpace($roleId)) {
+            [void]$details.Add(
+                "Reverse inventory role '$roleName' returned no role ID."
+            )
+            continue
+        }
+
+        $membership = $null
+        try {
+            $membership = Invoke-DataverseRequest `
+                -Method GET `
+                -Path (Get-ConvergenceSolutionMembershipPath `
+                    -ComponentId $roleId)
+        }
+        catch {
+            if (Test-ConvergenceTransportError $_) {
+                throw
+            }
+
+            [void]$details.Add($_.Exception.Message)
+            continue
+        }
+
+        $solutionNames = @($membership.value | ForEach-Object {
+                if ($_.solutionid) {
+                    [string]$_.solutionid.uniquename
+                }
+            })
+        if (-not (Test-ConvergenceContainsExactString `
+                    -Value $solutionNames `
+                    -Expected 'crmshow_Foundation')) {
+            continue
+        }
+
+        if (-not (Test-ConvergenceContainsExactString `
+                    -Value @($expectedInventory.RolesBySolution['crmshow_Foundation']) `
+                    -Expected $roleName)) {
+            [void]$unexpected.Add("crmshow_Foundation/role/$roleName")
+            [void]$details.Add(
+                "Unexpected root role '$roleName' is owned by solution 'crmshow_Foundation' but is not listed in the contract."
+            )
+        }
+    }
+
+    foreach ($tableLogicalName in @($expectedInventory.ReviewedTables)) {
+        $tableInventory = $null
+        try {
+            $tableInventory = Invoke-DataverseRequest `
+                -Method GET `
+                -Path (Get-ConvergenceTableUnexpectedChildrenPath `
+                    -LogicalName $tableLogicalName `
+                    -PublisherPrefix $publisherPrefix)
+        }
+        catch {
+            if (Test-ConvergenceTransportError $_) {
+                throw
+            }
+
+            return New-ConvergenceResult `
+                -Component $component `
+                -State 'ContractConflict' `
+                -Details @($_.Exception.Message)
+        }
+
+        if ($null -eq $tableInventory) {
+            continue
+        }
+
+        $primaryIdAttribute = [string]$tableInventory.PrimaryIdAttribute
+        foreach ($attribute in @($tableInventory.Attributes | Sort-Object LogicalName, SchemaName)) {
+            if (-not (Test-ConvergenceUnexpectedAttributeCandidate `
+                        -Attribute $attribute `
+                        -PrimaryIdAttribute $primaryIdAttribute `
+                        -PublisherPrefix $publisherPrefix)) {
+                continue
+            }
+
+            $logicalName = [string]$attribute.LogicalName
+            if (-not (Test-ConvergenceContainsExactString `
+                        -Value @($expectedInventory.ColumnsByTable[$tableLogicalName]) `
+                        -Expected $logicalName)) {
+                [void]$unexpected.Add("$tableLogicalName/column/$logicalName")
+                [void]$details.Add(
+                    "Unexpected custom column '$logicalName' exists on '$tableLogicalName' but is not listed in the contract."
+                )
+            }
+        }
+
+        foreach ($relationship in @($tableInventory.ManyToOneRelationships |
+                    Sort-Object SchemaName, ReferencingAttribute)) {
+            if (-not (Test-ConvergenceUnexpectedRelationshipCandidate `
+                        -Relationship $relationship `
+                        -PublisherPrefix $publisherPrefix)) {
+                continue
+            }
+
+            $schemaName = [string]$relationship.SchemaName
+            if (-not (Test-ConvergenceContainsExactString `
+                        -Value @($expectedInventory.RelationshipsByTable[$tableLogicalName]) `
+                        -Expected $schemaName)) {
+                [void]$unexpected.Add("$tableLogicalName/relationship/$schemaName")
+                [void]$details.Add(
+                    "Unexpected custom relationship '$schemaName' exists on '$tableLogicalName' but is not listed in the contract."
+                )
+            }
+        }
+
+        foreach ($key in @($tableInventory.Keys | Sort-Object SchemaName)) {
+            if (-not (Test-ConvergenceUnexpectedKeyCandidate `
+                        -Key $key `
+                        -PublisherPrefix $publisherPrefix)) {
+                continue
+            }
+
+            $schemaName = [string]$key.SchemaName
+            if (-not (Test-ConvergenceContainsExactString `
+                        -Value @($expectedInventory.KeysByTable[$tableLogicalName]) `
+                        -Expected $schemaName)) {
+                [void]$unexpected.Add("$tableLogicalName/key/$schemaName")
+                [void]$details.Add(
+                    "Unexpected custom alternate key '$schemaName' exists on '$tableLogicalName' but is not listed in the contract."
+                )
+            }
+        }
+    }
+
+    if ($unexpected.Count -eq 0 -and $details.Count -eq 0) {
+        return New-ConvergenceResult -Component $component -State 'Ready'
+    }
+
+    return New-ConvergenceResult `
+        -Component $component `
+        -State 'ContractConflict' `
+        -Unexpected @($unexpected) `
+        -Details @($details)
 }
 
 function Test-InsuranceFoundationRoles {
@@ -2338,6 +3379,12 @@ function Invoke-InsuranceFoundationConvergence {
             -EnvironmentUrl $EnvironmentUrl `
             -Contract $contract)
     )
+    [void]$results.Add(
+        (Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $contract `
+            -Manifest $manifest)
+    )
 
     return New-ConvergenceSummary -Results @($results)
 }
@@ -2359,6 +3406,8 @@ if ($MyInvocation.InvocationName -ne '.') {
             -ContractPath $ContractPath
         $result | ConvertTo-Json -Depth 50
 
+        # Exit 2 is deliberate for prerequisite gaps and tenant limitations,
+        # including GET-only UnsupportedInTenant classifications.
         switch ([string]$result.State) {
             'Ready' { exit 0 }
             'ManualPrerequisite' { exit 2 }

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -1,10 +1,12 @@
 <#
 .SYNOPSIS
-    Performs read-only verification of the reviewed Insurance Foundation roles.
+    Performs read-only structural verification of the reviewed Insurance Foundation roles.
 .DESCRIPTION
     Uses GET-only `az rest` requests against Dataverse v9.2 with the
-    environment URL resource. The verifier never mutates role metadata and is
-    safe to dot-source for testing.
+    environment URL resource. The verifier proves exact root-role identity,
+    solution membership, and declared privilege/depth structure without
+    mutating Dataverse. It does not retrieve localized role labels or
+    descriptions and is safe to dot-source for testing.
 #>
 [CmdletBinding()]
 param(
@@ -596,6 +598,23 @@ function Test-InsuranceSecurityRole {
             -State 'ContractConflict' `
             -Details @(
                 "Expected exactly one root security role named '$roleName', found $($matches.Count)."
+            )
+    }
+
+    $resolvedRoleName = [string]$matches[0].name
+    if (-not ($resolvedRoleName -ceq $roleName)) {
+        $resolvedRoleNameDetail = if ([string]::IsNullOrWhiteSpace($resolvedRoleName)) {
+            '<empty>'
+        }
+        else {
+            $resolvedRoleName
+        }
+
+        return New-InsuranceSecurityRoleResult `
+            -Role $roleName `
+            -State 'ContractConflict' `
+            -Details @(
+                "Root security role query for contract name '$roleName' returned name '$resolvedRoleNameDetail'; exact case-sensitive identity match is required."
             )
     }
 

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -81,6 +81,43 @@ function Get-InsuranceSecurityRoleSolutionMembershipPath {
     )
 }
 
+function Get-InsuranceRoleActualReviewedMembership {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Membership,
+
+        [Parameter(Mandatory)]
+        [object[]]$ReviewedSolutions
+    )
+
+    $solutionNames = @(Get-UniqueExactStrings -Value @($Membership.value | ForEach-Object {
+                if ($_.solutionid) {
+                    [string]$_.solutionid.uniquename
+                }
+            }))
+    return @($ReviewedSolutions | Where-Object {
+            Test-ContainsExactString `
+                -Value $solutionNames `
+                -Expected ([string]$_)
+        })
+}
+
+function Get-InsuranceRoleReviewedMembershipDisplayText {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$SolutionUniqueNames
+    )
+
+    $resolved = @(Get-UniqueExactStrings -Value $SolutionUniqueNames)
+    if ($resolved.Count -eq 0) {
+        return '<none>'
+    }
+
+    return ($resolved -join ', ')
+}
+
 function Get-InsuranceRoleEntityPrivilegesPath {
     [CmdletBinding()]
     param(
@@ -625,17 +662,31 @@ function Test-InsuranceSecurityRole {
         -Method GET `
         -EnvironmentUrl $EnvironmentUrl `
         -Path (Get-InsuranceSecurityRoleSolutionMembershipPath -RoleId $roleId)
-    $solutionNames = foreach ($entry in @($membershipResponse.value)) {
-        if ($null -ne $entry -and $entry.solutionid) {
-            [string]$entry.solutionid.uniquename
-        }
-    }
-    if (-not (Test-ContainsExactString -Value $solutionNames -Expected ([string]$Role.solution))) {
+    $expectedReviewedMembership = @([string]$Role.solution)
+    $actualReviewedMembership = @(Get-InsuranceRoleActualReviewedMembership `
+            -Membership $membershipResponse `
+            -ReviewedSolutions @($Contract.solutions))
+    $missingReviewedMembership = @($expectedReviewedMembership | Where-Object {
+            -not (Test-ContainsExactString `
+                -Value $actualReviewedMembership `
+                -Expected ([string]$_))
+        })
+    $unexpectedReviewedMembership = @($actualReviewedMembership | Where-Object {
+            -not (Test-ContainsExactString `
+                -Value $expectedReviewedMembership `
+                -Expected ([string]$_))
+        })
+    if ($missingReviewedMembership.Count -gt 0 -or
+        $unexpectedReviewedMembership.Count -gt 0) {
+        $expectedReviewedMembershipText = Get-InsuranceRoleReviewedMembershipDisplayText `
+            -SolutionUniqueNames $expectedReviewedMembership
+        $actualReviewedMembershipText = Get-InsuranceRoleReviewedMembershipDisplayText `
+            -SolutionUniqueNames $actualReviewedMembership
         return New-InsuranceSecurityRoleResult `
             -Role $roleName `
             -State 'ContractConflict' `
             -Details @(
-                "Role '$roleName' is not a member of solution '$([string]$Role.solution)'."
+                "Role '$roleName' reviewed-solution membership expected '$expectedReviewedMembershipText'; actual reviewed membership was '$actualReviewedMembershipText'."
             )
     }
 

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -1,0 +1,733 @@
+<#
+.SYNOPSIS
+    Performs read-only verification of the reviewed Insurance Foundation roles.
+.DESCRIPTION
+    Uses GET-only `az rest` requests against Dataverse v9.2 with the
+    environment URL resource. The verifier never mutates role metadata and is
+    safe to dot-source for testing.
+#>
+[CmdletBinding()]
+param(
+    [string]$EnvironmentUrl,
+    [string]$ContractPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-ODataStringLiteral {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    return $Value.Replace("'", "''")
+}
+
+function Get-ContractTableSchemaName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogicalName,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    switch ($LogicalName) {
+        'account' { return 'Account' }
+        'contact' { return 'Contact' }
+    }
+
+    $tables = @($Contract.tables | Where-Object logicalName -eq $LogicalName)
+    if ($tables.Count -ne 1 -or
+        [string]::IsNullOrWhiteSpace([string]$tables[0].schemaName)) {
+        throw "Cannot resolve the contract schema name for table '$LogicalName'."
+    }
+
+    return [string]$tables[0].schemaName
+}
+
+function Get-InsuranceSecurityRolePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RoleName
+    )
+
+    $escapedName = ConvertTo-ODataStringLiteral -Value $RoleName
+    return (
+        "/roles?`$select=roleid,name&" +
+        "`$filter=_parentrootroleid_value eq null and name eq '$escapedName'"
+    )
+}
+
+function Get-InsuranceSecurityRoleSolutionMembershipPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RoleId
+    )
+
+    $componentId = ([string]$RoleId).Trim('{}')
+    return (
+        "/solutioncomponents?`$select=solutioncomponentid&" +
+        "`$filter=objectid eq $componentId&" +
+        "`$expand=solutionid(`$select=uniquename)"
+    )
+}
+
+function Get-InsuranceRoleEntityPrivilegesPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogicalName
+    )
+
+    $escapedLogicalName = ConvertTo-ODataStringLiteral -Value $LogicalName
+    return (
+        "/EntityDefinitions(LogicalName='$escapedLogicalName')?" +
+        "`$select=LogicalName,SchemaName,Privileges"
+    )
+}
+
+function Get-InsuranceSecurityRolePrivilegesPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RoleId
+    )
+
+    $resolvedRoleId = ([string]$RoleId).Trim('{}')
+    return "/RetrieveRolePrivilegesRole(RoleId=$resolvedRoleId)"
+}
+
+function Invoke-InsuranceSecurityRoleDataverseRequest {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('GET')]
+        [string]$Method = 'GET',
+
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $url = if ($Path -match '^https://') {
+        $Path
+    }
+    else {
+        "$baseUrl/api/data/v9.2$Path"
+    }
+
+    $arguments = @(
+        'rest',
+        '--method', 'get',
+        '--url', $url,
+        '--resource', "$baseUrl/",
+        '--only-show-errors'
+    )
+
+    $output = & az @arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $detail = ($output | Out-String).Trim()
+        throw "Dataverse security-role verification failed (GET $Path); az rest exited with code $exitCode. $detail"
+    }
+
+    $text = ($output | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    return $text | ConvertFrom-Json -ErrorAction Stop
+}
+
+function Test-ContainsExactString {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value,
+
+        [Parameter(Mandatory)]
+        [string]$Expected
+    )
+
+    return @($Value | Where-Object {
+            [string]$_ -ceq $Expected
+        }).Count -gt 0
+}
+
+function Get-UniqueExactStrings {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Value
+    )
+
+    $unique = [System.Collections.Generic.List[string]]::new()
+    foreach ($item in @($Value)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $text = [string]$item
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        if (-not (Test-ContainsExactString -Value @($unique) -Expected $text)) {
+            [void]$unique.Add($text)
+        }
+    }
+
+    return @($unique)
+}
+
+function Get-DuplicateInsuranceRolePrivilegeNames {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Privileges
+    )
+
+    $seen = [System.Collections.Generic.List[string]]::new()
+    $duplicates = [System.Collections.Generic.List[string]]::new()
+    foreach ($privilege in @($Privileges)) {
+        if ($null -eq $privilege) {
+            continue
+        }
+
+        $name = [string]$privilege.Name
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            continue
+        }
+
+        if (Test-ContainsExactString -Value @($seen) -Expected $name) {
+            if (-not (Test-ContainsExactString -Value @($duplicates) -Expected $name)) {
+                [void]$duplicates.Add($name)
+            }
+            continue
+        }
+
+        [void]$seen.Add($name)
+    }
+
+    return @($duplicates)
+}
+
+function New-InsuranceSecurityRoleResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Role,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Ready', 'ManualPrerequisite', 'ContractConflict')]
+        [string]$State,
+
+        [AllowNull()]
+        [object[]]$Missing = @(),
+
+        [AllowNull()]
+        [object[]]$Unexpected = @(),
+
+        [AllowNull()]
+        [object[]]$WrongDepth = @(),
+
+        [AllowNull()]
+        [object[]]$DuplicateExpected = @(),
+
+        [AllowNull()]
+        [object[]]$DuplicateActual = @(),
+
+        [AllowNull()]
+        [object[]]$Details = @()
+    )
+
+    return [pscustomobject][ordered]@{
+        Role = $Role
+        State = $State
+        Missing = @(Get-UniqueExactStrings -Value $Missing)
+        Unexpected = @(Get-UniqueExactStrings -Value $Unexpected)
+        WrongDepth = @($WrongDepth)
+        DuplicateExpected = @(Get-UniqueExactStrings -Value $DuplicateExpected)
+        DuplicateActual = @(Get-UniqueExactStrings -Value $DuplicateActual)
+        Details = @($Details | Where-Object {
+                -not [string]::IsNullOrWhiteSpace([string]$_)
+            })
+    }
+}
+
+function Get-InsuranceRoleRequestedPrivilegeVerbs {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Role
+    )
+
+    $verbs = foreach ($tablePrivilege in @($Role.tablePrivileges)) {
+        foreach ($verb in @($tablePrivilege.privileges)) {
+            [string]$verb
+        }
+    }
+
+    return @(Get-UniqueExactStrings -Value $verbs)
+}
+
+function Get-OverlappingInsuranceRolePrivilegeVerbs {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Role
+    )
+
+    $requestedVerbs = @(Get-InsuranceRoleRequestedPrivilegeVerbs -Role $Role)
+    $overlap = foreach ($denied in @($Role.deniedPrivileges)) {
+        $verb = [string]$denied
+        if (Test-ContainsExactString -Value $requestedVerbs -Expected $verb) {
+            $verb
+        }
+    }
+
+    return @(Get-UniqueExactStrings -Value $overlap)
+}
+
+function Get-InsuranceDataversePrivilegeDepth {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ContractDepth
+    )
+
+    switch ($ContractDepth) {
+        'Organization' { return 'Global' }
+        default { return $null }
+    }
+}
+
+function Normalize-InsuranceRolePrivilegeCollection {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Privileges
+    )
+
+    $normalized = foreach ($privilege in @($Privileges)) {
+        if ($null -eq $privilege) {
+            continue
+        }
+
+        $name = $null
+        foreach ($propertyName in @('Name', 'PrivilegeName')) {
+            $property = $privilege.PSObject.Properties[$propertyName]
+            if ($null -ne $property) {
+                $name = [string]$property.Value
+                break
+            }
+        }
+
+        $privilegeId = $null
+        foreach ($propertyName in @('PrivilegeId', 'privilegeid')) {
+            $property = $privilege.PSObject.Properties[$propertyName]
+            if ($null -ne $property) {
+                $privilegeId = [string]$property.Value
+                break
+            }
+        }
+
+        $depth = $null
+        $depthProperty = $privilege.PSObject.Properties['Depth']
+        if ($null -ne $depthProperty) {
+            $depth = [string]$depthProperty.Value
+        }
+
+        [pscustomobject]@{
+            Name = if ($null -eq $name) { '' } else { $name.Trim() }
+            PrivilegeId = if ($null -eq $privilegeId) { '' } else { $privilegeId.Trim() }
+            Depth = if ($null -eq $depth) { '' } else { $depth.Trim() }
+        }
+    }
+
+    return @($normalized)
+}
+
+function Compare-InsuranceRolePrivileges {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RoleName,
+
+        [AllowNull()]
+        [object[]]$Expected = @(),
+
+        [AllowNull()]
+        [object[]]$Actual = @()
+    )
+
+    $expectedItems = @(Normalize-InsuranceRolePrivilegeCollection -Privileges $Expected)
+    $actualItems = @(Normalize-InsuranceRolePrivilegeCollection -Privileges $Actual)
+
+    $duplicateExpected = @(Get-DuplicateInsuranceRolePrivilegeNames -Privileges $expectedItems)
+    $duplicateActual = @(Get-DuplicateInsuranceRolePrivilegeNames -Privileges $actualItems)
+
+    $missing = foreach ($name in @(Get-UniqueExactStrings -Value @($expectedItems.Name))) {
+        if (-not (Test-ContainsExactString -Value @($actualItems.Name) -Expected $name)) {
+            $name
+        }
+    }
+
+    $unexpected = foreach ($name in @(Get-UniqueExactStrings -Value @($actualItems.Name))) {
+        if (-not (Test-ContainsExactString -Value @($expectedItems.Name) -Expected $name)) {
+            $name
+        }
+    }
+
+    $wrongDepth = foreach ($name in @(Get-UniqueExactStrings -Value @($expectedItems.Name))) {
+        $expectedMatches = @($expectedItems | Where-Object {
+                [string]$_.Name -ceq $name
+            })
+        $actualMatches = @($actualItems | Where-Object {
+                [string]$_.Name -ceq $name
+            })
+
+        if ($expectedMatches.Count -ne 1 -or $actualMatches.Count -ne 1) {
+            continue
+        }
+
+        if ([string]$actualMatches[0].Depth -cne [string]$expectedMatches[0].Depth) {
+            [pscustomobject]@{
+                Name = [string]$expectedMatches[0].Name
+                ExpectedDepth = [string]$expectedMatches[0].Depth
+                ActualDepth = [string]$actualMatches[0].Depth
+            }
+        }
+    }
+
+    $state = if (@($missing).Count -eq 0 -and
+        @($unexpected).Count -eq 0 -and
+        @($wrongDepth).Count -eq 0 -and
+        $duplicateExpected.Count -eq 0 -and
+        $duplicateActual.Count -eq 0) {
+        'Ready'
+    }
+    else {
+        'ContractConflict'
+    }
+
+    return New-InsuranceSecurityRoleResult `
+        -Role $RoleName `
+        -State $state `
+        -Missing $missing `
+        -Unexpected $unexpected `
+        -WrongDepth $wrongDepth `
+        -DuplicateExpected $duplicateExpected `
+        -DuplicateActual $duplicateActual
+}
+
+function Resolve-InsuranceRoleExpectedPrivileges {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Role,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    $expected = [System.Collections.Generic.List[object]]::new()
+    foreach ($tablePrivilege in @($Role.tablePrivileges)) {
+        $logicalName = [string]$tablePrivilege.table
+        $requestedDepth = [string]$tablePrivilege.depth
+        $depth = Get-InsuranceDataversePrivilegeDepth -ContractDepth $requestedDepth
+        if ([string]::IsNullOrWhiteSpace($depth)) {
+            return [pscustomobject]@{
+                State = 'ContractConflict'
+                Details = @(
+                    "Unsupported contract privilege depth '$requestedDepth' for role '$($Role.name)' table '$logicalName'."
+                )
+                Expected = @()
+            }
+        }
+
+        try {
+            $schemaName = Get-ContractTableSchemaName -LogicalName $logicalName -Contract $Contract
+        }
+        catch {
+            return [pscustomobject]@{
+                State = 'ContractConflict'
+                Details = @($_.Exception.Message)
+                Expected = @()
+            }
+        }
+
+        $entityMetadata = Invoke-InsuranceSecurityRoleDataverseRequest `
+            -Method GET `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Path (Get-InsuranceRoleEntityPrivilegesPath -LogicalName $logicalName)
+        if ($null -eq $entityMetadata -or
+            [string]$entityMetadata.SchemaName -cne $schemaName) {
+            return [pscustomobject]@{
+                State = 'ContractConflict'
+                Details = @(
+                    "Dataverse metadata for table '$logicalName' did not return contract schema name '$schemaName'."
+                )
+                Expected = @()
+            }
+        }
+
+        foreach ($verb in @($tablePrivilege.privileges)) {
+            $exactName = "prv$verb$schemaName"
+            $matches = @($entityMetadata.Privileges | Where-Object {
+                    [string]$_.Name -ceq $exactName
+                })
+            if ($matches.Count -ne 1 -or
+                [string]::IsNullOrWhiteSpace([string]$matches[0].PrivilegeId)) {
+                return [pscustomobject]@{
+                    State = 'ContractConflict'
+                    Details = @(
+                        "Required Dataverse privilege '$exactName' was not found in metadata for '$logicalName'."
+                    )
+                    Expected = @()
+                }
+            }
+
+            [void]$expected.Add([pscustomobject]@{
+                    Name = [string]$matches[0].Name
+                    PrivilegeId = [string]$matches[0].PrivilegeId
+                    Depth = $depth
+                })
+        }
+    }
+
+    return [pscustomobject]@{
+        State = 'Ready'
+        Details = @()
+        Expected = @($expected)
+    }
+}
+
+function Get-InsuranceRoleConflictDetails {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Comparison
+    )
+
+    $details = [System.Collections.Generic.List[string]]::new()
+    if (@($Comparison.DuplicateExpected).Count -gt 0) {
+        [void]$details.Add(
+            "Expected privileges resolved with duplicate names: $(@($Comparison.DuplicateExpected) -join ', ')."
+        )
+    }
+    if (@($Comparison.DuplicateActual).Count -gt 0) {
+        [void]$details.Add(
+            "Actual role '$($Comparison.Role)' contains duplicate privilege names: $(@($Comparison.DuplicateActual) -join ', ')."
+        )
+    }
+    if (@($Comparison.Missing).Count -gt 0) {
+        [void]$details.Add(
+            "Missing privileges: $(@($Comparison.Missing) -join ', ')."
+        )
+    }
+    if (@($Comparison.Unexpected).Count -gt 0) {
+        [void]$details.Add(
+            "Unexpected privileges: $(@($Comparison.Unexpected) -join ', ')."
+        )
+    }
+    foreach ($entry in @($Comparison.WrongDepth)) {
+        [void]$details.Add(
+            "Privilege '$($entry.Name)' depth mismatch: expected '$($entry.ExpectedDepth)', actual '$($entry.ActualDepth)'."
+        )
+    }
+
+    return @($details)
+}
+
+function Test-InsuranceSecurityRole {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Role,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    $roleName = [string]$Role.name
+    $overlap = @(Get-OverlappingInsuranceRolePrivilegeVerbs -Role $Role)
+    if ($overlap.Count -gt 0) {
+        return New-InsuranceSecurityRoleResult `
+            -Role $roleName `
+            -State 'ContractConflict' `
+            -Details @(
+                "Role '$roleName' deniedPrivileges overlap requested privilege verbs: $($overlap -join ', ')."
+            )
+    }
+
+    $roleResponse = Invoke-InsuranceSecurityRoleDataverseRequest `
+        -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-InsuranceSecurityRolePath -RoleName $roleName)
+    $matches = @()
+    if ($null -ne $roleResponse) {
+        $matches = @($roleResponse.value)
+    }
+
+    if ($matches.Count -eq 0) {
+        return New-InsuranceSecurityRoleResult `
+            -Role $roleName `
+            -State 'ManualPrerequisite' `
+            -Details @("Root security role '$roleName' was not found.")
+    }
+
+    if ($matches.Count -gt 1) {
+        return New-InsuranceSecurityRoleResult `
+            -Role $roleName `
+            -State 'ContractConflict' `
+            -Details @(
+                "Expected exactly one root security role named '$roleName', found $($matches.Count)."
+            )
+    }
+
+    $roleId = [string]$matches[0].roleid
+    $membershipResponse = Invoke-InsuranceSecurityRoleDataverseRequest `
+        -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-InsuranceSecurityRoleSolutionMembershipPath -RoleId $roleId)
+    $solutionNames = foreach ($entry in @($membershipResponse.value)) {
+        if ($null -ne $entry -and $entry.solutionid) {
+            [string]$entry.solutionid.uniquename
+        }
+    }
+    if (-not (Test-ContainsExactString -Value $solutionNames -Expected ([string]$Role.solution))) {
+        return New-InsuranceSecurityRoleResult `
+            -Role $roleName `
+            -State 'ContractConflict' `
+            -Details @(
+                "Role '$roleName' is not a member of solution '$([string]$Role.solution)'."
+            )
+    }
+
+    $expectedResolution = Resolve-InsuranceRoleExpectedPrivileges `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Role $Role `
+        -Contract $Contract
+    if ($expectedResolution.State -ne 'Ready') {
+        return New-InsuranceSecurityRoleResult `
+            -Role $roleName `
+            -State 'ContractConflict' `
+            -Details $expectedResolution.Details
+    }
+
+    $actualResponse = Invoke-InsuranceSecurityRoleDataverseRequest `
+        -Method GET `
+        -EnvironmentUrl $EnvironmentUrl `
+        -Path (Get-InsuranceSecurityRolePrivilegesPath -RoleId $roleId)
+    $actual = @()
+    if ($null -ne $actualResponse -and
+        $actualResponse.PSObject.Properties.Name -contains 'RolePrivileges') {
+        $actual = @(Normalize-InsuranceRolePrivilegeCollection -Privileges @(
+                $actualResponse.RolePrivileges
+            ))
+    }
+
+    $comparison = Compare-InsuranceRolePrivileges `
+        -RoleName $roleName `
+        -Expected $expectedResolution.Expected `
+        -Actual $actual
+    if ($comparison.State -eq 'Ready') {
+        return $comparison
+    }
+
+    return New-InsuranceSecurityRoleResult `
+        -Role $comparison.Role `
+        -State $comparison.State `
+        -Missing $comparison.Missing `
+        -Unexpected $comparison.Unexpected `
+        -WrongDepth $comparison.WrongDepth `
+        -DuplicateExpected $comparison.DuplicateExpected `
+        -DuplicateActual $comparison.DuplicateActual `
+        -Details (Get-InsuranceRoleConflictDetails -Comparison $comparison)
+}
+
+function Get-InsuranceSecurityRolesOverallState {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object[]]$Results = @()
+    )
+
+    if (@($Results | Where-Object State -eq 'ManualPrerequisite').Count -gt 0) {
+        return 'ManualPrerequisite'
+    }
+    if (@($Results | Where-Object State -ne 'Ready').Count -gt 0) {
+        return 'ContractConflict'
+    }
+
+    return 'Ready'
+}
+
+function Invoke-InsuranceSecurityRoleVerification {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$EnvironmentUrl,
+
+        [Parameter(Mandatory)]
+        $Contract
+    )
+
+    $results = foreach ($role in @($Contract.roles)) {
+        Test-InsuranceSecurityRole `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Role $role `
+            -Contract $Contract
+    }
+
+    return [pscustomobject][ordered]@{
+        State = Get-InsuranceSecurityRolesOverallState -Results @($results)
+        MutationOccurred = $false
+        Results = @($results)
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        if ([string]::IsNullOrWhiteSpace($EnvironmentUrl)) {
+            throw 'EnvironmentUrl is required.'
+        }
+        if ([string]::IsNullOrWhiteSpace($ContractPath)) {
+            throw 'ContractPath is required.'
+        }
+        if (-not (Test-Path -LiteralPath $ContractPath -PathType Leaf)) {
+            throw "ContractPath was not found: $ContractPath"
+        }
+
+        $contract = Get-Content -LiteralPath $ContractPath -Raw -Encoding UTF8 |
+            ConvertFrom-Json -ErrorAction Stop
+        $result = Invoke-InsuranceSecurityRoleVerification `
+            -EnvironmentUrl $EnvironmentUrl `
+            -Contract $contract
+        $result | ConvertTo-Json -Depth 20
+
+        if ($result.State -eq 'Ready') {
+            exit 0
+        }
+
+        exit 2
+    }
+    catch {
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -14,6 +14,8 @@ param(
     [string]$ContractPath
 )
 
+. (Join-Path $PSScriptRoot 'ConvertTo-SafeCliDiagnosticLine.ps1')
+
 $ErrorActionPreference = 'Stop'
 
 function ConvertTo-ODataStringLiteral {
@@ -136,8 +138,8 @@ function Invoke-InsuranceSecurityRoleDataverseRequest {
     $output = & az @arguments 2>&1
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
-        $detail = ($output | Out-String).Trim()
-        throw "Dataverse security-role verification failed (GET $Path); az rest exited with code $exitCode. $detail"
+        $detail = ConvertTo-SafeCliDiagnosticLine -Value $output
+        throw "Dataverse security-role verification failed (GET $Path); az rest exited with code $exitCode. Output: $detail"
     }
 
     $text = ($output | Out-String).Trim()
@@ -746,7 +748,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         exit 2
     }
     catch {
-        Write-Error $_
+        Write-SafeCliErrorLine -ErrorRecord $_
         exit 1
     }
 }

--- a/scripts/solution/tests/ConvertTo-SafeCliDiagnosticLine.Tests.ps1
+++ b/scripts/solution/tests/ConvertTo-SafeCliDiagnosticLine.Tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    . "$PSScriptRoot/../ConvertTo-SafeCliDiagnosticLine.ps1"
+
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+}
+
+Describe 'ConvertTo-SafeCliDiagnosticLine' {
+    It 'collapses hostile CLI text into one readable safe line' {
+        $escape = [char]27
+        $input = (
+            "::warning::Heads up`r`nSecond`tline" +
+            [string][char]0 +
+            [string][char]0x1F +
+            [string][char]0x9F +
+            "$escape[31mRED$escape[0m"
+        )
+
+        $actual = ConvertTo-SafeCliDiagnosticLine -Value $input -MaxLength 200
+
+        script:Assert-SafeDiagnosticLine -Text $actual -MaxLength 200
+        $actual | Should -Match (
+            [regex]::Escape("'::warning::Heads up Second line RED")
+        )
+        $actual | Should -Not -Match '\[31m|\[0m'
+    }
+
+    It 'extracts exception text and preserves prefix, suffix, and the truncation marker' {
+        $payload = (
+            "::error::prefix " +
+            ('a' * 120) +
+            ' suffix-tail'
+        )
+        $exception = New-Object System.Exception($payload)
+
+        $actual = Get-SafeCliErrorMessage -ErrorRecord $exception -MaxLength 80
+
+        script:Assert-SafeDiagnosticLine -Text $actual -MaxLength 80
+        $actual | Should -Match ([regex]::Escape("'::error::prefix"))
+        $actual | Should -Match '\.\.\.\[truncated\]\.\.\.'
+        $actual | Should -Match 'suffix-tail$'
+    }
+
+    It 'returns the empty placeholder when output contains only controls and ANSI sequences' {
+        $escape = [char]27
+        $input = (
+            "`r`n`t" +
+            "$escape[31m$escape[0m" +
+            [string][char]0x07 +
+            ([string][char]0x9B + '31m')
+        )
+
+        ConvertTo-SafeCliDiagnosticLine -Value $input |
+            Should -Be '<no output>'
+    }
+}

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -127,6 +127,57 @@ exit 0
         )
     }
 
+    function script:Get-ContextDirectoryPaths {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Context
+        )
+
+        if (-not (Test-Path -LiteralPath $Context.RootPath -PathType Container)) {
+            return @()
+        }
+
+        return @(
+            Get-ChildItem -LiteralPath $Context.RootPath -Directory -Force |
+                ForEach-Object { $_.FullName } |
+                Sort-Object
+        )
+    }
+
+    function script:Get-DirectoryFileNames {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path
+        )
+
+        if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+            return @()
+        }
+
+        return @(
+            Get-ChildItem -LiteralPath $Path -File -Force |
+                ForEach-Object { $_.Name } |
+                Sort-Object
+        )
+    }
+
+    function script:Get-StagingDirectoryPaths {
+        [CmdletBinding()]
+        param(
+            [AllowNull()]
+            [object[]]$Invocations
+        )
+
+        return @(
+            @($Invocations) |
+                Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_.Path) } |
+                ForEach-Object { Split-Path -Path ([string]$_.Path) -Parent } |
+                Sort-Object -Unique
+        )
+    }
+
     function script:Invoke-ExportEntryScript {
         [CmdletBinding()]
         param(
@@ -186,8 +237,15 @@ exit 0
                 $arguments += '-WhatIf'
             }
 
-            $output = & $script:childPowerShellPath @arguments 2>&1
-            $exitCode = $LASTEXITCODE
+            $previousErrorActionPreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            try {
+                $output = & $script:childPowerShellPath @arguments 2>&1
+                $exitCode = $LASTEXITCODE
+            }
+            finally {
+                $ErrorActionPreference = $previousErrorActionPreference
+            }
         }
         finally {
             if ($null -eq $previousPacPath) {
@@ -377,8 +435,17 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
             -OutputDirectory $context.OutputDirectory
 
+        $invocations = @(script:Get-FakePacInvocations -LogPath $context.LogPath)
+        $stagingDirectories = @(script:Get-StagingDirectoryPaths -Invocations $invocations)
+
+        $stagingDirectories.Count | Should -Be 1
+        $stagingDirectory = $stagingDirectories[0]
+        $stagingDirectory | Should -Not -Be $context.OutputDirectory
+        (Split-Path -Path $stagingDirectory -Parent) |
+            Should -Be (Split-Path -Path $context.OutputDirectory -Parent)
+
         $actual = @(
-            script:Get-FakePacInvocations -LogPath $context.LogPath |
+            $invocations |
                 Sort-Object Path |
                 ForEach-Object { @($_.Arguments) -join '|' }
         )
@@ -388,7 +455,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
                     'solution', 'export',
                     '--environment', 'https://unit.crm.dynamics.com',
                     '--name', 'crmshow_DataModel',
-                    '--path', (Join-Path $context.OutputDirectory 'crmshow_DataModel.zip'),
+                    '--path', (Join-Path $stagingDirectory 'crmshow_DataModel.zip'),
                     '--managed', 'false',
                     '--overwrite'
                 ) -join '|'),
@@ -396,7 +463,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
                     'solution', 'export',
                     '--environment', 'https://unit.crm.dynamics.com',
                     '--name', 'crmshow_DataModel',
-                    '--path', (Join-Path $context.OutputDirectory 'crmshow_DataModel_managed.zip'),
+                    '--path', (Join-Path $stagingDirectory 'crmshow_DataModel_managed.zip'),
                     '--managed', 'true',
                     '--overwrite'
                 ) -join '|'),
@@ -404,7 +471,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
                     'solution', 'export',
                     '--environment', 'https://unit.crm.dynamics.com',
                     '--name', 'crmshow_Foundation',
-                    '--path', (Join-Path $context.OutputDirectory 'crmshow_Foundation.zip'),
+                    '--path', (Join-Path $stagingDirectory 'crmshow_Foundation.zip'),
                     '--managed', 'false',
                     '--overwrite'
                 ) -join '|'),
@@ -412,7 +479,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
                     'solution', 'export',
                     '--environment', 'https://unit.crm.dynamics.com',
                     '--name', 'crmshow_Foundation',
-                    '--path', (Join-Path $context.OutputDirectory 'crmshow_Foundation_managed.zip'),
+                    '--path', (Join-Path $stagingDirectory 'crmshow_Foundation_managed.zip'),
                     '--managed', 'true',
                     '--overwrite'
                 ) -join '|')
@@ -489,22 +556,39 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         } | Should -Throw '*did not produce package*crmshow_Foundation_managed.zip*'
     }
 
-    It 'rejects a preexisting unrelated file in the output directory' {
+    It 'rejects a preexisting nonempty target untouched and does not invoke pac' {
         $context = script:New-ExportTestContext
         script:New-FakePacCommand -Path $context.PacPath | Out-Null
         New-Item -ItemType Directory -Path $context.OutputDirectory -Force | Out-Null
         Set-Content -LiteralPath (Join-Path $context.OutputDirectory 'keep.txt') -Value 'x'
+        New-Item -ItemType Directory -Path (Join-Path $context.OutputDirectory 'keep-dir') -Force | Out-Null
 
         $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
         $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
 
-        {
+        $message = $null
+        try {
             Invoke-InsuranceFoundationPackageExport `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -OutputDirectory $context.OutputDirectory
-        } | Should -Throw '*already contains file*keep.txt*'
+            throw 'Expected output directory preflight to fail.'
+        }
+        catch {
+            $message = $_.Exception.Message
+        }
+
+        $message | Should -Match 'already contains item'
+        $message | Should -Match 'keep\.txt'
+        $message | Should -Match 'keep-dir'
 
         @(script:Get-FakePacInvocations -LogPath $context.LogPath).Count | Should -Be 0
+        $existingItems = @(
+            Get-ChildItem -LiteralPath $context.OutputDirectory -Force |
+                ForEach-Object { $_.Name }
+        )
+        $existingItems.Count | Should -Be 2
+        $existingItems | Should -Contain 'keep.txt'
+        $existingItems | Should -Contain 'keep-dir'
     }
 
     It 'runs successfully as a standalone entry point with a fake pac command' {
@@ -514,14 +598,62 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $invocation = script:Invoke-ExportEntryScript -Context $context
 
         $invocation.ExitCode | Should -Be 0
-        @(Get-ChildItem -LiteralPath $invocation.OutputDirectory -File | ForEach-Object Name |
-                Sort-Object) | Should -Be @(
+        $stagingDirectories = @(script:Get-StagingDirectoryPaths -Invocations $invocation.Invocations)
+
+        $stagingDirectories.Count | Should -Be 1
+        $stagingDirectories[0] | Should -Not -Be $invocation.OutputDirectory
+        (Split-Path -Path $stagingDirectories[0] -Parent) |
+            Should -Be (Split-Path -Path $invocation.OutputDirectory -Parent)
+        Test-Path -LiteralPath $stagingDirectories[0] | Should -BeFalse
+        @(script:Get-DirectoryFileNames -Path $invocation.OutputDirectory) | Should -Be @(
             'crmshow_DataModel.zip',
             'crmshow_DataModel_managed.zip',
             'crmshow_Foundation.zip',
             'crmshow_Foundation_managed.zip'
         )
+        @(script:Get-ContextDirectoryPaths -Context $context) | Should -Be @(
+            $invocation.OutputDirectory
+        )
         @($invocation.Invocations).Count | Should -Be 4
+    }
+
+    It 'fourth export failure leaves zero final files and cleans the staging directory' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -FailFile 'crmshow_DataModel_managed.zip'
+
+        $invocation.ExitCode | Should -Not -Be 0
+        $invocation.Output | Should -Match 'crmshow_DataModel_managed.zip'
+        $invocation.Output | Should -Match 'simulated export failure'
+        @($invocation.Invocations).Count | Should -Be 4
+
+        $stagingDirectories = @(script:Get-StagingDirectoryPaths -Invocations $invocation.Invocations)
+        $stagingDirectories.Count | Should -Be 1
+        Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $stagingDirectories[0] | Should -BeFalse
+        @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
+    }
+
+    It 'zero-byte validation failure leaves zero final files' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -ZeroByteFile 'crmshow_Foundation.zip'
+
+        $invocation.ExitCode | Should -Not -Be 0
+        $invocation.Output | Should -Match 'zero-byte package'
+        @($invocation.Invocations).Count | Should -Be 1
+
+        $stagingDirectories = @(script:Get-StagingDirectoryPaths -Invocations $invocation.Invocations)
+        $stagingDirectories.Count | Should -Be 1
+        Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $stagingDirectories[0] | Should -BeFalse
+        @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
     }
 
     It 'does not invoke pac or fail a final package assertion when run with WhatIf' {
@@ -533,6 +665,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $invocation.ExitCode | Should -Be 0
         @($invocation.Invocations).Count | Should -Be 0
         Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
+        @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
         $invocation.Output | Should -Not -Match 'Unexpected authored package set'
     }
 
@@ -550,6 +683,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
 
         @(script:Get-FakePacInvocations -LogPath $context.LogPath).Count | Should -Be 0
         Test-Path -LiteralPath $context.OutputDirectory | Should -BeFalse
+        @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
     }
 }
 
@@ -587,5 +721,55 @@ function pac { throw 'pac was called' }
             Replace('__OUTPUT__', $outputDirectory.Replace("'", "''"))
 
         & ([scriptblock]::Create($text))
+    }
+
+    It 'uses only literal-path Remove-Item calls without wildcard arguments' {
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:exportScriptPath,
+            [ref]$tokens,
+            [ref]$errors
+        )
+
+        @($errors) | Should -BeNullOrEmpty
+
+        $removeItemCalls = @(
+            $ast.FindAll({
+                    param($node)
+
+                    $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -eq 'Remove-Item'
+                }, $true)
+        )
+
+        $removeItemCalls.Count | Should -BeGreaterThan 0
+
+        foreach ($call in $removeItemCalls) {
+            $parameters = @(
+                $call.CommandElements |
+                    Where-Object {
+                        $_ -is [System.Management.Automation.Language.CommandParameterAst]
+                    }
+            )
+
+            @($parameters | Where-Object { $_.ParameterName -eq 'Path' }).Count |
+                Should -Be 0
+            @($parameters | Where-Object { $_.ParameterName -eq 'LiteralPath' }).Count |
+                Should -BeGreaterThan 0
+
+            $argumentValues = @(
+                $call.CommandElements |
+                    Select-Object -Skip 1 |
+                    Where-Object {
+                        $_ -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
+                        $_ -is [System.Management.Automation.Language.ExpandableStringExpressionAst]
+                    } |
+                    ForEach-Object { $_.Value }
+            )
+
+            @($argumentValues | Where-Object { $_ -match '[\*\?]' }) |
+                Should -BeNullOrEmpty
+        }
     }
 }

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -373,7 +373,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
         $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
 
-        & $script:exportScriptPath `
+        Invoke-InsuranceFoundationPackageExport `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
             -OutputDirectory $context.OutputDirectory
 
@@ -421,6 +421,29 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $actual | Should -Be $expected
     }
 
+    It 'calls the export helper only after approval is granted' {
+        $outputDirectory = Join-Path (Get-PSDrive -Name TestDrive).Root 'approval-gate'
+
+        Mock Invoke-InsuranceFoundationPackageExport {}
+
+        Invoke-InsuranceFoundationPackageExportEntry `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -OutputDirectory $outputDirectory `
+            -ApprovalGranted:$false
+
+        Should -Invoke Invoke-InsuranceFoundationPackageExport -Times 0 -Exactly
+
+        Invoke-InsuranceFoundationPackageExportEntry `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -OutputDirectory $outputDirectory `
+            -ApprovalGranted:$true
+
+        Should -Invoke Invoke-InsuranceFoundationPackageExport -Times 1 -Exactly -ParameterFilter {
+            $EnvironmentUrl -eq 'https://unit.crm.dynamics.com' -and
+            $OutputDirectory -eq $outputDirectory
+        }
+    }
+
     It 'includes the package file name and CLI output when an export fails' {
         $context = script:New-ExportTestContext
         script:New-FakePacCommand -Path $context.PacPath | Out-Null
@@ -430,7 +453,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $env:TEST_EXPORT_PAC_FAIL_FILE = 'crmshow_DataModel_managed.zip'
 
         {
-            & $script:exportScriptPath `
+            Invoke-InsuranceFoundationPackageExport `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -OutputDirectory $context.OutputDirectory
         } | Should -Throw '*crmshow_DataModel_managed.zip*simulated export failure*'
@@ -445,7 +468,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE = 'crmshow_Foundation.zip'
 
         {
-            & $script:exportScriptPath `
+            Invoke-InsuranceFoundationPackageExport `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -OutputDirectory $context.OutputDirectory
         } | Should -Throw '*zero-byte package*crmshow_Foundation.zip*'
@@ -460,7 +483,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $env:TEST_EXPORT_PAC_SKIP_FILE = 'crmshow_Foundation_managed.zip'
 
         {
-            & $script:exportScriptPath `
+            Invoke-InsuranceFoundationPackageExport `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -OutputDirectory $context.OutputDirectory
         } | Should -Throw '*did not produce package*crmshow_Foundation_managed.zip*'
@@ -476,7 +499,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
 
         {
-            & $script:exportScriptPath `
+            Invoke-InsuranceFoundationPackageExport `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -OutputDirectory $context.OutputDirectory
         } | Should -Throw '*already contains file*keep.txt*'
@@ -512,9 +535,49 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
         $invocation.Output | Should -Not -Match 'Unexpected authored package set'
     }
+
+    It 'declined approval performs no exports and leaves the output directory empty' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
+        $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
+
+        Invoke-InsuranceFoundationPackageExportEntry `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -OutputDirectory $context.OutputDirectory `
+            -ApprovalGranted:$false
+
+        @(script:Get-FakePacInvocations -LogPath $context.LogPath).Count | Should -Be 0
+        Test-Path -LiteralPath $context.OutputDirectory | Should -BeFalse
+    }
 }
 
 Describe 'Export package script safety' {
+    It 'contains exactly one ShouldProcess approval gate' {
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:exportScriptPath,
+            [ref]$tokens,
+            [ref]$errors
+        )
+
+        @($errors) | Should -BeNullOrEmpty
+
+        $shouldProcessCalls = @(
+            $ast.FindAll({
+                    param($node)
+
+                    $node -is [System.Management.Automation.Language.InvokeMemberExpressionAst] -and
+                    $node.Member -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+                    $node.Member.Value -eq 'ShouldProcess'
+                }, $true)
+        )
+
+        $shouldProcessCalls.Count | Should -Be 1
+    }
+
     It 'does not invoke pac when dot-sourced' {
         $outputDirectory = Join-Path (Get-PSDrive -Name TestDrive).Root 'dot-source-only'
         $text = @'

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -26,6 +26,31 @@ BeforeAll {
         $Text.Length | Should -BeLessThan ($MaxLength + 1)
     }
 
+    function script:Get-OrdinalSortedStrings {
+        [CmdletBinding()]
+        param(
+            [AllowNull()]
+            [object[]]$Values
+        )
+
+        $items = [System.Collections.Generic.List[string]]::new()
+        foreach ($value in @($Values)) {
+            if ($null -eq $value) {
+                $items.Add($null) | Out-Null
+                continue
+            }
+
+            $items.Add([string]$value) | Out-Null
+        }
+
+        $sorted = $items.ToArray()
+        if ($sorted.Length -gt 1) {
+            [Array]::Sort($sorted, [System.StringComparer]::Ordinal)
+        }
+
+        return $sorted
+    }
+
     function script:New-ExportTestContext {
         [CmdletBinding()]
         param()
@@ -165,9 +190,10 @@ exit 0
         }
 
         return @(
-            Get-ChildItem -LiteralPath $Context.RootPath -Directory -Force |
-                ForEach-Object { $_.FullName } |
-                Sort-Object
+            script:Get-OrdinalSortedStrings -Values @(
+                Get-ChildItem -LiteralPath $Context.RootPath -Directory -Force |
+                    ForEach-Object { $_.FullName }
+            )
         )
     }
 
@@ -183,9 +209,10 @@ exit 0
         }
 
         return @(
-            Get-ChildItem -LiteralPath $Path -File -Force |
-                ForEach-Object { $_.Name } |
-                Sort-Object
+            script:Get-OrdinalSortedStrings -Values @(
+                Get-ChildItem -LiteralPath $Path -File -Force |
+                    ForEach-Object { $_.Name }
+            )
         )
     }
 
@@ -196,12 +223,20 @@ exit 0
             [object[]]$Invocations
         )
 
-        return @(
-            @($Invocations) |
-                Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_.Path) } |
-                ForEach-Object { Split-Path -Path ([string]$_.Path) -Parent } |
-                Sort-Object -Unique
+        $paths = New-Object 'System.Collections.Generic.HashSet[string]' (
+            [System.StringComparer]::Ordinal
         )
+
+        foreach ($invocation in @($Invocations)) {
+            $path = [string]$invocation.Path
+            if ([string]::IsNullOrWhiteSpace($path)) {
+                continue
+            }
+
+            $null = $paths.Add((Split-Path -Path $path -Parent))
+        }
+
+        return @(script:Get-OrdinalSortedStrings -Values @($paths))
     }
 
     function script:Invoke-ExportEntryScript {
@@ -354,13 +389,12 @@ exit 0
 
 Describe 'Get-InsuranceFoundationExports' {
     It 'returns exactly the four reviewed package definitions' {
-        $definitions = @(
+        $definitions = @(script:Get-OrdinalSortedStrings -Values @(
             Get-InsuranceFoundationExports |
-                Sort-Object File |
                 ForEach-Object {
                     '{0}|{1}|{2}' -f $_.Name, $_.Managed.ToString().ToLowerInvariant(), $_.File
                 }
-        )
+        ))
 
         $definitions | Should -Be @(
             'crmshow_DataModel|false|crmshow_DataModel.zip',
@@ -548,13 +582,12 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         (Split-Path -Path $stagingDirectory -Parent) |
             Should -Be (Split-Path -Path $context.OutputDirectory -Parent)
 
-        $actual = @(
+        $actual = @(script:Get-OrdinalSortedStrings -Values @(
             $invocations |
-                Sort-Object Path |
                 ForEach-Object { @($_.Arguments) -join '|' }
-        )
+        ))
 
-        $expected = @(
+        $expected = @(script:Get-OrdinalSortedStrings -Values @(
             (@(
                     'solution', 'export',
                     '--environment', 'https://unit.crm.dynamics.com',
@@ -587,7 +620,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
                     '--managed', 'true',
                     '--overwrite'
                 ) -join '|')
-        ) | Sort-Object
+        ))
 
         $actual | Should -Be $expected
     }
@@ -711,9 +744,10 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         @($invocation.Invocations).Count | Should -Be 0
 
         $existingItems = @(
-            Get-ChildItem -LiteralPath $context.OutputDirectory -Force |
-                ForEach-Object { $_.Name } |
-                Sort-Object
+            script:Get-OrdinalSortedStrings -Values @(
+                Get-ChildItem -LiteralPath $context.OutputDirectory -Force |
+                    ForEach-Object { $_.Name }
+            )
         )
         $existingItems.Count | Should -Be 2
         $existingItems | Should -Contain 'keep.txt'
@@ -783,9 +817,10 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
         $invocation.Output | Should -Match 'pac solution export failed'
         $invocation.Output | Should -Match 'crmshow_DataModel_managed\.zip'
+        $invocation.Output | Should -Match 'Output:'
         $invocation.Output | Should -Match (
             [regex]::Escape(
-                "Output: '::warning::export transport Permission denied blocked"
+                '::warning::export transport Permission denied blocked'
             )
         )
         $invocation.Output | Should -Not -Match 'At line:|--environment|--name|--path'

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -591,6 +591,31 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $existingItems | Should -Contain 'keep-dir'
     }
 
+    It 'fails WhatIf target preflight against a nonempty target and does not invoke pac' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+        New-Item -ItemType Directory -Path $context.OutputDirectory -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $context.OutputDirectory 'keep.txt') -Value 'x'
+        New-Item -ItemType Directory -Path (Join-Path $context.OutputDirectory 'keep-dir') -Force | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript -Context $context -WhatIf
+
+        $invocation.ExitCode | Should -Not -Be 0
+        $invocation.Output | Should -Match 'already contains item'
+        $invocation.Output | Should -Match 'keep\.txt'
+        $invocation.Output | Should -Match 'keep-dir'
+        @($invocation.Invocations).Count | Should -Be 0
+
+        $existingItems = @(
+            Get-ChildItem -LiteralPath $context.OutputDirectory -Force |
+                ForEach-Object { $_.Name } |
+                Sort-Object
+        )
+        $existingItems.Count | Should -Be 2
+        $existingItems | Should -Contain 'keep.txt'
+        $existingItems | Should -Contain 'keep-dir'
+    }
+
     It 'runs successfully as a standalone entry point with a fake pac command' {
         $context = script:New-ExportTestContext
         script:New-FakePacCommand -Path $context.PacPath | Out-Null
@@ -656,8 +681,50 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
     }
 
+    It 'removes a freshly created output parent after a nested failure' {
+        $context = script:New-ExportTestContext
+        $outputParent = Join-Path $context.RootPath 'fresh-parent'
+        $context.OutputDirectory = Join-Path $outputParent 'out'
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -FailFile 'crmshow_DataModel_managed.zip'
+
+        $invocation.ExitCode | Should -Not -Be 0
+        $invocation.Output | Should -Match 'crmshow_DataModel_managed.zip'
+        $invocation.Output | Should -Match 'simulated export failure'
+        @($invocation.Invocations).Count | Should -Be 4
+        Test-Path -LiteralPath $context.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $outputParent | Should -BeFalse
+        @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
+    }
+
+    It 'preserves a pre-existing empty output parent after failure' {
+        $context = script:New-ExportTestContext
+        $outputParent = Join-Path $context.RootPath 'existing-parent'
+        $null = New-Item -ItemType Directory -Path $outputParent -Force
+        $context.OutputDirectory = Join-Path $outputParent 'out'
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -FailFile 'crmshow_DataModel_managed.zip'
+
+        $invocation.ExitCode | Should -Not -Be 0
+        @($invocation.Invocations).Count | Should -Be 4
+        Test-Path -LiteralPath $context.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $outputParent | Should -BeTrue
+        @(Get-ChildItem -LiteralPath $outputParent -Force).Count | Should -Be 0
+        @(script:Get-ContextDirectoryPaths -Context $context) | Should -Be @(
+            $outputParent
+        )
+    }
+
     It 'does not invoke pac or fail a final package assertion when run with WhatIf' {
         $context = script:New-ExportTestContext
+        $outputParent = Join-Path $context.RootPath 'whatif-parent'
+        $context.OutputDirectory = Join-Path $outputParent 'out'
         script:New-FakePacCommand -Path $context.PacPath | Out-Null
 
         $invocation = script:Invoke-ExportEntryScript -Context $context -WhatIf
@@ -665,6 +732,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $invocation.ExitCode | Should -Be 0
         @($invocation.Invocations).Count | Should -Be 0
         Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $outputParent | Should -BeFalse
         @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
         $invocation.Output | Should -Not -Match 'Unexpected authored package set'
     }

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -1,0 +1,528 @@
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:exportScriptPath = Join-Path $script:repoRoot 'scripts/solution/Export-InsuranceFoundationPackages.ps1'
+    $script:childPowerShellPath = if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+        (Get-Command pwsh -ErrorAction Stop).Source
+    }
+    else {
+        (Get-Command powershell -ErrorAction Stop).Source
+    }
+
+    . $script:exportScriptPath `
+        -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+        -OutputDirectory (Join-Path (Get-PSDrive -Name TestDrive).Root 'dot-source')
+
+    function script:New-ExportTestContext {
+        [CmdletBinding()]
+        param()
+
+        $rootPath = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+        $null = New-Item -ItemType Directory -Path $rootPath -Force
+
+        return [pscustomobject]@{
+            RootPath        = $rootPath
+            OutputDirectory = Join-Path $rootPath 'out'
+            LogPath         = Join-Path $rootPath 'pac.log'
+            PacPath         = Join-Path $rootPath 'pac.ps1'
+        }
+    }
+
+    function script:New-FakePacCommand {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path
+        )
+
+        $scriptContent = @'
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ArgumentValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$InputArguments,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $index = [Array]::IndexOf($InputArguments, $Name)
+    if ($index -lt 0 -or $index -ge ($InputArguments.Count - 1)) {
+        throw "Missing required argument: $Name"
+    }
+
+    return $InputArguments[$index + 1]
+}
+
+$path = Get-ArgumentValue -InputArguments $Arguments -Name '--path'
+$environment = Get-ArgumentValue -InputArguments $Arguments -Name '--environment'
+$name = Get-ArgumentValue -InputArguments $Arguments -Name '--name'
+$managed = Get-ArgumentValue -InputArguments $Arguments -Name '--managed'
+$fileName = [System.IO.Path]::GetFileName($path)
+
+if (-not [string]::IsNullOrWhiteSpace($env:TEST_EXPORT_PAC_LOG_PATH)) {
+    $record = [pscustomobject][ordered]@{
+        Arguments   = @($Arguments)
+        Environment = $environment
+        Name        = $name
+        Path        = $path
+        Managed     = $managed
+        File        = $fileName
+        Overwrite   = ([Array]::IndexOf($Arguments, '--overwrite') -ge 0)
+    }
+
+    Add-Content -LiteralPath $env:TEST_EXPORT_PAC_LOG_PATH `
+        -Value ($record | ConvertTo-Json -Compress -Depth 10) `
+        -Encoding UTF8
+}
+
+if ($env:TEST_EXPORT_PAC_FAIL_FILE -eq $fileName) {
+    Write-Output "simulated export failure for $fileName"
+    exit 19
+}
+
+$directoryPath = Split-Path -Path $path -Parent
+if (-not [string]::IsNullOrWhiteSpace($directoryPath)) {
+    New-Item -ItemType Directory -Path $directoryPath -Force | Out-Null
+}
+
+if ($env:TEST_EXPORT_PAC_SKIP_FILE -ne $fileName) {
+    if ($env:TEST_EXPORT_PAC_ZERO_BYTE_FILE -eq $fileName) {
+        [System.IO.File]::WriteAllBytes($path, [byte[]]@())
+    }
+    else {
+        [System.IO.File]::WriteAllText($path, "package:$fileName")
+    }
+}
+
+Write-Output "exported $fileName"
+exit 0
+'@
+
+        Set-Content -LiteralPath $Path -Value $scriptContent -Encoding UTF8
+        return $Path
+    }
+
+    function script:Get-FakePacInvocations {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$LogPath
+        )
+
+        if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) {
+            return @()
+        }
+
+        return @(
+            Get-Content -LiteralPath $LogPath -Encoding UTF8 |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { $_ | ConvertFrom-Json -ErrorAction Stop }
+        )
+    }
+
+    function script:Invoke-ExportEntryScript {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Context,
+
+            [switch]$WhatIf,
+
+            [string]$FailFile,
+            [string]$ZeroByteFile,
+            [string]$SkipFile
+        )
+
+        $previousPacPath = $env:POWERPLATFORMTOOLS_PACPATH
+        $previousLogPath = $env:TEST_EXPORT_PAC_LOG_PATH
+        $previousFailFile = $env:TEST_EXPORT_PAC_FAIL_FILE
+        $previousZeroByteFile = $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE
+        $previousSkipFile = $env:TEST_EXPORT_PAC_SKIP_FILE
+
+        try {
+            $env:POWERPLATFORMTOOLS_PACPATH = $Context.PacPath
+            $env:TEST_EXPORT_PAC_LOG_PATH = $Context.LogPath
+
+            if ([string]::IsNullOrWhiteSpace($FailFile)) {
+                Remove-Item Env:TEST_EXPORT_PAC_FAIL_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_FAIL_FILE = $FailFile
+            }
+
+            if ([string]::IsNullOrWhiteSpace($ZeroByteFile)) {
+                Remove-Item Env:TEST_EXPORT_PAC_ZERO_BYTE_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE = $ZeroByteFile
+            }
+
+            if ([string]::IsNullOrWhiteSpace($SkipFile)) {
+                Remove-Item Env:TEST_EXPORT_PAC_SKIP_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_SKIP_FILE = $SkipFile
+            }
+
+            $arguments = @(
+                '-NoLogo',
+                '-NoProfile',
+                '-NonInteractive',
+                '-File',
+                $script:exportScriptPath,
+                '-EnvironmentUrl',
+                'https://unit.crm.dynamics.com',
+                '-OutputDirectory',
+                $Context.OutputDirectory
+            )
+            if ($WhatIf) {
+                $arguments += '-WhatIf'
+            }
+
+            $output = & $script:childPowerShellPath @arguments 2>&1
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            if ($null -eq $previousPacPath) {
+                Remove-Item Env:POWERPLATFORMTOOLS_PACPATH -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:POWERPLATFORMTOOLS_PACPATH = $previousPacPath
+            }
+
+            if ($null -eq $previousLogPath) {
+                Remove-Item Env:TEST_EXPORT_PAC_LOG_PATH -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_LOG_PATH = $previousLogPath
+            }
+
+            if ($null -eq $previousFailFile) {
+                Remove-Item Env:TEST_EXPORT_PAC_FAIL_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_FAIL_FILE = $previousFailFile
+            }
+
+            if ($null -eq $previousZeroByteFile) {
+                Remove-Item Env:TEST_EXPORT_PAC_ZERO_BYTE_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE = $previousZeroByteFile
+            }
+
+            if ($null -eq $previousSkipFile) {
+                Remove-Item Env:TEST_EXPORT_PAC_SKIP_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_SKIP_FILE = $previousSkipFile
+            }
+        }
+
+        return [pscustomobject]@{
+            ExitCode        = $exitCode
+            Output          = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+            OutputDirectory = $Context.OutputDirectory
+            LogPath         = $Context.LogPath
+            Invocations     = @(script:Get-FakePacInvocations -LogPath $Context.LogPath)
+        }
+    }
+}
+
+Describe 'Get-InsuranceFoundationExports' {
+    It 'returns exactly the four reviewed package definitions' {
+        $definitions = @(
+            Get-InsuranceFoundationExports |
+                Sort-Object File |
+                ForEach-Object {
+                    '{0}|{1}|{2}' -f $_.Name, $_.Managed.ToString().ToLowerInvariant(), $_.File
+                }
+        )
+
+        $definitions | Should -Be @(
+            'crmshow_DataModel|false|crmshow_DataModel.zip',
+            'crmshow_DataModel|true|crmshow_DataModel_managed.zip',
+            'crmshow_Foundation|false|crmshow_Foundation.zip',
+            'crmshow_Foundation|true|crmshow_Foundation_managed.zip'
+        )
+    }
+}
+
+Describe 'Assert-InsuranceFoundationPackageSet' {
+    It 'accepts the exact four files regardless of order' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                'crmshow_Foundation_managed.zip',
+                'crmshow_DataModel.zip',
+                'crmshow_DataModel_managed.zip',
+                'crmshow_Foundation.zip'
+            )
+        } | Should -Not -Throw
+    }
+
+    It 'rejects a missing package' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                'crmshow_Foundation.zip',
+                'crmshow_Foundation_managed.zip',
+                'crmshow_DataModel.zip'
+            )
+        } | Should -Throw '*Unexpected authored package set*crmshow_DataModel_managed.zip*'
+    }
+
+    It 'rejects an additional package' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                (Get-InsuranceFoundationExports).File + 'unexpected.zip'
+            )
+        } | Should -Throw '*Unexpected authored package set*unexpected.zip*'
+    }
+
+    It 'rejects a duplicate package' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                'crmshow_Foundation.zip',
+                'crmshow_Foundation.zip',
+                'crmshow_Foundation_managed.zip',
+                'crmshow_DataModel.zip',
+                'crmshow_DataModel_managed.zip'
+            )
+        } | Should -Throw '*Unexpected authored package set*crmshow_Foundation.zip*'
+    }
+
+    It 'rejects a case mismatch' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                'crmshow_foundation.zip',
+                'crmshow_Foundation_managed.zip',
+                'crmshow_DataModel.zip',
+                'crmshow_DataModel_managed.zip'
+            )
+        } | Should -Throw '*Unexpected authored package set*crmshow_foundation.zip*crmshow_Foundation.zip*'
+    }
+
+    It 'rejects a wrong extension' {
+        {
+            Assert-InsuranceFoundationPackageSet -FileNames @(
+                'crmshow_Foundation.zip',
+                'crmshow_Foundation_managed.zip',
+                'crmshow_DataModel.zip',
+                'crmshow_DataModel_managed.pak'
+            )
+        } | Should -Throw '*Unexpected authored package set*crmshow_DataModel_managed.pak*crmshow_DataModel_managed.zip*'
+    }
+}
+
+Describe 'Export-InsuranceFoundationPackages entry point' {
+    BeforeEach {
+        $script:originalPacPath = $env:POWERPLATFORMTOOLS_PACPATH
+        $script:originalLogPath = $env:TEST_EXPORT_PAC_LOG_PATH
+        $script:originalFailFile = $env:TEST_EXPORT_PAC_FAIL_FILE
+        $script:originalZeroByteFile = $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE
+        $script:originalSkipFile = $env:TEST_EXPORT_PAC_SKIP_FILE
+    }
+
+    AfterEach {
+        if ($null -eq $script:originalPacPath) {
+            Remove-Item Env:POWERPLATFORMTOOLS_PACPATH -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:POWERPLATFORMTOOLS_PACPATH = $script:originalPacPath
+        }
+
+        if ($null -eq $script:originalLogPath) {
+            Remove-Item Env:TEST_EXPORT_PAC_LOG_PATH -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TEST_EXPORT_PAC_LOG_PATH = $script:originalLogPath
+        }
+
+        if ($null -eq $script:originalFailFile) {
+            Remove-Item Env:TEST_EXPORT_PAC_FAIL_FILE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TEST_EXPORT_PAC_FAIL_FILE = $script:originalFailFile
+        }
+
+        if ($null -eq $script:originalZeroByteFile) {
+            Remove-Item Env:TEST_EXPORT_PAC_ZERO_BYTE_FILE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE = $script:originalZeroByteFile
+        }
+
+        if ($null -eq $script:originalSkipFile) {
+            Remove-Item Env:TEST_EXPORT_PAC_SKIP_FILE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TEST_EXPORT_PAC_SKIP_FILE = $script:originalSkipFile
+        }
+    }
+
+    It 'invokes the resolved pac command with the exact arguments for all four exports' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
+        $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
+
+        & $script:exportScriptPath `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -OutputDirectory $context.OutputDirectory
+
+        $actual = @(
+            script:Get-FakePacInvocations -LogPath $context.LogPath |
+                Sort-Object Path |
+                ForEach-Object { @($_.Arguments) -join '|' }
+        )
+
+        $expected = @(
+            (@(
+                    'solution', 'export',
+                    '--environment', 'https://unit.crm.dynamics.com',
+                    '--name', 'crmshow_DataModel',
+                    '--path', (Join-Path $context.OutputDirectory 'crmshow_DataModel.zip'),
+                    '--managed', 'false',
+                    '--overwrite'
+                ) -join '|'),
+            (@(
+                    'solution', 'export',
+                    '--environment', 'https://unit.crm.dynamics.com',
+                    '--name', 'crmshow_DataModel',
+                    '--path', (Join-Path $context.OutputDirectory 'crmshow_DataModel_managed.zip'),
+                    '--managed', 'true',
+                    '--overwrite'
+                ) -join '|'),
+            (@(
+                    'solution', 'export',
+                    '--environment', 'https://unit.crm.dynamics.com',
+                    '--name', 'crmshow_Foundation',
+                    '--path', (Join-Path $context.OutputDirectory 'crmshow_Foundation.zip'),
+                    '--managed', 'false',
+                    '--overwrite'
+                ) -join '|'),
+            (@(
+                    'solution', 'export',
+                    '--environment', 'https://unit.crm.dynamics.com',
+                    '--name', 'crmshow_Foundation',
+                    '--path', (Join-Path $context.OutputDirectory 'crmshow_Foundation_managed.zip'),
+                    '--managed', 'true',
+                    '--overwrite'
+                ) -join '|')
+        ) | Sort-Object
+
+        $actual | Should -Be $expected
+    }
+
+    It 'includes the package file name and CLI output when an export fails' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
+        $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
+        $env:TEST_EXPORT_PAC_FAIL_FILE = 'crmshow_DataModel_managed.zip'
+
+        {
+            & $script:exportScriptPath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -OutputDirectory $context.OutputDirectory
+        } | Should -Throw '*crmshow_DataModel_managed.zip*simulated export failure*'
+    }
+
+    It 'rejects a zero-byte exported package' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
+        $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
+        $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE = 'crmshow_Foundation.zip'
+
+        {
+            & $script:exportScriptPath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -OutputDirectory $context.OutputDirectory
+        } | Should -Throw '*zero-byte package*crmshow_Foundation.zip*'
+    }
+
+    It 'rejects a missing exported package' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
+        $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
+        $env:TEST_EXPORT_PAC_SKIP_FILE = 'crmshow_Foundation_managed.zip'
+
+        {
+            & $script:exportScriptPath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -OutputDirectory $context.OutputDirectory
+        } | Should -Throw '*did not produce package*crmshow_Foundation_managed.zip*'
+    }
+
+    It 'rejects a preexisting unrelated file in the output directory' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+        New-Item -ItemType Directory -Path $context.OutputDirectory -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $context.OutputDirectory 'keep.txt') -Value 'x'
+
+        $env:POWERPLATFORMTOOLS_PACPATH = $context.PacPath
+        $env:TEST_EXPORT_PAC_LOG_PATH = $context.LogPath
+
+        {
+            & $script:exportScriptPath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -OutputDirectory $context.OutputDirectory
+        } | Should -Throw '*already contains file*keep.txt*'
+
+        @(script:Get-FakePacInvocations -LogPath $context.LogPath).Count | Should -Be 0
+    }
+
+    It 'runs successfully as a standalone entry point with a fake pac command' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript -Context $context
+
+        $invocation.ExitCode | Should -Be 0
+        @(Get-ChildItem -LiteralPath $invocation.OutputDirectory -File | ForEach-Object Name |
+                Sort-Object) | Should -Be @(
+            'crmshow_DataModel.zip',
+            'crmshow_DataModel_managed.zip',
+            'crmshow_Foundation.zip',
+            'crmshow_Foundation_managed.zip'
+        )
+        @($invocation.Invocations).Count | Should -Be 4
+    }
+
+    It 'does not invoke pac or fail a final package assertion when run with WhatIf' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript -Context $context -WhatIf
+
+        $invocation.ExitCode | Should -Be 0
+        @($invocation.Invocations).Count | Should -Be 0
+        Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
+        $invocation.Output | Should -Not -Match 'Unexpected authored package set'
+    }
+}
+
+Describe 'Export package script safety' {
+    It 'does not invoke pac when dot-sourced' {
+        $outputDirectory = Join-Path (Get-PSDrive -Name TestDrive).Root 'dot-source-only'
+        $text = @'
+function pac { throw 'pac was called' }
+. '__SCRIPT__' -EnvironmentUrl 'https://unit.crm.dynamics.com' -OutputDirectory '__OUTPUT__'
+'@.Replace('__SCRIPT__', $script:exportScriptPath.Replace("'", "''")).
+            Replace('__OUTPUT__', $outputDirectory.Replace("'", "''"))
+
+        & ([scriptblock]::Create($text))
+    }
+}

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -12,6 +12,20 @@ BeforeAll {
         -EnvironmentUrl 'https://unit.crm.dynamics.com' `
         -OutputDirectory (Join-Path (Get-PSDrive -Name TestDrive).Root 'dot-source')
 
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+
     function script:New-ExportTestContext {
         [CmdletBinding()]
         param()
@@ -90,7 +104,12 @@ if (-not [string]::IsNullOrWhiteSpace($env:TEST_EXPORT_PAC_INTERFERENCE_FILE)) {
 }
 
 if ($env:TEST_EXPORT_PAC_FAIL_FILE -eq $fileName) {
-    Write-Output "simulated export failure for $fileName"
+    if (-not [string]::IsNullOrWhiteSpace($env:TEST_EXPORT_PAC_FAIL_TEXT)) {
+        Write-Error $env:TEST_EXPORT_PAC_FAIL_TEXT -ErrorAction Continue
+    }
+    else {
+        Write-Output "simulated export failure for $fileName"
+    }
     exit 19
 }
 
@@ -194,6 +213,7 @@ exit 0
             [switch]$WhatIf,
 
             [string]$FailFile,
+            [string]$FailText,
             [string]$ZeroByteFile,
             [string]$SkipFile,
             [string]$InterferenceFile
@@ -202,6 +222,7 @@ exit 0
         $previousPacPath = $env:POWERPLATFORMTOOLS_PACPATH
         $previousLogPath = $env:TEST_EXPORT_PAC_LOG_PATH
         $previousFailFile = $env:TEST_EXPORT_PAC_FAIL_FILE
+        $previousFailText = $env:TEST_EXPORT_PAC_FAIL_TEXT
         $previousZeroByteFile = $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE
         $previousSkipFile = $env:TEST_EXPORT_PAC_SKIP_FILE
         $previousInterferenceFile = $env:TEST_EXPORT_PAC_INTERFERENCE_FILE
@@ -215,6 +236,13 @@ exit 0
             }
             else {
                 $env:TEST_EXPORT_PAC_FAIL_FILE = $FailFile
+            }
+
+            if ([string]::IsNullOrWhiteSpace($FailText)) {
+                Remove-Item Env:TEST_EXPORT_PAC_FAIL_TEXT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_FAIL_TEXT = $FailText
             }
 
             if ([string]::IsNullOrWhiteSpace($ZeroByteFile)) {
@@ -283,6 +311,13 @@ exit 0
             }
             else {
                 $env:TEST_EXPORT_PAC_FAIL_FILE = $previousFailFile
+            }
+
+            if ($null -eq $previousFailText) {
+                Remove-Item Env:TEST_EXPORT_PAC_FAIL_TEXT -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_FAIL_TEXT = $previousFailText
             }
 
             if ($null -eq $previousZeroByteFile) {
@@ -729,6 +764,31 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         Test-Path -LiteralPath $invocation.OutputDirectory | Should -BeFalse
         Test-Path -LiteralPath $stagingDirectories[0] | Should -BeFalse
         @(script:Get-ContextDirectoryPaths -Context $context).Count | Should -Be 0
+    }
+
+    It 'emits a single safe pac export failure without raw command formatting' {
+        $context = script:New-ExportTestContext
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+        $escape = [char]27
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -FailFile 'crmshow_DataModel_managed.zip' `
+            -FailText (
+                "::warning::export transport`r`nPermission denied`t" +
+                "$escape[31mblocked$escape[0m"
+            )
+
+        $invocation.ExitCode | Should -Be 1
+        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
+        $invocation.Output | Should -Match 'pac solution export failed'
+        $invocation.Output | Should -Match 'crmshow_DataModel_managed\.zip'
+        $invocation.Output | Should -Match (
+            [regex]::Escape(
+                "Output: '::warning::export transport Permission denied blocked"
+            )
+        )
+        $invocation.Output | Should -Not -Match 'At line:|--environment|--name|--path'
     }
 
     It 'zero-byte validation failure leaves zero final files' {

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -82,6 +82,13 @@ if (-not [string]::IsNullOrWhiteSpace($env:TEST_EXPORT_PAC_LOG_PATH)) {
         -Encoding UTF8
 }
 
+if (-not [string]::IsNullOrWhiteSpace($env:TEST_EXPORT_PAC_INTERFERENCE_FILE)) {
+    [System.IO.File]::WriteAllText(
+        $env:TEST_EXPORT_PAC_INTERFERENCE_FILE,
+        'interference'
+    )
+}
+
 if ($env:TEST_EXPORT_PAC_FAIL_FILE -eq $fileName) {
     Write-Output "simulated export failure for $fileName"
     exit 19
@@ -188,7 +195,8 @@ exit 0
 
             [string]$FailFile,
             [string]$ZeroByteFile,
-            [string]$SkipFile
+            [string]$SkipFile,
+            [string]$InterferenceFile
         )
 
         $previousPacPath = $env:POWERPLATFORMTOOLS_PACPATH
@@ -196,6 +204,7 @@ exit 0
         $previousFailFile = $env:TEST_EXPORT_PAC_FAIL_FILE
         $previousZeroByteFile = $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE
         $previousSkipFile = $env:TEST_EXPORT_PAC_SKIP_FILE
+        $previousInterferenceFile = $env:TEST_EXPORT_PAC_INTERFERENCE_FILE
 
         try {
             $env:POWERPLATFORMTOOLS_PACPATH = $Context.PacPath
@@ -220,6 +229,13 @@ exit 0
             }
             else {
                 $env:TEST_EXPORT_PAC_SKIP_FILE = $SkipFile
+            }
+
+            if ([string]::IsNullOrWhiteSpace($InterferenceFile)) {
+                Remove-Item Env:TEST_EXPORT_PAC_INTERFERENCE_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_INTERFERENCE_FILE = $InterferenceFile
             }
 
             $arguments = @(
@@ -281,6 +297,13 @@ exit 0
             }
             else {
                 $env:TEST_EXPORT_PAC_SKIP_FILE = $previousSkipFile
+            }
+
+            if ($null -eq $previousInterferenceFile) {
+                Remove-Item Env:TEST_EXPORT_PAC_INTERFERENCE_FILE -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_EXPORT_PAC_INTERFERENCE_FILE = $previousInterferenceFile
             }
         }
 
@@ -378,6 +401,44 @@ Describe 'Assert-InsuranceFoundationPackageSet' {
     }
 }
 
+Describe 'New-InsuranceFoundationPackageStagingDirectory' {
+    It 'tracks the first pre-existing ancestor and every created parent directory' {
+        $context = script:New-ExportTestContext
+        $ancestor = Join-Path $context.RootPath 'pre-existing-ancestor'
+        $mid = Join-Path $ancestor 'created-mid'
+        $outputParent = Join-Path $mid 'created-parent'
+        $outputDirectory = Join-Path $outputParent 'out'
+        $null = New-Item -ItemType Directory -Path $ancestor -Force
+
+        $stagingInfo = $null
+        try {
+            $stagingInfo = New-InsuranceFoundationPackageStagingDirectory `
+                -OutputDirectory $outputDirectory `
+                -OutputDirectoryParent $outputParent
+
+            $stagingInfo.FirstPreExistingAncestor | Should -Be $ancestor
+            @($stagingInfo.CreatedDirectories) | Should -Be @(
+                $mid
+                $outputParent
+            )
+            Test-Path -LiteralPath $stagingInfo.StagingDirectory | Should -BeTrue
+            (Split-Path -Path $stagingInfo.StagingDirectory -Parent) |
+                Should -Be $outputParent
+        }
+        finally {
+            Remove-InsuranceFoundationStagingDirectory -Path $stagingInfo.StagingDirectory
+            Remove-InsuranceFoundationCreatedDirectories `
+                -FirstPreExistingAncestor $stagingInfo.FirstPreExistingAncestor `
+                -CreatedDirectories $stagingInfo.CreatedDirectories
+        }
+
+        Test-Path -LiteralPath $outputParent | Should -BeFalse
+        Test-Path -LiteralPath $mid | Should -BeFalse
+        Test-Path -LiteralPath $ancestor | Should -BeTrue
+        @(Get-ChildItem -LiteralPath $ancestor -Force).Count | Should -Be 0
+    }
+}
+
 Describe 'Export-InsuranceFoundationPackages entry point' {
     BeforeEach {
         $script:originalPacPath = $env:POWERPLATFORMTOOLS_PACPATH
@@ -385,6 +446,7 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $script:originalFailFile = $env:TEST_EXPORT_PAC_FAIL_FILE
         $script:originalZeroByteFile = $env:TEST_EXPORT_PAC_ZERO_BYTE_FILE
         $script:originalSkipFile = $env:TEST_EXPORT_PAC_SKIP_FILE
+        $script:originalInterferenceFile = $env:TEST_EXPORT_PAC_INTERFERENCE_FILE
     }
 
     AfterEach {
@@ -421,6 +483,13 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         }
         else {
             $env:TEST_EXPORT_PAC_SKIP_FILE = $script:originalSkipFile
+        }
+
+        if ($null -eq $script:originalInterferenceFile) {
+            Remove-Item Env:TEST_EXPORT_PAC_INTERFERENCE_FILE -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TEST_EXPORT_PAC_INTERFERENCE_FILE = $script:originalInterferenceFile
         }
     }
 
@@ -752,14 +821,13 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         $mid = Join-Path $ancestor 'created-mid'
         $outputParent = Join-Path $mid 'created-parent'
         $null = New-Item -ItemType Directory -Path $ancestor -Force
-        $null = New-Item -ItemType Directory -Path $mid -Force
-        Set-Content -LiteralPath (Join-Path $mid 'block.txt') -Value 'x'
         $context.OutputDirectory = Join-Path $outputParent 'out'
         script:New-FakePacCommand -Path $context.PacPath | Out-Null
 
         $invocation = script:Invoke-ExportEntryScript `
             -Context $context `
-            -FailFile 'crmshow_DataModel_managed.zip'
+            -FailFile 'crmshow_DataModel_managed.zip' `
+            -InterferenceFile (Join-Path $mid 'block.txt')
 
         $invocation.ExitCode | Should -Not -Be 0
         @($invocation.Invocations).Count | Should -Be 4
@@ -767,10 +835,11 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         Test-Path -LiteralPath $outputParent | Should -BeFalse
         Test-Path -LiteralPath $mid | Should -BeTrue
         Test-Path -LiteralPath $ancestor | Should -BeTrue
-        @(Get-ChildItem -LiteralPath $mid -Force).Count | Should -Be 1
+        @(Get-ChildItem -LiteralPath $mid -Force | ForEach-Object { $_.Name }) | Should -Be @(
+            'block.txt'
+        )
         @(script:Get-ContextDirectoryPaths -Context $context) | Should -Be @(
             $ancestor
-            $mid
         )
     }
 

--- a/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
+++ b/scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1
@@ -721,6 +721,59 @@ Describe 'Export-InsuranceFoundationPackages entry point' {
         )
     }
 
+    It 'removes run-created empty ancestors on failure but retains the pre-existing ancestor' {
+        $context = script:New-ExportTestContext
+        $ancestor = Join-Path $context.RootPath 'pre-existing-ancestor'
+        $mid = Join-Path $ancestor 'created-mid'
+        $outputParent = Join-Path $mid 'created-parent'
+        $null = New-Item -ItemType Directory -Path $ancestor -Force
+        $context.OutputDirectory = Join-Path $outputParent 'out'
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -FailFile 'crmshow_DataModel_managed.zip'
+
+        $invocation.ExitCode | Should -Not -Be 0
+        @($invocation.Invocations).Count | Should -Be 4
+        Test-Path -LiteralPath $context.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $outputParent | Should -BeFalse
+        Test-Path -LiteralPath $mid | Should -BeFalse
+        Test-Path -LiteralPath $ancestor | Should -BeTrue
+        @(Get-ChildItem -LiteralPath $ancestor -Force).Count | Should -Be 0
+        @(script:Get-ContextDirectoryPaths -Context $context) | Should -Be @(
+            $ancestor
+        )
+    }
+
+    It 'stops cleanup when a created ancestor becomes nonempty' {
+        $context = script:New-ExportTestContext
+        $ancestor = Join-Path $context.RootPath 'interference-ancestor'
+        $mid = Join-Path $ancestor 'created-mid'
+        $outputParent = Join-Path $mid 'created-parent'
+        $null = New-Item -ItemType Directory -Path $ancestor -Force
+        $null = New-Item -ItemType Directory -Path $mid -Force
+        Set-Content -LiteralPath (Join-Path $mid 'block.txt') -Value 'x'
+        $context.OutputDirectory = Join-Path $outputParent 'out'
+        script:New-FakePacCommand -Path $context.PacPath | Out-Null
+
+        $invocation = script:Invoke-ExportEntryScript `
+            -Context $context `
+            -FailFile 'crmshow_DataModel_managed.zip'
+
+        $invocation.ExitCode | Should -Not -Be 0
+        @($invocation.Invocations).Count | Should -Be 4
+        Test-Path -LiteralPath $context.OutputDirectory | Should -BeFalse
+        Test-Path -LiteralPath $outputParent | Should -BeFalse
+        Test-Path -LiteralPath $mid | Should -BeTrue
+        Test-Path -LiteralPath $ancestor | Should -BeTrue
+        @(Get-ChildItem -LiteralPath $mid -Force).Count | Should -Be 1
+        @(script:Get-ContextDirectoryPaths -Context $context) | Should -Be @(
+            $ancestor
+            $mid
+        )
+    }
+
     It 'does not invoke pac or fail a final package assertion when run with WhatIf' {
         $context = script:New-ExportTestContext
         $outputParent = Join-Path $context.RootPath 'whatif-parent'

--- a/scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1
+++ b/scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1
@@ -1,5 +1,19 @@
 BeforeAll {
     . "$PSScriptRoot/../Get-InsuranceAuthoringPreflightFailureMessage.ps1"
+
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
 }
 
 Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
@@ -15,7 +29,9 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
 
         $message | Should -Match 'ManualPrerequisite'
         $message | Should -Match (
-            [regex]::Escape('MissingRoles=[CRM Showcase Insurance Data Steward]')
+            [regex]::Escape(
+                'MissingRoles=["CRM Showcase Insurance Data Steward"]'
+            )
         )
         $message | Should -Match (
             [regex]::Escape(
@@ -38,12 +54,15 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
 
         $message | Should -Match 'Required solution/environment prerequisites are missing'
         $message | Should -Match (
-            [regex]::Escape('MissingSolutions=[crmshow_DataModel]')
+            [regex]::Escape('MissingSolutions=["crmshow_DataModel"]')
         )
         $message | Should -Match (
-            [regex]::Escape('MissingLanguageLcid=[1031, 1036]')
+            [regex]::Escape('MissingLanguageLcid=["1031", "1036"]')
         )
-        $message | Should -Match 'LanguageAction=Reconcile'
+        $message | Should -Match (
+            [regex]::Escape('LanguageAction="Reconcile"')
+        )
+        $message | Should -Match 'preflight diagnostics above'
         $message | Should -Not -Match (
             'insurance-foundation-security-role-bootstrap'
         )
@@ -62,7 +81,9 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
         $message | Should -Match 'UnsupportedInTenant'
         $message | Should -Match 'CI identity or tenant capability is unsupported'
         $message | Should -Match (
-            [regex]::Escape('AssignedRoleNames=[Basic User, Environment Maker]')
+            [regex]::Escape(
+                'AssignedRoleNames=["Basic User", "Environment Maker"]'
+            )
         )
         $message | Should -Match 'Escalate for identity correction or tenant capability review'
         $message | Should -Not -Match (
@@ -80,8 +101,10 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
             -JsonText $json
 
         $message | Should -Match 'non-ready state'
-        $message | Should -Match 'State=UnexpectedState'
-        $message | Should -Match 'JSON echoed above'
+        $message | Should -Match 'preflight diagnostics above'
+        $message | Should -Match (
+            [regex]::Escape('State="UnexpectedState"')
+        )
         $message | Should -Not -Match (
             'insurance-foundation-security-role-bootstrap'
         )
@@ -93,7 +116,7 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
             -JsonText 'not-json'
 
         $message | Should -Match 'non-ready state'
-        $message | Should -Match 'JSON echoed above'
+        $message | Should -Match 'preflight diagnostics above'
         $message | Should -Not -Match (
             'insurance-foundation-security-role-bootstrap'
         )
@@ -107,5 +130,91 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
         $message | Should -Be (
             'Authoring preflight transport or execution failed. Review the error output above.'
         )
+    }
+
+    It 'sanitizes hostile ManualPrerequisite names to a single safe line' {
+        $json = [ordered]@{
+            State        = 'ManualPrerequisite'
+            MissingRoles = @(
+                "`n::warning::owned`trole$([char]1)",
+                "CRM`rShowcase$([char]0x85)Operator"
+            )
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText $json
+
+        Assert-SafeDiagnosticLine -Text $message -MaxLength 350
+        $message | Should -Match 'ManualPrerequisite'
+        $message | Should -Match 'warning::owned role'
+        $message | Should -Match 'CRM Showcase Operator'
+    }
+
+    It 'bounds long diagnostic lists to avoid log flooding' {
+        $veryLongName = 'Role-' + ('Z' * 240)
+        $json = [ordered]@{
+            State        = 'ManualPrerequisite'
+            MissingRoles = @(
+                $veryLongName,
+                ('Role-B-' + ('Y' * 240)),
+                ('Role-C-' + ('X' * 240)),
+                ('Role-D-' + ('W' * 240)),
+                ('Role-E-' + ('V' * 240))
+            )
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText $json
+
+        Assert-SafeDiagnosticLine -Text $message -MaxLength 450
+        $message | Should -Match 'ManualPrerequisite'
+        $message | Should -Match '\.\.\. \(\+\d+ more\)'
+        $message | Should -Not -Match (
+            [regex]::Escape(('Z' * 150))
+        )
+    }
+}
+
+Describe 'Get-InsuranceAuthoringPreflightDiagnosticSummary' {
+    It 'builds a compact sanitized workflow summary from parsed diagnostics' {
+        $json = [ordered]@{
+            State               = 'Precondition'
+            MissingSolutions    = @(
+                "crmshow_DataModel`n::warning::owned",
+                "crmshow_Foundation`r`t$([char]0x9f)Ready"
+            )
+            MissingLanguageLcid = @(
+                "1031`r::warning::owned",
+                "1036`t$([char]0x1f)"
+            )
+            LanguageAction      = "`n::warning::Reconcile`t$([char]0x85)"
+        } | ConvertTo-Json -Depth 10
+
+        $summary = Get-InsuranceAuthoringPreflightDiagnosticSummary `
+            -JsonText $json
+
+        Assert-SafeDiagnosticLine -Text $summary -MaxLength 500
+        $summary | Should -Match (
+            [regex]::Escape('Authoring preflight diagnostics: State="Precondition";')
+        )
+        $summary | Should -Match 'warning::owned'
+        $summary | Should -Match (
+            [regex]::Escape('LanguageAction="[literal] ::warning::Reconcile"')
+        )
+    }
+
+    It 'sanitizes unparseable workflow output without echoing raw multiline text' {
+        $summary = Get-InsuranceAuthoringPreflightDiagnosticSummary `
+            -JsonText ("`n::warning::boom`t" + ('Q' * 400) + [char]0x85)
+
+        Assert-SafeDiagnosticLine -Text $summary -MaxLength 430
+        $summary | Should -Match (
+            [regex]::Escape('State="(unparseable)"')
+        )
+        $summary | Should -Match 'RawResult='
+        $summary | Should -Match 'warning::boom'
+        $summary | Should -Match '\.\.\.'
     }
 }

--- a/scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1
+++ b/scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1
@@ -1,0 +1,111 @@
+BeforeAll {
+    . "$PSScriptRoot/../Get-InsuranceAuthoringPreflightFailureMessage.ps1"
+}
+
+Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
+    It 'points ManualPrerequisite to the role bootstrap runbook and missing roles' {
+        $json = [ordered]@{
+            State        = 'ManualPrerequisite'
+            MissingRoles = @('CRM Showcase Insurance Data Steward')
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText $json
+
+        $message | Should -Match 'ManualPrerequisite'
+        $message | Should -Match (
+            [regex]::Escape('MissingRoles=[CRM Showcase Insurance Data Steward]')
+        )
+        $message | Should -Match (
+            [regex]::Escape(
+                'docs/runbooks/insurance-foundation-security-role-bootstrap.md'
+            )
+        )
+    }
+
+    It 'reports Precondition prerequisites without role bootstrap guidance' {
+        $json = [ordered]@{
+            State               = 'Precondition'
+            MissingSolutions    = @('crmshow_DataModel')
+            MissingLanguageLcid = @(1031, 1036)
+            LanguageAction      = 'Reconcile'
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText $json
+
+        $message | Should -Match 'Required solution/environment prerequisites are missing'
+        $message | Should -Match (
+            [regex]::Escape('MissingSolutions=[crmshow_DataModel]')
+        )
+        $message | Should -Match (
+            [regex]::Escape('MissingLanguageLcid=[1031, 1036]')
+        )
+        $message | Should -Match 'LanguageAction=Reconcile'
+        $message | Should -Not -Match (
+            'insurance-foundation-security-role-bootstrap'
+        )
+    }
+
+    It 'reports UnsupportedInTenant identity guidance without role bootstrap guidance' {
+        $json = [ordered]@{
+            State             = 'UnsupportedInTenant'
+            AssignedRoleNames = @('Basic User', 'Environment Maker')
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText $json
+
+        $message | Should -Match 'UnsupportedInTenant'
+        $message | Should -Match 'CI identity or tenant capability is unsupported'
+        $message | Should -Match (
+            [regex]::Escape('AssignedRoleNames=[Basic User, Environment Maker]')
+        )
+        $message | Should -Match 'Escalate for identity correction or tenant capability review'
+        $message | Should -Not -Match (
+            'insurance-foundation-security-role-bootstrap'
+        )
+    }
+
+    It 'uses a generic non-ready message for unknown states without privileged action guidance' {
+        $json = [ordered]@{
+            State = 'UnexpectedState'
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText $json
+
+        $message | Should -Match 'non-ready state'
+        $message | Should -Match 'State=UnexpectedState'
+        $message | Should -Match 'JSON echoed above'
+        $message | Should -Not -Match (
+            'insurance-foundation-security-role-bootstrap'
+        )
+    }
+
+    It 'uses a generic non-ready message for unparseable JSON without privileged action guidance' {
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 2 `
+            -JsonText 'not-json'
+
+        $message | Should -Match 'non-ready state'
+        $message | Should -Match 'JSON echoed above'
+        $message | Should -Not -Match (
+            'insurance-foundation-security-role-bootstrap'
+        )
+    }
+
+    It 'uses a generic transport failure for other nonzero exits' {
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 1 `
+            -JsonText '{"State":"ManualPrerequisite"}'
+
+        $message | Should -Be (
+            'Authoring preflight transport or execution failed. Review the error output above.'
+        )
+    }
+}

--- a/scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1
+++ b/scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1
@@ -132,6 +132,36 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
         )
     }
 
+    It 'reports ContractConflict ownership guidance on exit three without bootstrap instructions' {
+        $json = [ordered]@{
+            State             = 'ContractConflict'
+            MissingSolutions  = @('crmshow_DataModel')
+            SolutionConflicts = @(
+                "Solution 'crmshow_Foundation' publisher metadata does not match solution/manifest.json: publisher.uniquename expected 'CRMShowcase' but was 'Contoso'."
+            )
+            RoleConflicts     = @(
+                "Role 'CRM Showcase Insurance Reader': Role 'CRM Showcase Insurance Reader' reviewed-solution membership expected 'crmshow_Foundation'; actual reviewed membership was 'crmshow_Foundation, crmshow_DataModel'."
+            )
+        } | ConvertTo-Json -Depth 10
+
+        $message = Get-InsuranceAuthoringPreflightFailureMessage `
+            -ExitCode 3 `
+            -JsonText $json
+
+        Assert-SafeDiagnosticLine -Text $message -MaxLength 600
+        $message | Should -Match 'ContractConflict'
+        $message | Should -Match (
+            'Reviewed publisher or role ownership differs from the contract'
+        )
+        $message | Should -Match (
+            [regex]::Escape('MissingSolutions=["crmshow_DataModel"]')
+        )
+        $message | Should -Match 'No mutation was performed'
+        $message | Should -Not -Match (
+            'insurance-foundation-security-role-bootstrap'
+        )
+    }
+
     It 'sanitizes hostile ManualPrerequisite names to a single safe line' {
         $json = [ordered]@{
             State        = 'ManualPrerequisite'
@@ -178,6 +208,33 @@ Describe 'Get-InsuranceAuthoringPreflightFailureMessage' {
 }
 
 Describe 'Get-InsuranceAuthoringPreflightDiagnosticSummary' {
+    It 'builds a compact sanitized contract-conflict workflow summary' {
+        $json = [ordered]@{
+            State             = 'ContractConflict'
+            MissingSolutions  = @("crmshow_DataModel`n::warning::owned")
+            SolutionConflicts = @(
+                "Solution`r`tpublisher$([char]0x85) mismatch"
+            )
+            RoleConflicts     = @(
+                "Role`n::warning::conflict`t$([char]1)"
+            )
+        } | ConvertTo-Json -Depth 10
+
+        $summary = Get-InsuranceAuthoringPreflightDiagnosticSummary `
+            -JsonText $json
+
+        Assert-SafeDiagnosticLine -Text $summary -MaxLength 500
+        $summary | Should -Match (
+            [regex]::Escape(
+                'Authoring preflight diagnostics: State="ContractConflict";'
+            )
+        )
+        $summary | Should -Match 'SolutionConflicts='
+        $summary | Should -Match 'RoleConflicts='
+        $summary | Should -Match 'warning::owned'
+        $summary | Should -Match 'warning::conflict'
+    }
+
     It 'builds a compact sanitized workflow summary from parsed diagnostics' {
         $json = [ordered]@{
             State               = 'Precondition'

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -4,6 +4,182 @@ BeforeAll {
     $script:publisherPath = Join-Path $script:repoRoot 'scripts/solution/Publish-InsuranceFoundation.ps1'
     . $script:publisherPath -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath $script:contractPath
     $script:contract = Get-Content $script:contractPath -Raw | ConvertFrom-Json
+
+    function Get-ContractTableByLogicalName {
+        param([Parameter(Mandatory)] [string]$LogicalName)
+        return @($script:contract.tables | Where-Object logicalName -eq $LogicalName)[0]
+    }
+
+    function Get-ColumnAttributeTypeName {
+        param([Parameter(Mandatory)] $Column)
+        return @{
+            Text = 'String'; Lookup = 'Lookup'; Customer = 'Customer'
+            GlobalChoice = 'Picklist'; DateOnly = 'DateTime'
+            DateTime = 'DateTime'
+        }[$Column.type]
+    }
+
+    function New-TableAttributeSnapshot {
+        param([Parameter(Mandatory)] $Column)
+
+        $attribute = [ordered]@{
+            MetadataId = "attribute-$($Column.logicalName)"
+            LogicalName = $Column.logicalName
+            SchemaName = $Column.schemaName
+            AttributeType = Get-ColumnAttributeTypeName $Column
+            DisplayName = ConvertTo-LocalizedLabel $Column.metadata.label
+            Description = ConvertTo-LocalizedLabel $Column.metadata.description
+        }
+        switch ($Column.type) {
+            'Text' {
+                $attribute.MaxLength = $Column.maxLength
+            }
+            'DateOnly' {
+                $attribute.Format = 'DateOnly'
+                $attribute.DateTimeBehavior = @{ Value = 'DateOnly' }
+            }
+            'DateTime' {
+                $attribute.Format = 'DateAndTime'
+                $attribute.DateTimeBehavior = @{ Value = 'TimeZoneIndependent' }
+            }
+            'GlobalChoice' {
+                $attribute.GlobalOptionSet = [pscustomobject]@{
+                    Name = $Column.choice
+                }
+            }
+            'Lookup' {
+                $attribute.Targets = @($Column.lookup.targets)
+            }
+            'Customer' {
+                $attribute.Targets = @($Column.lookup.targets)
+            }
+        }
+        return [pscustomobject]$attribute
+    }
+
+    function New-TableRelationshipSnapshots {
+        param(
+            [Parameter(Mandatory)] $Table,
+            [Parameter(Mandatory)] $Relationship
+        )
+
+        $targets = if ($Relationship.authoring -eq 'CreateCustomerRelationships') {
+            @($Relationship.referencedTables)
+        } else {
+            @([string]$Relationship.referencedTables[0])
+        }
+        $relationships = foreach ($target in $targets) {
+            [pscustomobject]@{
+                SchemaName = if (
+                    $Relationship.authoring -eq 'CreateCustomerRelationships'
+                ) {
+                    "$($Relationship.schemaName)_$target"
+                } else {
+                    $Relationship.schemaName
+                }
+                ReferencedEntity = [string]$target
+                ReferencingEntity = $Table.logicalName
+                ReferencingAttribute = $Relationship.lookupColumn
+                CascadeConfiguration = [pscustomobject]@{
+                    Assign = 'NoCascade'
+                    Delete = 'Restrict'
+                    Merge = if ($target -in @('account', 'contact')) {
+                        'Cascade'
+                    } else {
+                        'NoCascade'
+                    }
+                    Reparent = 'NoCascade'
+                    Share = 'NoCascade'
+                    Unshare = 'NoCascade'
+                }
+            }
+        }
+        return @($relationships)
+    }
+
+    function New-TableMetadataSnapshot {
+        param(
+            [Parameter(Mandatory)] $Table,
+            [switch]$IncludeCustomerRelationships,
+            [string[]]$OmitColumns = @(),
+            [string[]]$OmitRelationshipSchemas = @()
+        )
+
+        $attributes = foreach ($column in @($Table.columns)) {
+            if ($column.logicalName -in $OmitColumns) { continue }
+            if ($column.type -eq 'Customer' -and
+                -not $IncludeCustomerRelationships) {
+                continue
+            }
+            New-TableAttributeSnapshot $column
+        }
+        $relationships = foreach ($relationship in @($Table.relationships)) {
+            if ($relationship.schemaName -in $OmitRelationshipSchemas) {
+                continue
+            }
+            if ($relationship.authoring -eq 'CreateCustomerRelationships' -and
+                -not $IncludeCustomerRelationships) {
+                continue
+            }
+            New-TableRelationshipSnapshots $Table $relationship
+        }
+        return [pscustomobject]@{
+            MetadataId = "table-$($Table.logicalName)"
+            LogicalName = $Table.logicalName
+            SchemaName = $Table.schemaName
+            OwnershipType = $Table.ownership
+            PrimaryNameAttribute = 'crmshow_name'
+            ObjectTypeCode = 10427
+            SolutionUniqueName = $Table.solution
+            DisplayName = ConvertTo-LocalizedLabel $Table.metadata.label
+            Description = ConvertTo-LocalizedLabel $Table.metadata.description
+            Attributes = @($attributes)
+            ManyToOneRelationships = @($relationships)
+        }
+    }
+
+    function New-TableTypedAttributeCollectionResponse {
+        param(
+            [Parameter(Mandatory)] $Table,
+            [Parameter(Mandatory)] [string]$TypeName,
+            [switch]$IncludeCustomerRelationships,
+            [string]$AttributeLogicalName,
+            [string[]]$OmitColumns = @(),
+            [string[]]$OmitRelationshipSchemas = @()
+        )
+
+        $snapshot = New-TableMetadataSnapshot -Table $Table `
+            -IncludeCustomerRelationships:$IncludeCustomerRelationships `
+            -OmitColumns $OmitColumns `
+            -OmitRelationshipSchemas $OmitRelationshipSchemas
+        $attributes = switch ($TypeName) {
+            'StringAttributeMetadata' {
+                @($snapshot.Attributes | Where-Object AttributeType -eq 'String')
+            }
+            'DateTimeAttributeMetadata' {
+                @($snapshot.Attributes | Where-Object AttributeType -eq 'DateTime')
+            }
+            'LookupAttributeMetadata' {
+                @($snapshot.Attributes | Where-Object {
+                    $_.AttributeType -in @('Lookup', 'Customer')
+                })
+            }
+            'PicklistAttributeMetadata' {
+                @($snapshot.Attributes | Where-Object AttributeType -eq 'Picklist')
+            }
+            default {
+                throw "Unsupported typed attribute test collection '$TypeName'."
+            }
+        }
+        if (-not [string]::IsNullOrWhiteSpace($AttributeLogicalName)) {
+            $attributes = @($attributes | Where-Object {
+                $_.LogicalName -eq $AttributeLogicalName
+            })
+        }
+        return [pscustomobject]@{
+            value = @($attributes)
+        }
+    }
 }
 
 Describe 'Insurance Foundation request builders' {
@@ -264,6 +440,74 @@ Describe 'Insurance Foundation request builders' {
     }
 }
 
+Describe 'Dataverse metadata convergence waits' {
+    BeforeEach {
+        $script:sleepCalls = [System.Collections.Generic.List[int]]::new()
+        Mock Start-Sleep {
+            param([int]$Seconds)
+            $script:sleepCalls.Add($Seconds) | Out-Null
+        }
+    }
+
+    It 'returns the first non-null result on the third attempt and sleeps only between failures' {
+        $script:attempts = 0
+        $expected = [pscustomobject]@{ marker = 'ready' }
+
+        $result = Wait-DataverseCondition -Component 'crmshow_table' -Condition {
+            $script:attempts++
+            if ($script:attempts -eq 3) { return $expected }
+            return $null
+        }
+
+        $result.marker | Should -Be 'ready'
+        $script:attempts | Should -Be 3
+        @($script:sleepCalls) | Should -Be @(5, 5)
+    }
+
+    It 'throws a classified timeout that includes the exact component and timeout' {
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            [datetime]'2026-08-09T12:00:00Z',
+            [datetime]'2026-08-09T12:00:00Z',
+            [datetime]'2026-08-09T12:03:00Z'
+        )) {
+            $script:clock.Enqueue($value)
+        }
+        Mock Get-Date { $script:clock.Dequeue() }
+
+        {
+            Wait-DataverseCondition -Component `
+                'crmshow_policyprojection/crmshow_accountid' `
+                -TimeoutSeconds 180 -Condition { $null }
+        } | Should -Throw (
+            '*EventualConsistencyTimeout*' +
+            'crmshow_policyprojection/crmshow_accountid*180*'
+        )
+    }
+
+    It 'bounds each sleep to the remaining deadline' {
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start.AddSeconds(5),
+            $start.AddSeconds(10),
+            $start.AddSeconds(12)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+        Mock Get-Date { $script:clock.Dequeue() }
+
+        {
+            Wait-DataverseCondition -Component 'crmshow_lookup' `
+                -TimeoutSeconds 12 -PollIntervalSeconds 5 `
+                -Condition { $null }
+        } | Should -Throw '*EventualConsistencyTimeout*crmshow_lookup*12*'
+        @($script:sleepCalls) | Should -Be @(5, 5, 2)
+    }
+}
+
 Describe 'az rest transport' {
     AfterEach {
         Remove-Item Function:\az -ErrorAction SilentlyContinue
@@ -383,9 +627,35 @@ Describe 'Insurance Foundation reconciliation' {
         $script:calls = [System.Collections.Generic.List[object]]::new()
         $script:choicesExist = $false
         $script:createdChoices = [System.Collections.Generic.HashSet[string]]::new()
+        $script:createdTables = [System.Collections.Generic.HashSet[string]]::new()
+        $script:tablesWithCustomerRelationships = `
+            [System.Collections.Generic.HashSet[string]]::new()
+        Mock Wait-TableMetadataSnapshot {
+            param($Table, $Component, $Ready)
+            $includeCustomerRelationships = @(
+                $Table.columns | Where-Object type -eq 'Customer'
+            ).Count -eq 0 -or
+                $script:tablesWithCustomerRelationships.Contains(
+                    $Table.logicalName
+                )
+            $snapshot = New-TableMetadataSnapshot -Table $Table `
+                -IncludeCustomerRelationships:$includeCustomerRelationships
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $Component
+                Body = $snapshot
+                Headers = $null
+            })
+            if ($Ready -and -not (& $Ready $snapshot)) {
+                return $null
+            }
+            return $snapshot
+        }
         Mock Invoke-DataverseRequest {
             param($Method, $Path, $Body, $Headers)
             $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
                 Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
             })
             if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
@@ -419,6 +689,58 @@ Describe 'Insurance Foundation reconciliation' {
                             }
                         })
                 }
+            }
+            if ($Method -eq 'GET' -and $Path -like '/EntityDefinitions?*' -and
+                $Path -match '\$expand=Attributes') {
+                $logicalName = [regex]::Match(
+                    $Path,
+                    "LogicalName eq '((?:[^']|'')*)'"
+                ).Groups[1].Value.Replace("''", "'")
+                $table = Get-ContractTableByLogicalName $logicalName
+                if ($null -eq $table -or
+                    -not $script:createdTables.Contains($logicalName)) {
+                    return [pscustomobject]@{ value = @() }
+                }
+                $includeCustomerRelationships = @(
+                    $table.columns | Where-Object type -eq 'Customer'
+                ).Count -eq 0 -or
+                    $script:tablesWithCustomerRelationships.Contains(
+                        $logicalName
+                    )
+                return [pscustomobject]@{
+                    value = @(
+                        New-TableMetadataSnapshot -Table $table `
+                            -IncludeCustomerRelationships:$includeCustomerRelationships
+                    )
+                }
+            }
+            if ($Method -eq 'GET' -and $Path -match (
+                "^/EntityDefinitions\(LogicalName='((?:[^']|'')*)'\)" +
+                '/Attributes/Microsoft\.Dynamics\.CRM\.' +
+                '(StringAttributeMetadata|DateTimeAttributeMetadata|' +
+                'LookupAttributeMetadata|PicklistAttributeMetadata)\?'
+            )) {
+                $logicalName = $Matches[1].Replace("''", "'")
+                $typeName = $Matches[2]
+                $attributeLogicalName = [regex]::Match(
+                    $Path,
+                    "LogicalName eq '((?:[^']|'')*)'"
+                ).Groups[1].Value.Replace("''", "'")
+                $table = Get-ContractTableByLogicalName $logicalName
+                if ($null -eq $table -or
+                    -not $script:createdTables.Contains($logicalName)) {
+                    return [pscustomobject]@{ value = @() }
+                }
+                $includeCustomerRelationships = @(
+                    $table.columns | Where-Object type -eq 'Customer'
+                ).Count -eq 0 -or
+                    $script:tablesWithCustomerRelationships.Contains(
+                        $logicalName
+                    )
+                return New-TableTypedAttributeCollectionResponse `
+                    -Table $table -TypeName $typeName `
+                    -IncludeCustomerRelationships:$includeCustomerRelationships `
+                    -AttributeLogicalName $attributeLogicalName
             }
             if ($Method -eq 'GET' -and
                 $Path -like "/GlobalOptionSetDefinitions(Name='*") {
@@ -456,6 +778,17 @@ Describe 'Insurance Foundation reconciliation' {
             if ($Method -eq 'POST' -and $Path -eq '/GlobalOptionSetDefinitions') {
                 $script:createdChoices.Add([string]$Body.Name) | Out-Null
             }
+            if ($Method -eq 'POST' -and $Path -eq '/EntityDefinitions') {
+                $script:createdTables.Add([string]$Body.LogicalName) | Out-Null
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/CreateCustomerRelationships') {
+                $tableLogicalName = [string]$Body.OneToManyRelationships[0].ReferencingEntity
+                if (-not [string]::IsNullOrWhiteSpace($tableLogicalName)) {
+                    $script:tablesWithCustomerRelationships.Add(
+                        $tableLogicalName
+                    ) | Out-Null
+                }
+            }
             if ($Path -eq '/savedqueries') {
                 return [pscustomobject]@{ savedqueryid = 'new-view' }
             }
@@ -482,7 +815,7 @@ Describe 'Insurance Foundation reconciliation' {
         $created = @($script:calls | Where-Object Method -eq 'POST')
         @($created | Where-Object Path -eq '/GlobalOptionSetDefinitions').Count | Should -Be 5
         @($created | Where-Object Path -eq '/EntityDefinitions').Count | Should -Be 3
-        @($created | Where-Object Path -eq '/PublishXml').Count | Should -Be 3
+        @($created | Where-Object Path -eq '/PublishXml').Count | Should -Be 6
         foreach ($publish in @($created | Where-Object Path -eq '/PublishXml')) {
             $publish.Body.ParameterXml |
                 Should -Match '^<importexportxml><entities><entity>crmshow_[a-z]+</entity></entities></importexportxml>$'
@@ -508,8 +841,23 @@ Describe 'Insurance Foundation reconciliation' {
             $_.Path -match '\$expand=Attributes'
         })
         $tableMetadataReads.Count | Should -Be 3
-        $tableMetadataReads.Path |
-            Should -Not -Match 'Targets|MaxLength|DateTimeBehavior|Format'
+        @($tableMetadataReads | Where-Object {
+            $_.Path -match "LogicalName eq 'crmshow_accountcontactrole'"
+        }).Count | Should -Be 1
+        @($tableMetadataReads | Where-Object {
+            $_.Path -match "LogicalName eq 'crmshow_policyprojection'"
+        }).Count | Should -Be 1
+        @($tableMetadataReads | Where-Object {
+            $_.Path -match "LogicalName eq 'crmshow_policypartyrole'"
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -match (
+                '/Attributes/Microsoft\.Dynamics\.CRM\.' +
+                '(StringAttributeMetadata|DateTimeAttributeMetadata|' +
+                'LookupAttributeMetadata|PicklistAttributeMetadata)\?'
+            )
+        }).Count | Should -BeGreaterThan 0
         $choiceBindings = @(
             $created |
                 Where-Object Path -match '/Attributes$' |
@@ -736,7 +1084,7 @@ Describe 'Insurance Foundation reconciliation' {
         @($script:calls | Where-Object {
             $_.Method -eq 'GET' -and
             $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?'
-        }).Count | Should -Be 2
+        }).Count | Should -BeGreaterOrEqual 2
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and
             $_.Path -match "EntityDefinitions\(LogicalName='(?:account|contact)'\)/Attributes$"
@@ -746,23 +1094,41 @@ Describe 'Insurance Foundation reconciliation' {
         }).Count | Should -Be 3
     }
 
-    It 'creates the Customer relationship after publishing its owning table and once' {
+    It 'publishes the Customer table, confirms visibility, and creates the relationship once' {
         $script:choicesExist = $true
         Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope DataModel -Confirm:$false
-        $mutations = @($script:calls | Where-Object Method -ne 'GET')
-        $tableIndex = -1
-        for ($i = 0; $i -lt $mutations.Count; $i++) {
-            if ($mutations[$i].Path -eq '/EntityDefinitions' -and
-                $mutations[$i].Body.LogicalName -eq 'crmshow_policypartyrole') {
-                $tableIndex = $i
-                break
-            }
+        $tableCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq '/EntityDefinitions' -and
+            $_.Body.LogicalName -eq 'crmshow_policypartyrole'
+        })[0]
+        $initialPublish = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq '/PublishXml' -and
+            $_.Sequence -gt $tableCreate.Sequence
+        })[0]
+        $customerCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/CreateCustomerRelationships'
+        })
+        $customerVisibilityReads = @($script:calls | Where-Object {
+            $_.Method -eq 'SNAPSHOT' -and
+            $_.Path -eq 'crmshow_policypartyrole' -and
+            $_.Sequence -gt $initialPublish.Sequence -and
+            $_.Sequence -lt $customerCreate[0].Sequence
+        })
+        $finalPublish = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq '/PublishXml' -and
+            $_.Sequence -gt $customerCreate[0].Sequence
+        })[0]
 
-        }
-        $tableIndex | Should -BeGreaterOrEqual 0
-        $mutations[$tableIndex + 1].Path | Should -Be '/PublishXml'
-        $mutations[$tableIndex + 2].Path | Should -Be '/CreateCustomerRelationships'
-        @($mutations | Where-Object Path -eq '/CreateCustomerRelationships').Count | Should -Be 1
+        $initialPublish.Sequence | Should -BeGreaterThan $tableCreate.Sequence
+        $customerCreate.Count | Should -Be 1
+        $customerVisibilityReads.Count | Should -BeGreaterThan 0
+        $customerCreate[0].Sequence |
+            Should -BeGreaterThan $customerVisibilityReads[-1].Sequence
+        $finalPublish.Sequence |
+            Should -BeGreaterThan $customerCreate[0].Sequence
     }
 
     It 'recovers an interrupted Customer relationship create on rerun' {
@@ -775,95 +1141,42 @@ Describe 'Insurance Foundation reconciliation' {
         $script:tableExists = $false
         $script:customerCreateAttempts = 0
 
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            if ($LogicalName -ne $table.logicalName -or
+                -not $script:tableExists) {
+                return $null
+            }
+            return New-TableMetadataSnapshot -Table $table `
+                -IncludeCustomerRelationships:(
+                    $script:customerCreateAttempts -ge 2
+                )
+        }
+        Mock Wait-TableMetadataSnapshot {
+            param($Table, $Component, $Ready)
+            $snapshot = Get-TableMetadataSnapshot $Table.logicalName
+            $script:calls.Add([pscustomobject]@{
+                Sequence=$script:calls.Count + 1
+                Method='SNAPSHOT'; Path=$Component; Body=$snapshot
+                Headers=$null
+            })
+            if ($Ready -and -not (& $Ready $snapshot)) {
+                return $null
+            }
+            return $snapshot
+        }
         Mock Invoke-DataverseRequest {
             param($Method, $Path, $Body, $Headers)
             $script:calls.Add([pscustomobject]@{
+                Sequence=$script:calls.Count + 1
                 Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
             })
-            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
-                if (-not $script:tableExists) {
-                    return [pscustomobject]@{ value=@() }
-                }
-                return [pscustomobject]@{ value=@([pscustomobject]@{
-                    MetadataId='policy-party-table'
-                    LogicalName=$table.logicalName
-                    OwnershipType=$table.ownership
-                    SolutionUniqueName=$table.solution
-                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
-                    Description=ConvertTo-LocalizedLabel $table.metadata.description
-                    Attributes=@($table.columns | Where-Object type -ne 'Customer' |
-                        ForEach-Object {
-                            [pscustomobject]@{
-                                MetadataId="attribute-$($_.logicalName)"
-                                LogicalName=$_.logicalName
-                                SchemaName=$_.schemaName
-                                AttributeType=@{
-                                    Text='String'; Lookup='Lookup'
-                                    GlobalChoice='Picklist'; DateOnly='DateTime'
-                                    DateTime='DateTime'
-                                }[$_.type]
-                                Targets=@($_.lookup.targets)
-                                MaxLength=$_.maxLength
-                                DateTimeBehavior=$(if ($_.type -eq 'DateOnly') {
-                                    @{ Value='DateOnly' }
-                                } elseif ($_.type -eq 'DateTime') {
-                                    @{ Value='TimeZoneIndependent' }
-                                })
-                                Format=$(if ($_.type -eq 'DateOnly') {
-                                    'DateOnly'
-                                } elseif ($_.type -eq 'DateTime') {
-                                    'DateAndTime'
-                                })
-                                DisplayName=ConvertTo-LocalizedLabel $_.metadata.label
-                                Description=ConvertTo-LocalizedLabel $_.metadata.description
-                            }
-                        })
-                    ManyToOneRelationships=@($table.relationships |
-                        Where-Object authoring -eq 'InitialTableCreate' |
-                        ForEach-Object {
-                            [pscustomobject]@{
-                                SchemaName=$_.schemaName
-                                ReferencedEntity=[string]$_.referencedTables[0]
-                                ReferencingEntity=$table.logicalName
-                                ReferencingAttribute=$_.lookupColumn
-                                CascadeConfiguration=[pscustomobject]@{
-                                    Assign='NoCascade'; Delete='Restrict'
-                                    Merge='NoCascade'; Reparent='NoCascade'
-                                    Share='NoCascade'; Unshare='NoCascade'
-                                }
-                            }
-                        })
-                }) }
-            }
-            if ($Method -eq 'GET' -and
-                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.LookupAttributeMetadata') {
-                return [pscustomobject]@{ value=@() }
-            }
-            if ($Method -eq 'GET' -and
-                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata') {
-                $column = $table.columns |
-                    Where-Object logicalName -eq 'crmshow_roletype'
-                return [pscustomobject]@{ value=@([pscustomobject]@{
-                    MetadataId="attribute-$($column.logicalName)"
-                    LogicalName=$column.logicalName
-                    SchemaName=$column.schemaName
-                    AttributeType='Picklist'
-                    GlobalOptionSet=[pscustomobject]@{ Name=$column.choice }
-                    DisplayName=ConvertTo-LocalizedLabel $column.metadata.label
-                    Description=ConvertTo-LocalizedLabel $column.metadata.description
-                }) }
-            }
-            if ($Method -eq 'GET' -and $Path -match '/ManyToOneRelationships\?') {
-                return [pscustomobject]@{ value=@() }
-            }
             if ($Method -eq 'GET' -and
                 $Path -like "/GlobalOptionSetDefinitions(Name='*") {
                 return [pscustomobject]@{
                     MetadataId='11111111-1111-1111-1111-111111111111'
                 }
-            }
-            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
-                return [pscustomobject]@{ ObjectTypeCode=10427 }
             }
             if ($Method -eq 'POST' -and $Path -eq '/EntityDefinitions') {
                 $script:tableExists = $true
@@ -886,9 +1199,9 @@ Describe 'Insurance Foundation reconciliation' {
         { Invoke-TableReconciliation $table } | Should -Not -Throw
 
         $recoveryMutations = @($script:calls[$beforeRecovery..($script:calls.Count - 1)] |
-            Where-Object Method -ne 'GET')
-        $recoveryMutations[0].Path | Should -Be '/PublishXml'
-        $recoveryMutations[1].Path | Should -Be '/CreateCustomerRelationships'
+            Where-Object { $_.Method -in @('POST', 'PATCH', 'PUT') })
+        $recoveryMutations[0].Path | Should -Be '/CreateCustomerRelationships'
+        $recoveryMutations[1].Path | Should -Be '/PublishXml'
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
         }).Count | Should -Be 1
@@ -990,25 +1303,28 @@ Describe 'Insurance Foundation reconciliation' {
     It 'uses the complete deterministic mutation order' {
         Invoke-InsuranceFoundationReconciliation -Contract $script:contract -Scope All -Confirm:$false |
             Out-Null
-        $actual = @($script:calls | Where-Object Method -ne 'GET' | ForEach-Object Path)
+        $actual = @($script:calls | Where-Object {
+            $_.Method -in @('POST', 'PATCH', 'PUT')
+        } | ForEach-Object Path)
         $expected = @(
             '/GlobalOptionSetDefinitions','/GlobalOptionSetDefinitions',
             '/GlobalOptionSetDefinitions','/GlobalOptionSetDefinitions',
             '/GlobalOptionSetDefinitions',
             "/EntityDefinitions(LogicalName='account')/Attributes",
             "/EntityDefinitions(LogicalName='contact')/Attributes",
-            '/EntityDefinitions','/PublishXml',
+            '/EntityDefinitions','/PublishXml','/PublishXml',
             "/EntityDefinitions(LogicalName='crmshow_accountcontactrole')/Keys",
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/systemforms','/SetLocLabels','/SetLocLabels',
-            '/EntityDefinitions','/PublishXml',
+            '/EntityDefinitions','/PublishXml','/PublishXml',
             "/EntityDefinitions(LogicalName='crmshow_policyprojection')/Keys",
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/systemforms','/SetLocLabels','/SetLocLabels',
             '/EntityDefinitions','/PublishXml','/CreateCustomerRelationships',
+            '/PublishXml',
             "/EntityDefinitions(LogicalName='crmshow_policypartyrole')/Keys",
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
@@ -1227,59 +1543,7 @@ Describe 'Insurance Foundation reconciliation' {
         }).Count | Should -Be 1
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
-        }).Count | Should -Be 2
-    }
-
-    It 'recovers wholly absent ordinary lookup relationships on an existing table' {
-        $table = $script:contract.tables[0] |
-            ConvertTo-Json -Depth 100 | ConvertFrom-Json
-        $table.columns = @($table.columns | Where-Object type -eq 'Lookup')
-        $table.alternateKeys = @()
-        $table.businessRules = @()
-        $table.views = @()
-        $table.forms = @()
-
-        Mock Invoke-DataverseRequest {
-            param($Method, $Path, $Body, $Headers)
-            $script:calls.Add([pscustomobject]@{
-                Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
-            })
-            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
-                return [pscustomobject]@{ value=@([pscustomobject]@{
-                    MetadataId='existing-table'
-                    LogicalName=$table.logicalName
-                    OwnershipType=$table.ownership
-                    SolutionUniqueName=$table.solution
-                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
-                    Description=ConvertTo-LocalizedLabel $table.metadata.description
-                    Attributes=@()
-                    ManyToOneRelationships=@()
-                }) }
-            }
-            if ($Method -eq 'GET' -and
-                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.LookupAttributeMetadata') {
-                return [pscustomobject]@{ value=@() }
-            }
-            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
-                return [pscustomobject]@{ ObjectTypeCode=10427 }
-            }
-            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
-            return [pscustomobject]@{}
-        }
-
-        Invoke-TableReconciliation $table | Out-Null
-
-        $creates = @($script:calls | Where-Object {
-            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
-        })
-        $creates.Count | Should -Be 2
-        @($creates.Body.Lookup.LogicalName) |
-            Should -Be @('crmshow_accountid', 'crmshow_contactid')
-        @($creates.Body.SchemaName) |
-            Should -Be @(
-                'crmshow_Account_AccountContactRoles',
-                'crmshow_Contact_AccountContactRoles'
-            )
+        }).Count | Should -Be 1
     }
 
     It 'rejects destructive cascade behavior on an existing ordinary relationship' {
@@ -1944,6 +2208,263 @@ Describe 'Insurance Foundation reconciliation' {
             Invoke-InsuranceFoundationReconciliation $invalid DataModel -Confirm:$false
         } | Should -Throw '*referentially invalid*'
         $script:calls.Count | Should -Be 0
+    }
+}
+
+Describe 'Insurance Foundation table metadata convergence' {
+    BeforeEach {
+        $script:calls = [System.Collections.Generic.List[object]]::new()
+    }
+
+    It 'waits for a newly created table snapshot before reconciling keys, views, and forms' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @('crmshow_name', 'crmshow_accountid')
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq 'crmshow_accountid'
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0])
+        $table.forms = @($table.forms[0])
+        $script:tableSnapshotReads = 0
+        $script:visibleSnapshotSequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            $script:tableSnapshotReads++
+            $snapshot = if ($script:tableSnapshotReads -lt 3) {
+                $null
+            } else {
+                New-TableMetadataSnapshot -Table $table
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            if ($null -ne $snapshot) {
+                $script:visibleSnapshotSequence = $script:calls[-1].Sequence
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Method $Path" }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $script:tableSnapshotReads | Should -Be 3
+        $script:visibleSnapshotSequence | Should -Not -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
+        }).Count | Should -Be 2
+
+        $keyCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys"
+        })[0]
+        $viewCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0]
+        $formCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0]
+
+        $keyCreate.Sequence |
+            Should -BeGreaterThan $script:visibleSnapshotSequence
+        $viewCreate.Sequence |
+            Should -BeGreaterThan $script:visibleSnapshotSequence
+        $formCreate.Sequence |
+            Should -BeGreaterThan $script:visibleSnapshotSequence
+    }
+
+    It 'waits for recovered ordinary lookups before posting child keys, views, and forms' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @('crmshow_name', 'crmshow_accountid')
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq 'crmshow_accountid'
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0])
+        $table.forms = @($table.forms[0])
+        $script:relationshipCreateSeen = $false
+        $script:relationshipVisibilityReads = 0
+        $script:visibleLookupSequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            if ($script:relationshipCreateSeen) {
+                $script:relationshipVisibilityReads++
+            }
+            $isVisible = $script:relationshipVisibilityReads -ge 2
+            $snapshot = if ($isVisible) {
+                New-TableMetadataSnapshot -Table $table
+            } else {
+                New-TableMetadataSnapshot -Table $table `
+                    -OmitColumns @('crmshow_accountid') `
+                    -OmitRelationshipSchemas @(
+                        'crmshow_Account_AccountContactRoles'
+                    )
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            if ($isVisible) {
+                $script:visibleLookupSequence = $script:calls[-1].Sequence
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence=$script:calls.Count + 1
+                Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/RelationshipDefinitions') {
+                $script:relationshipCreateSeen = $true
+                return [pscustomobject]@{}
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object Method -eq 'DELETE') |
+            Should -BeNullOrEmpty
+        $script:visibleLookupSequence | Should -Not -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys"
+        })[0].Sequence | Should -BeGreaterThan $script:visibleLookupSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0].Sequence | Should -BeGreaterThan $script:visibleLookupSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0].Sequence | Should -BeGreaterThan $script:visibleLookupSequence
+    }
+
+    It 'blocks child reconciliation and reports the exact component when lookup visibility times out' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @('crmshow_name', 'crmshow_accountid')
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq 'crmshow_accountid'
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0])
+        $table.forms = @($table.forms[0])
+
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            $snapshot = New-TableMetadataSnapshot -Table $table `
+                -OmitColumns @('crmshow_accountid') `
+                -OmitRelationshipSchemas @(
+                    'crmshow_Account_AccountContactRoles'
+                )
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence=$script:calls.Count + 1
+                Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
+            })
+            if ($Method -eq 'POST' -and $Path -eq '/RelationshipDefinitions') {
+                return [pscustomobject]@{}
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw (
+            '*EventualConsistencyTimeout*' +
+            "$($table.logicalName)/crmshow_accountid*180*"
+        )
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @(
+                "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys",
+                '/savedqueries',
+                '/systemforms'
+            )
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        }).Count | Should -Be 1
     }
 }
 

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1894,34 +1894,48 @@ Describe 'Insurance Foundation reconciliation' {
         $table.views = @()
         $table.forms = @()
         $metadataId = '22222222-2222-2222-2222-222222222222'
+        $script:tableSnapshotReads = 0
 
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
+        Mock Wait-TableMetadataSnapshot {
+            param($Table, $Component, $Ready, $RequestedAttributeLogicalNames)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @($choiceColumn.logicalName)
+                }
+                default { New-TableMetadataSnapshot -Table $table }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Method = 'SNAPSHOT'
+                Path = $Component
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            if ($Ready -and -not (& $Ready $snapshot)) {
+                return $null
+            }
+            return $snapshot
+        }
         Mock Invoke-DataverseRequest {
             param($Method, $Path, $Body, $Headers)
             $script:calls.Add([pscustomobject]@{
                 Method=$Method; Path=$Path; Body=$Body; Headers=$Headers
             })
-            if ($Method -eq 'GET' -and $Path -match '^/EntityDefinitions\?') {
-                return [pscustomobject]@{ value=@([pscustomobject]@{
-                    MetadataId='existing-table'
-                    LogicalName=$table.logicalName
-                    OwnershipType=$table.ownership
-                    SolutionUniqueName=$table.solution
-                    DisplayName=ConvertTo-LocalizedLabel $table.metadata.label
-                    Description=ConvertTo-LocalizedLabel $table.metadata.description
-                    Attributes=@()
-                    ManyToOneRelationships=@()
-                }) }
-            }
-            if ($Method -eq 'GET' -and
-                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata') {
-                return [pscustomobject]@{ value=@() }
-            }
             if ($Method -eq 'GET' -and
                 $Path -like "/GlobalOptionSetDefinitions(Name='*") {
                 return [pscustomobject]@{ MetadataId=$metadataId }
-            }
-            if ($Method -eq 'GET' -and $Path -match 'ObjectTypeCode') {
-                return [pscustomobject]@{ ObjectTypeCode=10427 }
             }
             if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
             return [pscustomobject]@{}
@@ -1938,6 +1952,7 @@ Describe 'Insurance Foundation reconciliation' {
         $create.Count | Should -Be 1
         $create[0].Body.'GlobalOptionSet@odata.bind' |
             Should -Be "/GlobalOptionSetDefinitions($metadataId)"
+        $script:tableSnapshotReads | Should -Be 2
     }
 
     It 'throws on lookup target and alternate-key structural conflicts' {
@@ -2573,6 +2588,299 @@ Describe 'Insurance Foundation table metadata convergence' {
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
         }).Count | Should -Be 1
+    }
+
+    It 'waits for a newly created scalar attribute on an existing table before publishing and posting children' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_accountid',
+                'crmshow_contactid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -in @('crmshow_accountid', 'crmshow_contactid')
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $script:tableSnapshotReads = 0
+        $script:firstPostCreateMissingSequence = $null
+        $script:visibleValidFromSequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'EXISTS'
+                Path = $LogicalName
+                Body = $null
+                Headers = $null
+            })
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @('crmshow_validfrom')
+                }
+                2 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @('crmshow_validfrom')
+                }
+                default { New-TableMetadataSnapshot -Table $table }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            $hasValidFrom = $null -ne $snapshot -and
+                @($snapshot.Attributes | Where-Object {
+                    $_.LogicalName -eq 'crmshow_validfrom'
+                }).Count -eq 1
+            if ($script:tableSnapshotReads -eq 2 -and -not $hasValidFrom) {
+                $script:firstPostCreateMissingSequence = `
+                    $script:calls[-1].Sequence
+            }
+            if ($hasValidFrom -and
+                $null -eq $script:visibleValidFromSequence) {
+                $script:visibleValidFromSequence = `
+                    $script:calls[-1].Sequence
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $attributeCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        })
+        $attributeCreate.Count | Should -Be 1
+        $attributeCreate[0].Body.LogicalName | Should -Be 'crmshow_validfrom'
+        $script:tableSnapshotReads | Should -Be 3
+        $script:firstPostCreateMissingSequence | Should -Not -BeNullOrEmpty
+        $script:visibleValidFromSequence | Should -Not -BeNullOrEmpty
+        $script:visibleValidFromSequence |
+            Should -BeGreaterThan $script:firstPostCreateMissingSequence
+
+        foreach ($snapshotCall in @($script:calls | Where-Object {
+            $_.Method -eq 'SNAPSHOT'
+        })) {
+            @($snapshotCall.RequestedAttributeLogicalNames | Sort-Object) |
+                Should -Be @($table.columns.logicalName | Sort-Object)
+        }
+
+        $publish = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
+        })[0]
+        $keyCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys"
+        })[0]
+        $viewCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0]
+        $formCreate = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0]
+
+        $publish.Sequence |
+            Should -BeGreaterThan $script:visibleValidFromSequence
+        $keyCreate.Sequence |
+            Should -BeGreaterThan $script:visibleValidFromSequence
+        $viewCreate.Sequence |
+            Should -BeGreaterThan $script:visibleValidFromSequence
+        $formCreate.Sequence |
+            Should -BeGreaterThan $script:visibleValidFromSequence
+    }
+
+    It 'times out scalar attribute visibility on an existing table without duplicating the create or posting children' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_accountid',
+                'crmshow_contactid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -in @('crmshow_accountid', 'crmshow_contactid')
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'EXISTS'
+                Path = $LogicalName
+                Body = $null
+                Headers = $null
+            })
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $snapshot = New-TableMetadataSnapshot -Table $table `
+                -OmitColumns @('crmshow_validfrom')
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw (
+            '*EventualConsistencyTimeout*' +
+            "$($table.logicalName)/crmshow_validfrom*180*"
+        )
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @(
+                '/PublishXml',
+                "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys",
+                '/savedqueries',
+                '/systemforms'
+            )
+        }) | Should -BeNullOrEmpty
     }
 
     It 'waits for all deep-inserted initial lookups atomically on a newly created table before posting child keys, views, and forms' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -377,6 +377,116 @@ Describe 'Insurance Foundation request builders' {
         $source | Should -Not -Match '\$expand=Attributes\([^\r\n]*\$expand=GlobalOptionSet'
     }
 
+    It 'derives initial table-create readiness attributes from the actual create request' {
+        $table = $script:contract.tables[2]
+        $request = Get-TableCreateRequest -Table $table
+
+        @((Get-RequestSubmittedAttributeLogicalNames `
+                -Request $request -Table $table) | Sort-Object) |
+            Should -Be @(
+                'crmshow_name',
+                'crmshow_policyid',
+                'crmshow_roletype',
+                'crmshow_sourceid',
+                'crmshow_sourcesystem',
+                'crmshow_validfrom',
+                'crmshow_validto'
+            )
+        @((Get-RequestSubmittedRelationshipSchemas -Request $request) |
+                Sort-Object) |
+            Should -Be @('crmshow_PolicyProjection_PartyRoles')
+    }
+
+    It 'limits typed table metadata fetches to requested contract attributes' {
+        $table = $script:contract.tables[1]
+        $requestedAttributeLogicalNames = @(
+            'crmshow_name',
+            'crmshow_policynumber',
+            'crmshow_status'
+        )
+        $snapshot = New-TableMetadataSnapshot -Table $table
+        $requestedAttributes = @($snapshot.Attributes | Where-Object {
+            $_.LogicalName -in $requestedAttributeLogicalNames
+        })
+        $script:entityDefinitionPath = $null
+        $script:typedAttributeRequests = [System.Collections.Generic.List[string]]::new()
+
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path)
+            if ($Method -ne 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            if ($Path -like '/EntityDefinitions?*' -and
+                $Path -match '\$expand=Attributes') {
+                $script:entityDefinitionPath = $Path
+                return [pscustomobject]@{
+                    value = @([pscustomobject]@{
+                        MetadataId = $snapshot.MetadataId
+                        LogicalName = $snapshot.LogicalName
+                        SchemaName = $snapshot.SchemaName
+                        OwnershipType = $snapshot.OwnershipType
+                        PrimaryNameAttribute = $snapshot.PrimaryNameAttribute
+                        ObjectTypeCode = $snapshot.ObjectTypeCode
+                        DisplayName = $snapshot.DisplayName
+                        Description = $snapshot.Description
+                        Attributes = @(
+                            $requestedAttributes +
+                            @([pscustomobject]@{
+                                MetadataId = 'attribute-createdon'
+                                LogicalName = 'createdon'
+                                SchemaName = 'CreatedOn'
+                                AttributeType = 'DateTime'
+                                DisplayName = @{ marker = 'unrelated' }
+                                Description = @{ marker = 'unrelated' }
+                            })
+                        )
+                        ManyToOneRelationships = @(
+                            $snapshot.ManyToOneRelationships
+                        )
+                    })
+                }
+            }
+            if ($Path -match (
+                "^/EntityDefinitions\(LogicalName='((?:[^']|'')*)'\)" +
+                '/Attributes/Microsoft\.Dynamics\.CRM\.' +
+                '(StringAttributeMetadata|DateTimeAttributeMetadata|' +
+                'LookupAttributeMetadata|PicklistAttributeMetadata)\?'
+            )) {
+                $script:typedAttributeRequests.Add($Path) | Out-Null
+                $logicalName = $Matches[1].Replace("''", "'")
+                $typeName = $Matches[2]
+                $attributeLogicalName = [regex]::Match(
+                    $Path,
+                    "LogicalName eq '((?:[^']|'')*)'"
+                ).Groups[1].Value.Replace("''", "'")
+                return New-TableTypedAttributeCollectionResponse `
+                    -Table $table -TypeName $typeName `
+                    -AttributeLogicalName $attributeLogicalName
+            }
+            throw "Unsupported mocked endpoint: $Method $Path"
+        }
+
+        $result = Get-TableMetadataSnapshot `
+            -LogicalName $table.logicalName `
+            -RequestedAttributeLogicalNames $requestedAttributeLogicalNames
+
+        @($result.Attributes.LogicalName | Sort-Object) |
+            Should -Be @($requestedAttributeLogicalNames | Sort-Object)
+        $expectedAttributeFilter = [regex]::Escape(
+            "LogicalName eq 'crmshow_name' or " +
+            "LogicalName eq 'crmshow_policynumber' or " +
+            "LogicalName eq 'crmshow_status'"
+        )
+        $script:entityDefinitionPath | Should -Match $expectedAttributeFilter
+        $script:typedAttributeRequests.Count | Should -Be 3
+        @($script:typedAttributeRequests | Where-Object {
+            $_ -match "LogicalName eq 'createdon'"
+        }) | Should -BeNullOrEmpty
+        (@($result.Attributes | Where-Object {
+            $_.LogicalName -eq 'crmshow_status'
+        })[0].GlobalOptionSet.Name) | Should -Be 'crmshow_policystatus'
+    }
+
     It 'builds the documented Customer relationship action' {
         $table = $script:contract.tables[2]
         $column = $table.columns | Where-Object logicalName -eq 'crmshow_partyid'
@@ -483,6 +593,24 @@ Describe 'Dataverse metadata convergence waits' {
             '*EventualConsistencyTimeout*' +
             'crmshow_policyprojection/crmshow_accountid*180*'
         )
+    }
+
+    It 'treats a late non-null condition result as a timeout' {
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            [datetime]'2026-08-09T12:00:00Z',
+            [datetime]'2026-08-09T12:00:11Z'
+        )) {
+            $script:clock.Enqueue($value)
+        }
+        Mock Get-Date { $script:clock.Dequeue() }
+
+        {
+            Wait-DataverseCondition -Component 'crmshow_table' `
+                -TimeoutSeconds 10 -Condition {
+                    [pscustomobject]@{ marker = 'late' }
+                }
+        } | Should -Throw '*EventualConsistencyTimeout*crmshow_table*10*'
     }
 
     It 'bounds each sleep to the remaining deadline' {
@@ -631,7 +759,7 @@ Describe 'Insurance Foundation reconciliation' {
         $script:tablesWithCustomerRelationships = `
             [System.Collections.Generic.HashSet[string]]::new()
         Mock Wait-TableMetadataSnapshot {
-            param($Table, $Component, $Ready)
+            param($Table, $Component, $Ready, $RequestedAttributeLogicalNames)
             $includeCustomerRelationships = @(
                 $Table.columns | Where-Object type -eq 'Customer'
             ).Count -eq 0 -or
@@ -1143,7 +1271,7 @@ Describe 'Insurance Foundation reconciliation' {
 
         Mock Start-Sleep {}
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             if ($LogicalName -ne $table.logicalName -or
                 -not $script:tableExists) {
                 return $null
@@ -1154,7 +1282,7 @@ Describe 'Insurance Foundation reconciliation' {
                 )
         }
         Mock Wait-TableMetadataSnapshot {
-            param($Table, $Component, $Ready)
+            param($Table, $Component, $Ready, $RequestedAttributeLogicalNames)
             $snapshot = Get-TableMetadataSnapshot $Table.logicalName
             $script:calls.Add([pscustomobject]@{
                 Sequence=$script:calls.Count + 1
@@ -2234,7 +2362,7 @@ Describe 'Insurance Foundation table metadata convergence' {
 
         Mock Start-Sleep {}
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             $script:tableSnapshotReads++
             $snapshot = if ($script:tableSnapshotReads -lt 3) {
                 $null
@@ -2322,7 +2450,7 @@ Describe 'Insurance Foundation table metadata convergence' {
 
         Mock Start-Sleep {}
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             $script:tableSnapshotReads++
             $snapshot = switch ($script:tableSnapshotReads) {
                 1 { $null }
@@ -2359,6 +2487,9 @@ Describe 'Insurance Foundation table metadata convergence' {
                 Path = $LogicalName
                 Body = $snapshot
                 Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
             })
             if ($null -ne $snapshot -and
                 $null -eq $script:firstVisibleTableSequence) {
@@ -2452,6 +2583,142 @@ Describe 'Insurance Foundation table metadata convergence' {
         })[0].Sequence | Should -BeGreaterThan $script:initialLookupReadySequence
     }
 
+    It 'waits for all initial scalar table-create attributes before posting children and never recreates them' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_accountid',
+                'crmshow_contactid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $script:tableSnapshotReads = 0
+        $script:partialScalarSequence = $null
+        $script:fullReadySequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 { $null }
+                2 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @(
+                            'crmshow_roletype',
+                            'crmshow_validfrom'
+                        )
+                }
+                default { New-TableMetadataSnapshot -Table $table }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            if ($null -ne $snapshot) {
+                $hasRoleType = @($snapshot.Attributes | Where-Object {
+                    $_.LogicalName -eq 'crmshow_roletype'
+                }).Count -eq 1
+                $hasValidFrom = @($snapshot.Attributes | Where-Object {
+                    $_.LogicalName -eq 'crmshow_validfrom'
+                }).Count -eq 1
+                if (-not $hasRoleType -and -not $hasValidFrom) {
+                    $script:partialScalarSequence = $script:calls[-1].Sequence
+                }
+                if ($hasRoleType -and $hasValidFrom) {
+                    $script:fullReadySequence = $script:calls[-1].Sequence
+                }
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $script:partialScalarSequence | Should -Not -BeNullOrEmpty
+        $script:fullReadySequence | Should -Not -BeNullOrEmpty
+        $script:fullReadySequence |
+            Should -BeGreaterThan $script:partialScalarSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        foreach ($snapshotCall in @($script:calls | Where-Object {
+            $_.Method -eq 'SNAPSHOT'
+        })) {
+            @($snapshotCall.RequestedAttributeLogicalNames | Sort-Object) |
+                Should -Be @($table.columns.logicalName | Sort-Object)
+        }
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys"
+        })[0].Sequence | Should -BeGreaterThan $script:fullReadySequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0].Sequence | Should -BeGreaterThan $script:fullReadySequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0].Sequence | Should -BeGreaterThan $script:fullReadySequence
+    }
+
     It 'fails closed instead of recreating an InitialTableCreate relationship after a current-run table already passed atomic readiness' {
         $table = $script:contract.tables[2] |
             ConvertTo-Json -Depth 100 | ConvertFrom-Json
@@ -2470,7 +2737,7 @@ Describe 'Insurance Foundation table metadata convergence' {
 
         Mock Start-Sleep {}
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             $script:tableSnapshotReads++
             $snapshot = switch ($script:tableSnapshotReads) {
                 1 { $null }
@@ -2518,6 +2785,79 @@ Describe 'Insurance Foundation table metadata convergence' {
         }) | Should -BeNullOrEmpty
     }
 
+    It 'fails closed instead of recreating an InitialTableCreate scalar attribute after a current-run table already passed atomic readiness' {
+        $table = $script:contract.tables[2] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_policyid',
+                'crmshow_partyid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+        $script:tableSnapshotReads = 0
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 { $null }
+                2 { New-TableMetadataSnapshot -Table $table }
+                default {
+                    New-TableMetadataSnapshot -Table $table `
+                        -IncludeCustomerRelationships `
+                        -OmitColumns @('crmshow_roletype')
+                }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw '*current-run InitialTableCreate metadata is absent after atomic readiness; recovery POST is forbidden*'
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/CreateCustomerRelationships'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+    }
+
     It 'times out initial deep-insert lookup visibility without recreating the relationship or children' {
         $table = $script:contract.tables[0] |
             ConvertTo-Json -Depth 100 | ConvertFrom-Json
@@ -2545,7 +2885,7 @@ Describe 'Insurance Foundation table metadata convergence' {
         Mock Start-Sleep {}
         Mock Get-Date { $script:clock.Dequeue() }
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             $snapshot = if ($script:calls.Count -eq 0) {
                 $null
             } else {
@@ -2598,6 +2938,112 @@ Describe 'Insurance Foundation table metadata convergence' {
         }) | Should -BeNullOrEmpty
     }
 
+    It 'times out initial scalar visibility without recreating the attribute or children' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_accountid',
+                'crmshow_contactid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_accountid',
+            'crmshow_contactid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $snapshot = if ($script:calls.Count -eq 0) {
+                $null
+            } else {
+                New-TableMetadataSnapshot -Table $table `
+                    -OmitColumns @('crmshow_roletype')
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw '*EventualConsistencyTimeout*180*'
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @(
+                '/RelationshipDefinitions',
+                "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys",
+                '/savedqueries',
+                '/systemforms'
+            )
+        }) | Should -BeNullOrEmpty
+    }
+
     It 'waits for recovered ordinary lookups before posting child keys, views, and forms' {
         $table = $script:contract.tables[0] |
             ConvertTo-Json -Depth 100 | ConvertFrom-Json
@@ -2617,7 +3063,7 @@ Describe 'Insurance Foundation table metadata convergence' {
 
         Mock Start-Sleep {}
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             if ($script:relationshipCreateSeen) {
                 $script:relationshipVisibilityReads++
             }
@@ -2714,7 +3160,7 @@ Describe 'Insurance Foundation table metadata convergence' {
         Mock Start-Sleep {}
         Mock Get-Date { $script:clock.Dequeue() }
         Mock Get-TableMetadataSnapshot {
-            param($LogicalName)
+            param($LogicalName, $RequestedAttributeLogicalNames)
             $snapshot = New-TableMetadataSnapshot -Table $table `
                 -OmitColumns @('crmshow_accountid') `
                 -OmitRelationshipSchemas @(

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -4563,6 +4563,7 @@ function pac { throw 'pac was called' }
         $expectedSuites = @(
             'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'
             'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'
+            'scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1'
             'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'
             'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'
             'scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1'
@@ -4597,7 +4598,7 @@ function pac { throw 'pac was called' }
         $script:authoringWorkflow | Should -Not -Match '\${{\s*secrets\.'
     }
 
-    It 'classifies preflight exit code 2 with runbook guidance before mutation' {
+    It 'captures, echoes, and classifies preflight JSON before mutation' {
         $preflight = $script:authoringWorkflow.IndexOf(
             '- name: Run authoring preflight'
         )
@@ -4607,17 +4608,34 @@ function pac { throw 'pac was called' }
         $metadata = $script:authoringWorkflow.IndexOf(
             '- name: Reconcile demo-safe metadata'
         )
+        $capture = $script:authoringWorkflow.IndexOf(
+            '$preflightJsonLines = & $pwsh'
+        )
+        $exitCapture = $script:authoringWorkflow.IndexOf(
+            '$exitCode = $LASTEXITCODE'
+        )
+        $logJson = $script:authoringWorkflow.IndexOf(
+            'Write-Host $preflightJson'
+        )
+        $failure = $script:authoringWorkflow.IndexOf(
+            'throw (Get-InsuranceAuthoringPreflightFailureMessage'
+        )
 
         $preflight | Should -BeGreaterOrEqual 0
         $preflight | Should -BeLessThan $languages
         $preflight | Should -BeLessThan $metadata
-        $script:authoringWorkflow | Should -Match 'if \(\$exitCode -eq 2\)'
-        $script:authoringWorkflow | Should -Match (
-            [regex]::Escape(
-                'docs/runbooks/insurance-foundation-security-role-bootstrap.md'
-            )
-        )
+        $capture | Should -BeGreaterOrEqual 0
+        $capture | Should -BeLessThan $exitCapture
+        $exitCapture | Should -BeLessThan $logJson
+        $logJson | Should -BeLessThan $failure
         $script:authoringWorkflow | Should -Match 'Test-InsuranceAuthoringPreflight\.ps1'
+        $script:authoringWorkflow | Should -Match (
+            'Get-InsuranceAuthoringPreflightFailureMessage\.ps1'
+        )
+        $script:authoringWorkflow | Should -Match 'Write-Host \$preflightJson'
+        $script:authoringWorkflow | Should -Match (
+            'throw \(Get-InsuranceAuthoringPreflightFailureMessage'
+        )
     }
 
     It 'reconciles only demo-safe metadata and never requests full or role authoring' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1112,7 +1112,7 @@ Describe 'Insurance Foundation reconciliation' {
         })
         $customerVisibilityReads = @($script:calls | Where-Object {
             $_.Method -eq 'SNAPSHOT' -and
-            $_.Path -eq 'crmshow_policypartyrole' -and
+            $_.Path -like 'crmshow_policypartyrole*' -and
             $_.Sequence -gt $initialPublish.Sequence -and
             $_.Sequence -lt $customerCreate[0].Sequence
         })
@@ -2300,14 +2300,15 @@ Describe 'Insurance Foundation table metadata convergence' {
             Should -BeGreaterThan $script:visibleSnapshotSequence
     }
 
-    It 'waits for deep-inserted initial lookups on a newly created table before posting child keys, views, and forms' {
+    It 'waits for all deep-inserted initial lookups atomically on a newly created table before posting child keys, views, and forms' {
         $table = $script:contract.tables[0] |
             ConvertTo-Json -Depth 100 | ConvertFrom-Json
         $table.columns = @($table.columns | Where-Object {
-            $_.logicalName -in @('crmshow_name', 'crmshow_accountid')
-        })
-        $table.relationships = @($table.relationships | Where-Object {
-            $_.lookupColumn -eq 'crmshow_accountid'
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_accountid',
+                'crmshow_contactid'
+            )
         })
         $table.alternateKeys = @($table.alternateKeys[0])
         $table.businessRules = @()
@@ -2315,6 +2316,8 @@ Describe 'Insurance Foundation table metadata convergence' {
         $table.forms = @($table.forms[0])
         $script:tableSnapshotReads = 0
         $script:firstVisibleTableSequence = $null
+        $script:accountLookupOnlySequence = $null
+        $script:contactLookupOnlySequence = $null
         $script:initialLookupReadySequence = $null
 
         Mock Start-Sleep {}
@@ -2324,6 +2327,24 @@ Describe 'Insurance Foundation table metadata convergence' {
             $snapshot = switch ($script:tableSnapshotReads) {
                 1 { $null }
                 2 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @(
+                            'crmshow_accountid',
+                            'crmshow_contactid'
+                        ) `
+                        -OmitRelationshipSchemas @(
+                            'crmshow_Account_AccountContactRoles',
+                            'crmshow_Contact_AccountContactRoles'
+                        )
+                }
+                3 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @('crmshow_contactid') `
+                        -OmitRelationshipSchemas @(
+                            'crmshow_Contact_AccountContactRoles'
+                        )
+                }
+                4 {
                     New-TableMetadataSnapshot -Table $table `
                         -OmitColumns @('crmshow_accountid') `
                         -OmitRelationshipSchemas @(
@@ -2344,16 +2365,37 @@ Describe 'Insurance Foundation table metadata convergence' {
                 $script:firstVisibleTableSequence = $script:calls[-1].Sequence
             }
             if ($null -ne $snapshot) {
-                $lookupMatches = @($snapshot.Attributes | Where-Object {
+                $accountLookupMatches = @($snapshot.Attributes | Where-Object {
                     $_.LogicalName -eq 'crmshow_accountid'
                 })
-                $relationshipMatches = @(
+                $accountRelationshipMatches = @(
                     $snapshot.ManyToOneRelationships | Where-Object {
                         $_.SchemaName -eq 'crmshow_Account_AccountContactRoles'
                     }
                 )
-                if ($lookupMatches.Count -eq 1 -and
-                    $relationshipMatches.Count -eq 1) {
+                $contactLookupMatches = @($snapshot.Attributes | Where-Object {
+                    $_.LogicalName -eq 'crmshow_contactid'
+                })
+                $contactRelationshipMatches = @(
+                    $snapshot.ManyToOneRelationships | Where-Object {
+                        $_.SchemaName -eq 'crmshow_Contact_AccountContactRoles'
+                    }
+                )
+                $hasAccountLookup = $accountLookupMatches.Count -eq 1 -and
+                    $accountRelationshipMatches.Count -eq 1
+                $hasContactLookup = $contactLookupMatches.Count -eq 1 -and
+                    $contactRelationshipMatches.Count -eq 1
+                if ($hasAccountLookup -and -not $hasContactLookup -and
+                    $null -eq $script:accountLookupOnlySequence) {
+                    $script:accountLookupOnlySequence = `
+                        $script:calls[-1].Sequence
+                }
+                if ($hasContactLookup -and -not $hasAccountLookup -and
+                    $null -eq $script:contactLookupOnlySequence) {
+                    $script:contactLookupOnlySequence = `
+                        $script:calls[-1].Sequence
+                }
+                if ($hasAccountLookup -and $hasContactLookup) {
                     $script:initialLookupReadySequence = `
                         $script:calls[-1].Sequence
                 }
@@ -2389,8 +2431,14 @@ Describe 'Insurance Foundation table metadata convergence' {
             $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
         }).Count | Should -Be 0
         $script:firstVisibleTableSequence | Should -Not -BeNullOrEmpty
+        $script:accountLookupOnlySequence | Should -Not -BeNullOrEmpty
+        $script:contactLookupOnlySequence | Should -Not -BeNullOrEmpty
         $script:initialLookupReadySequence | Should -Not -BeNullOrEmpty
         $script:firstVisibleTableSequence |
+            Should -BeLessThan $script:accountLookupOnlySequence
+        $script:accountLookupOnlySequence |
+            Should -BeLessThan $script:initialLookupReadySequence
+        $script:contactLookupOnlySequence |
             Should -BeLessThan $script:initialLookupReadySequence
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and
@@ -2402,6 +2450,72 @@ Describe 'Insurance Foundation table metadata convergence' {
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
         })[0].Sequence | Should -BeGreaterThan $script:initialLookupReadySequence
+    }
+
+    It 'fails closed instead of recreating an InitialTableCreate relationship after a current-run table already passed atomic readiness' {
+        $table = $script:contract.tables[2] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_policyid',
+                'crmshow_partyid'
+            )
+        })
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+        $script:tableSnapshotReads = 0
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 { $null }
+                2 { New-TableMetadataSnapshot -Table $table }
+                default {
+                    New-TableMetadataSnapshot -Table $table `
+                        -IncludeCustomerRelationships `
+                        -OmitColumns @('crmshow_policyid') `
+                        -OmitRelationshipSchemas @(
+                            'crmshow_PolicyProjection_PartyRoles'
+                        )
+                }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Method $Path" }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw '*current-run InitialTableCreate metadata is absent after atomic readiness*'
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/CreateCustomerRelationships'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        }) | Should -BeNullOrEmpty
     }
 
     It 'times out initial deep-insert lookup visibility without recreating the relationship or children' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -843,8 +843,9 @@ Describe 'az rest transport' {
         $message | Should -Match 'crmshow_accounttype'
         $message | Should -Match 'Permission denied'
         $message | Should -Match 'blocked'
+        $message | Should -Match 'Output:'
         $message | Should -Match (
-            [regex]::Escape("Output: '::warning::publish transport")
+            [regex]::Escape('::warning::publish transport')
         )
         $message | Should -Not -Match 'At line:|--body|--headers|--method|--url|--resource'
     }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -5,6 +5,20 @@ BeforeAll {
     . $script:publisherPath -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath $script:contractPath
     $script:contract = Get-Content $script:contractPath -Raw | ConvertFrom-Json
 
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+
     function Get-ContractTableByLogicalName {
         param([Parameter(Mandatory)] [string]$LogicalName)
         return @($script:contract.tables | Where-Object logicalName -eq $LogicalName)[0]
@@ -743,16 +757,35 @@ Describe 'az rest transport' {
         Get-GlobalOptionSet 'crmshow_accounttype' | Should -BeNullOrEmpty
     }
 
-    It 'does not hide a non-404 Dataverse error emitted by az on stderr' {
+    It 'sanitizes hostile non-404 Dataverse stderr without leaking command formatting' {
+        $escape = [char]27
         function global:az {
-            Write-Error 'ERROR: {"error":{"code":"0x80040265","message":"Permission denied"}}' `
-                -ErrorAction Continue
+            Write-Error (
+                "::warning::publish transport`r`n" +
+                'ERROR: {"error":{"code":"0x80040265","message":"Permission denied"}}' +
+                "`t$escape[31mblocked$escape[0m"
+            ) -ErrorAction Continue
             $global:LASTEXITCODE = 4
         }
 
-        {
-            Get-GlobalOptionSet 'crmshow_accounttype'
-        } | Should -Throw '*exited with code 4*Permission denied*'
+        $message = $null
+        try {
+            Get-GlobalOptionSet 'crmshow_accounttype' | Out-Null
+            throw 'Expected transport failure.'
+        }
+        catch {
+            $message = $_.Exception.Message
+        }
+
+        script:Assert-SafeDiagnosticLine -Text $message -MaxLength 400
+        $message | Should -Match 'exited with code 4'
+        $message | Should -Match 'crmshow_accounttype'
+        $message | Should -Match 'Permission denied'
+        $message | Should -Match 'blocked'
+        $message | Should -Match (
+            [regex]::Escape("Output: '::warning::publish transport")
+        )
+        $message | Should -Not -Match 'At line:|--body|--headers|--method|--url|--resource'
     }
 }
 
@@ -4563,6 +4596,7 @@ function pac { throw 'pac was called' }
         $expectedSuites = @(
             'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'
             'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'
+            'scripts/solution/tests/ConvertTo-SafeCliDiagnosticLine.Tests.ps1'
             'scripts/solution/tests/Get-InsuranceAuthoringPreflightFailureMessage.Tests.ps1'
             'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'
             'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -2275,7 +2275,7 @@ Describe 'Insurance Foundation table metadata convergence' {
 
         Invoke-TableReconciliation $table | Out-Null
 
-        $script:tableSnapshotReads | Should -Be 3
+        $script:tableSnapshotReads | Should -BeGreaterThan 2
         $script:visibleSnapshotSequence | Should -Not -BeNullOrEmpty
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
@@ -2298,6 +2298,190 @@ Describe 'Insurance Foundation table metadata convergence' {
             Should -BeGreaterThan $script:visibleSnapshotSequence
         $formCreate.Sequence |
             Should -BeGreaterThan $script:visibleSnapshotSequence
+    }
+
+    It 'waits for deep-inserted initial lookups on a newly created table before posting child keys, views, and forms' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @('crmshow_name', 'crmshow_accountid')
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq 'crmshow_accountid'
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0])
+        $table.forms = @($table.forms[0])
+        $script:tableSnapshotReads = 0
+        $script:firstVisibleTableSequence = $null
+        $script:initialLookupReadySequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 { $null }
+                2 {
+                    New-TableMetadataSnapshot -Table $table `
+                        -OmitColumns @('crmshow_accountid') `
+                        -OmitRelationshipSchemas @(
+                            'crmshow_Account_AccountContactRoles'
+                        )
+                }
+                default { New-TableMetadataSnapshot -Table $table }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            if ($null -ne $snapshot -and
+                $null -eq $script:firstVisibleTableSequence) {
+                $script:firstVisibleTableSequence = $script:calls[-1].Sequence
+            }
+            if ($null -ne $snapshot) {
+                $lookupMatches = @($snapshot.Attributes | Where-Object {
+                    $_.LogicalName -eq 'crmshow_accountid'
+                })
+                $relationshipMatches = @(
+                    $snapshot.ManyToOneRelationships | Where-Object {
+                        $_.SchemaName -eq 'crmshow_Account_AccountContactRoles'
+                    }
+                )
+                if ($lookupMatches.Count -eq 1 -and
+                    $relationshipMatches.Count -eq 1) {
+                    $script:initialLookupReadySequence = `
+                        $script:calls[-1].Sequence
+                }
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Method $Path" }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        }).Count | Should -Be 0
+        $script:firstVisibleTableSequence | Should -Not -BeNullOrEmpty
+        $script:initialLookupReadySequence | Should -Not -BeNullOrEmpty
+        $script:firstVisibleTableSequence |
+            Should -BeLessThan $script:initialLookupReadySequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys"
+        })[0].Sequence | Should -BeGreaterThan $script:initialLookupReadySequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0].Sequence | Should -BeGreaterThan $script:initialLookupReadySequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0].Sequence | Should -BeGreaterThan $script:initialLookupReadySequence
+    }
+
+    It 'times out initial deep-insert lookup visibility without recreating the relationship or children' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @('crmshow_name', 'crmshow_accountid')
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq 'crmshow_accountid'
+        })
+        $table.alternateKeys = @($table.alternateKeys[0])
+        $table.businessRules = @()
+        $table.views = @($table.views[0])
+        $table.forms = @($table.forms[0])
+
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName)
+            $snapshot = if ($script:calls.Count -eq 0) {
+                $null
+            } else {
+                New-TableMetadataSnapshot -Table $table `
+                    -OmitColumns @('crmshow_accountid') `
+                    -OmitRelationshipSchemas @(
+                        'crmshow_Account_AccountContactRoles'
+                    )
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET') { throw "Unsupported mocked endpoint: $Path" }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw (
+            '*EventualConsistencyTimeout*' +
+            "$($table.logicalName)/crmshow_accountid*180*"
+        )
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @(
+                '/RelationshipDefinitions',
+                "/EntityDefinitions(LogicalName='$($table.logicalName)')/Keys",
+                '/savedqueries',
+                '/systemforms'
+            )
+        }) | Should -BeNullOrEmpty
     }
 
     It 'waits for recovered ordinary lookups before posting child keys, views, and forms' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -487,6 +487,37 @@ Describe 'Insurance Foundation request builders' {
         })[0].GlobalOptionSet.Name) | Should -Be 'crmshow_policystatus'
     }
 
+    It 'queries table existence without expanding attributes or typed endpoints' {
+        $script:paths = [System.Collections.Generic.List[string]]::new()
+
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path)
+            if ($Method -ne 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            $script:paths.Add($Path) | Out-Null
+            return [pscustomobject]@{
+                value = @([pscustomobject]@{
+                    MetadataId = 'existing-table'
+                    LogicalName = 'crmshow_policyprojection'
+                    SchemaName = 'crmshow_PolicyProjection'
+                })
+            }
+        }
+
+        $result = Get-TableExistenceSnapshot -LogicalName 'crmshow_policyprojection'
+
+        $result.MetadataId | Should -Be 'existing-table'
+        @($script:paths) | Should -Be @(
+            "/EntityDefinitions?" +
+            "`$select=MetadataId,LogicalName,SchemaName&" +
+            "`$filter=LogicalName eq 'crmshow_policyprojection'"
+        )
+        $script:paths[0] | Should -Not -Match '\$expand=Attributes'
+        $script:paths[0] |
+            Should -Not -Match '/Attributes/Microsoft\.Dynamics\.CRM\.'
+    }
+
     It 'builds the documented Customer relationship action' {
         $table = $script:contract.tables[2]
         $column = $table.columns | Where-Object logicalName -eq 'crmshow_partyid'
@@ -760,6 +791,16 @@ Describe 'Insurance Foundation reconciliation' {
             [System.Collections.Generic.HashSet[string]]::new()
         Mock Wait-TableMetadataSnapshot {
             param($Table, $Component, $Ready, $RequestedAttributeLogicalNames)
+            if (-not $script:createdTables.Contains($Table.logicalName)) {
+                $snapshot = Get-TableMetadataSnapshot `
+                    -LogicalName $Table.logicalName `
+                    -RequestedAttributeLogicalNames `
+                        $RequestedAttributeLogicalNames
+                if ($Ready -and -not (& $Ready $snapshot)) {
+                    return $null
+                }
+                return $snapshot
+            }
             $includeCustomerRelationships = @(
                 $Table.columns | Where-Object type -eq 'Customer'
             ).Count -eq 0 -or
@@ -963,21 +1004,28 @@ Describe 'Insurance Foundation reconciliation' {
             Should -Be @('Global')
         @($created | Where-Object Path -eq '/savedqueries').Body.layoutxml |
             Should -Match 'object="10427"'
+        $tableExistenceReads = @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -like '/EntityDefinitions?*' -and
+            $_.Path -match '\$select=MetadataId,LogicalName,SchemaName&' -and
+            $_.Path -notmatch '\$expand=Attributes'
+        })
+        $tableExistenceReads.Count | Should -Be 3
+        @($tableExistenceReads | Where-Object {
+            $_.Path -match "LogicalName eq 'crmshow_accountcontactrole'"
+        }).Count | Should -Be 1
+        @($tableExistenceReads | Where-Object {
+            $_.Path -match "LogicalName eq 'crmshow_policyprojection'"
+        }).Count | Should -Be 1
+        @($tableExistenceReads | Where-Object {
+            $_.Path -match "LogicalName eq 'crmshow_policypartyrole'"
+        }).Count | Should -Be 1
         $tableMetadataReads = @($script:calls | Where-Object {
             $_.Method -eq 'GET' -and
             $_.Path -like '/EntityDefinitions?*' -and
             $_.Path -match '\$expand=Attributes'
         })
-        $tableMetadataReads.Count | Should -Be 3
-        @($tableMetadataReads | Where-Object {
-            $_.Path -match "LogicalName eq 'crmshow_accountcontactrole'"
-        }).Count | Should -Be 1
-        @($tableMetadataReads | Where-Object {
-            $_.Path -match "LogicalName eq 'crmshow_policyprojection'"
-        }).Count | Should -Be 1
-        @($tableMetadataReads | Where-Object {
-            $_.Path -match "LogicalName eq 'crmshow_policypartyrole'"
-        }).Count | Should -Be 1
+        $tableMetadataReads.Count | Should -Be 0
         @($script:calls | Where-Object {
             $_.Method -eq 'GET' -and
             $_.Path -match (
@@ -1270,6 +1318,18 @@ Describe 'Insurance Foundation reconciliation' {
         $script:customerCreateAttempts = 0
 
         Mock Start-Sleep {}
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            if ($LogicalName -ne $table.logicalName -or
+                -not $script:tableExists) {
+                return $null
+            }
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
         Mock Get-TableMetadataSnapshot {
             param($LogicalName, $RequestedAttributeLogicalNames)
             if ($LogicalName -ne $table.logicalName -or
@@ -2342,6 +2402,7 @@ Describe 'Insurance Foundation reconciliation' {
 Describe 'Insurance Foundation table metadata convergence' {
     BeforeEach {
         $script:calls = [System.Collections.Generic.List[object]]::new()
+        Mock Get-TableExistenceSnapshot { $null }
     }
 
     It 'waits for a newly created table snapshot before reconciling keys, views, and forms' {
@@ -2426,6 +2487,92 @@ Describe 'Insurance Foundation table metadata convergence' {
             Should -BeGreaterThan $script:visibleSnapshotSequence
         $formCreate.Sequence |
             Should -BeGreaterThan $script:visibleSnapshotSequence
+    }
+
+    It 'awaits typed metadata for an already existing table before reconciling it' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -eq 'crmshow_name'
+        })
+        $table.relationships = @()
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+        $script:expandedReads = 0
+        $script:typedReads = 0
+
+        Mock Start-Sleep {}
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'EXISTS'
+                Path = $LogicalName
+                Body = $null
+                Headers = $null
+            })
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and $Path -like '/EntityDefinitions?*' -and
+                $Path -match '\$expand=Attributes') {
+                $script:expandedReads++
+                return [pscustomobject]@{
+                    value = @(
+                        New-TableMetadataSnapshot -Table $table
+                    )
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.StringAttributeMetadata') {
+                $script:typedReads++
+                if ($script:typedReads -eq 1) {
+                    return [pscustomobject]@{ value = @() }
+                }
+                return New-TableTypedAttributeCollectionResponse `
+                    -Table $table -TypeName 'StringAttributeMetadata' `
+                    -AttributeLogicalName 'crmshow_name'
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:/Keys\?|^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        @($script:calls | Where-Object Method -eq 'EXISTS').Count | Should -Be 1
+        $script:calls[0].Method | Should -Be 'EXISTS'
+        $script:expandedReads | Should -Be 2
+        $script:typedReads | Should -Be 2
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
+        }).Count | Should -Be 1
     }
 
     It 'waits for all deep-inserted initial lookups atomically on a newly created table before posting child keys, views, and forms' {
@@ -2877,6 +3024,8 @@ Describe 'Insurance Foundation table metadata convergence' {
         foreach ($value in @(
             $start,
             $start,
+            $start,
+            $start,
             $start.AddSeconds(180)
         )) {
             $script:clock.Enqueue($value)
@@ -2976,6 +3125,8 @@ Describe 'Insurance Foundation table metadata convergence' {
         foreach ($value in @(
             $start,
             $start,
+            $start,
+            $start,
             $start.AddSeconds(180)
         )) {
             $script:clock.Enqueue($value)
@@ -3044,6 +3195,85 @@ Describe 'Insurance Foundation table metadata convergence' {
         }) | Should -BeNullOrEmpty
     }
 
+    It 'times out existing typed metadata visibility without creating the table or duplicate attributes' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -eq 'crmshow_name'
+        })
+        $table.relationships = @()
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @()
+        $table.forms = @()
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'EXISTS'
+                Path = $LogicalName
+                Body = $null
+                Headers = $null
+            })
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and $Path -like '/EntityDefinitions?*' -and
+                $Path -match '\$expand=Attributes') {
+                return [pscustomobject]@{
+                    value = @(
+                        New-TableMetadataSnapshot -Table $table
+                    )
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.StringAttributeMetadata') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw "*EventualConsistencyTimeout*$($table.logicalName)*180*"
+        @($script:calls | Where-Object Method -eq 'EXISTS').Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @(
+                '/EntityDefinitions',
+                "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes",
+                '/PublishXml'
+            )
+        }) | Should -BeNullOrEmpty
+    }
+
     It 'waits for recovered ordinary lookups before posting child keys, views, and forms' {
         $table = $script:contract.tables[0] |
             ConvertTo-Json -Depth 100 | ConvertFrom-Json
@@ -3062,6 +3292,14 @@ Describe 'Insurance Foundation table metadata convergence' {
         $script:visibleLookupSequence = $null
 
         Mock Start-Sleep {}
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
         Mock Get-TableMetadataSnapshot {
             param($LogicalName, $RequestedAttributeLogicalNames)
             if ($script:relationshipCreateSeen) {
@@ -3152,6 +3390,8 @@ Describe 'Insurance Foundation table metadata convergence' {
         foreach ($value in @(
             $start,
             $start,
+            $start,
+            $start,
             $start.AddSeconds(180)
         )) {
             $script:clock.Enqueue($value)
@@ -3159,6 +3399,14 @@ Describe 'Insurance Foundation table metadata convergence' {
 
         Mock Start-Sleep {}
         Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableExistenceSnapshot {
+            param($LogicalName)
+            return [pscustomobject]@{
+                MetadataId = 'existing-table'
+                LogicalName = $LogicalName
+                SchemaName = $table.schemaName
+            }
+        }
         Mock Get-TableMetadataSnapshot {
             param($LogicalName, $RequestedAttributeLogicalNames)
             $snapshot = New-TableMetadataSnapshot -Table $table `

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -4474,6 +4474,11 @@ Describe 'Insurance Foundation table metadata convergence' {
 }
 
 Describe 'Publisher entry point safety' {
+    BeforeAll {
+        $script:authoringWorkflow = Get-Content (Join-Path $script:repoRoot `
+            '.github/workflows/solution-author-dev.yml') -Raw
+    }
+
     It 'does not invoke az or pac when dot-sourced' {
         $text = @'
 function az { throw 'az was called' }
@@ -4484,23 +4489,191 @@ function pac { throw 'pac was called' }
         & ([scriptblock]::Create($text))
     }
 
-    It 'runs all offline tests before authentication and language mutation' {
-        $workflow = Get-Content (Join-Path $script:repoRoot `
-            '.github/workflows/solution-author-dev.yml') -Raw
-        $tests = $workflow.IndexOf('- name: Run offline authoring contract tests')
-        $auth = $workflow.IndexOf('- name: Authenticate Power Platform CLI')
-        $languages = $workflow.IndexOf('- name: Reconcile Dataverse languages')
+    It 'allows manual dispatch only with exact top-level permissions' {
+        $script:authoringWorkflow | Should -Match (
+            '(?ms)^on:\r?\n' +
+            '\s+workflow_dispatch:\s*\{\}\s*\r?\n' +
+            '\r?\npermissions:\r?\n' +
+            '\s+contents:\s+read\r?\n' +
+            '\s+id-token:\s+write\r?\n' +
+            '\r?\njobs:\r?\n'
+        )
+        $script:authoringWorkflow | Should -Not -Match (
+            '(?m)^\s*(pull_request|pull_request_target|push|workflow_run|' +
+            'issue_comment|schedule|repository_dispatch):'
+        )
+    }
+
+    It 'pins the authoring job to ubuntu-latest in the dev environment' {
+        $script:authoringWorkflow | Should -Match (
+            '(?ms)jobs:\r?\n' +
+            '\s+author:\r?\n' +
+            '\s+runs-on:\s+ubuntu-latest\r?\n' +
+            '\s+environment:\s+dev\r?\n'
+        )
+    }
+
+    It 'checks out the reviewed commit without persisting credentials' {
+        $script:authoringWorkflow | Should -Match (
+            '(?ms)- name: Check out reviewed commit\r?\n' +
+            '\s+uses: actions/checkout@[0-9a-f]{40}\s+#\s+v[0-9][^\r\n]*\r?\n' +
+            '\s+with:\r?\n' +
+            '\s+persist-credentials:\s+false\r?\n'
+        )
+    }
+
+    It 'pins every external action to a full commit SHA with a version comment' {
+        $usesMatches = [regex]::Matches(
+            $script:authoringWorkflow,
+            '(?m)^\s+uses:\s+(?<action>[^@\s#]+)@(?<ref>[^\s#]+)(?:\s+#\s+(?<comment>[^\r\n]+))?\s*$'
+        )
+
+        $usesMatches.Count | Should -Be 4
+        foreach ($match in $usesMatches) {
+            $match.Groups['ref'].Value | Should -Match '^[0-9a-f]{40}$'
+            $match.Groups['comment'].Value | Should -Match '^v[0-9]'
+        }
+
+        $script:authoringWorkflow | Should -Not -Match (
+            '(?m)^\s+uses:\s+\S+@(main|master|v[0-9][^\s#]*)\s*$'
+        )
+    }
+
+    It 'runs offline authoring suites before PAC authentication and any mutation' {
+        $tests = $script:authoringWorkflow.IndexOf(
+            '- name: Run offline authoring contract tests'
+        )
+        $pacAuth = $script:authoringWorkflow.IndexOf(
+            '- name: Authenticate Power Platform CLI'
+        )
+        $preflight = $script:authoringWorkflow.IndexOf(
+            '- name: Run authoring preflight'
+        )
+        $languages = $script:authoringWorkflow.IndexOf(
+            '- name: Reconcile Dataverse languages'
+        )
         $tests | Should -BeGreaterOrEqual 0
-        $tests | Should -BeLessThan $auth
+        $tests | Should -BeLessThan $pacAuth
+        $pacAuth | Should -BeLessThan $preflight
+        $preflight | Should -BeLessThan $languages
         $tests | Should -BeLessThan $languages
     }
 
-    It 'runs the Dataverse language tests before mutating the environment' {
-        $workflow = Get-Content (Join-Path $script:repoRoot `
-            '.github/workflows/solution-author-dev.yml') -Raw
+    It 'includes the required targeted offline suites and then the full solution suite' {
+        $expectedSuites = @(
+            'scripts/solution/tests/InsuranceFoundationContract.Tests.ps1'
+            'scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1'
+            'scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1'
+            'scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1'
+            'scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1'
+            'scripts/solution/tests/Export-InsuranceFoundationPackages.Tests.ps1'
+            'infra/scripts/tests/Set-DataverseLanguages.Tests.ps1'
+        )
 
-        $expected = [regex]::Escape(
-            "(Join-Path `$root 'infra/scripts/tests/Set-DataverseLanguages.Tests.ps1')")
-        $workflow | Should -Match $expected
+        foreach ($suite in $expectedSuites) {
+            $script:authoringWorkflow | Should -Match ([regex]::Escape($suite))
+        }
+
+        $targeted = $script:authoringWorkflow.IndexOf('-Path @(')
+        $full = $script:authoringWorkflow.IndexOf(
+            "Invoke-Pester -Path (Join-Path `$root 'scripts/solution/tests')"
+        )
+        $targeted | Should -BeGreaterOrEqual 0
+        $full | Should -BeGreaterThan $targeted
+    }
+
+    It 'authenticates Azure and PAC with workload federation only' {
+        $script:authoringWorkflow | Should -Match (
+            [regex]::Escape('client-id: ${{ env.AZURE_CLIENT_ID }}')
+        )
+        $script:authoringWorkflow | Should -Match (
+            [regex]::Escape('tenant-id: ${{ env.AZURE_TENANT_ID }}')
+        )
+        $script:authoringWorkflow | Should -Match 'allow-no-subscriptions:\s+true'
+        $script:authoringWorkflow | Should -Match '--githubFederated'
+        $script:authoringWorkflow | Should -Match '--applicationId \$env:AZURE_CLIENT_ID'
+        $script:authoringWorkflow | Should -Match '--tenant \$env:AZURE_TENANT_ID'
+        $script:authoringWorkflow | Should -Not -Match 'client-secret|creds:|password'
+        $script:authoringWorkflow | Should -Not -Match '\${{\s*secrets\.'
+    }
+
+    It 'classifies preflight exit code 2 with runbook guidance before mutation' {
+        $preflight = $script:authoringWorkflow.IndexOf(
+            '- name: Run authoring preflight'
+        )
+        $languages = $script:authoringWorkflow.IndexOf(
+            '- name: Reconcile Dataverse languages'
+        )
+        $metadata = $script:authoringWorkflow.IndexOf(
+            '- name: Reconcile demo-safe metadata'
+        )
+
+        $preflight | Should -BeGreaterOrEqual 0
+        $preflight | Should -BeLessThan $languages
+        $preflight | Should -BeLessThan $metadata
+        $script:authoringWorkflow | Should -Match 'if \(\$exitCode -eq 2\)'
+        $script:authoringWorkflow | Should -Match (
+            [regex]::Escape(
+                'docs/runbooks/insurance-foundation-security-role-bootstrap.md'
+            )
+        )
+        $script:authoringWorkflow | Should -Match 'Test-InsuranceAuthoringPreflight\.ps1'
+    }
+
+    It 'reconciles only demo-safe metadata and never requests full or role authoring' {
+        $script:authoringWorkflow | Should -Match '- name: Reconcile demo-safe metadata'
+        $script:authoringWorkflow | Should -Match '-Scope Demo'
+        $script:authoringWorkflow | Should -Not -Match '-Scope (?:All|SecurityRoles)'
+    }
+
+    It 'validates convergence before exporting and uses the tested export script only' {
+        $validation = $script:authoringWorkflow.IndexOf(
+            '- name: Validate complete demo convergence'
+        )
+        $export = $script:authoringWorkflow.IndexOf(
+            '- name: Export managed and unmanaged solutions'
+        )
+
+        $validation | Should -BeGreaterOrEqual 0
+        $validation | Should -BeLessThan $export
+        $script:authoringWorkflow | Should -Match (
+            'Test-InsuranceFoundationConvergence\.ps1'
+        )
+        $script:authoringWorkflow | Should -Match (
+            'Export-InsuranceFoundationPackages\.ps1'
+        )
+        $script:authoringWorkflow | Should -Not -Match 'pac solution export'
+        $script:authoringWorkflow | Should -Not -Match 'Verify exact authored package set'
+    }
+
+    It 'uploads the exact export directory after export with immutable retention' {
+        $export = $script:authoringWorkflow.IndexOf(
+            '- name: Export managed and unmanaged solutions'
+        )
+        $upload = $script:authoringWorkflow.IndexOf(
+            '- name: Upload authored solution packages'
+        )
+
+        $upload | Should -BeGreaterThan $export
+        $script:authoringWorkflow | Should -Match (
+            [regex]::Escape(
+                'path: ${{ runner.temp }}/insurance-foundation-authoring'
+            )
+        )
+        $script:authoringWorkflow | Should -Not -Match (
+            [regex]::Escape(
+                'path: ${{ runner.temp }}/insurance-foundation-authoring/*.zip'
+            )
+        )
+        $script:authoringWorkflow | Should -Match 'if-no-files-found:\s+error'
+        $script:authoringWorkflow | Should -Match 'retention-days:\s+14'
+    }
+
+    It 'avoids dangerous triggers, event interpolation, and credential inputs' {
+        $script:authoringWorkflow | Should -Not -Match (
+            'pull_request_target|workflow_run|issue_comment'
+        )
+        $script:authoringWorkflow | Should -Not -Match '\${{\s*github\.event\.'
+        $script:authoringWorkflow | Should -Not -Match 'client-secret|password'
     }
 }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -180,6 +180,28 @@ BeforeAll {
             value = @($attributes)
         }
     }
+
+    function Get-SnapshotAttribute {
+        param(
+            [Parameter(Mandatory)] $Snapshot,
+            [Parameter(Mandatory)] [string]$LogicalName
+        )
+
+        return @($Snapshot.Attributes | Where-Object {
+            $_.LogicalName -eq $LogicalName
+        })[0]
+    }
+
+    function Get-SnapshotRelationship {
+        param(
+            [Parameter(Mandatory)] $Snapshot,
+            [Parameter(Mandatory)] [string]$SchemaName
+        )
+
+        return @($Snapshot.ManyToOneRelationships | Where-Object {
+            $_.SchemaName -eq $SchemaName
+        })[0]
+    }
 }
 
 Describe 'Insurance Foundation request builders' {
@@ -2588,6 +2610,689 @@ Describe 'Insurance Foundation table metadata convergence' {
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
         }).Count | Should -Be 1
+    }
+
+    It 'waits for initial choice binding metadata before posting child components' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @()
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $script:tableSnapshotReads = 0
+        $script:partialChoiceSequence = $null
+        $script:fullChoiceSequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 { $null }
+                2 {
+                    $candidate = New-TableMetadataSnapshot -Table $table
+                    $choice = Get-SnapshotAttribute $candidate `
+                        'crmshow_roletype'
+                    $choice.PSObject.Properties.Remove('GlobalOptionSet')
+                    $candidate
+                }
+                default { New-TableMetadataSnapshot -Table $table }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            if ($null -ne $snapshot) {
+                $choice = Get-SnapshotAttribute $snapshot 'crmshow_roletype'
+                if ($null -eq $choice.GlobalOptionSet -and
+                    $null -eq $script:partialChoiceSequence) {
+                    $script:partialChoiceSequence = $script:calls[-1].Sequence
+                }
+                if ($null -ne $choice.GlobalOptionSet -and
+                    $null -eq $script:fullChoiceSequence) {
+                    $script:fullChoiceSequence = $script:calls[-1].Sequence
+                }
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $script:tableSnapshotReads | Should -Be 3
+        $script:partialChoiceSequence | Should -Not -BeNullOrEmpty
+        $script:fullChoiceSequence | Should -Not -BeNullOrEmpty
+        $script:fullChoiceSequence |
+            Should -BeGreaterThan $script:partialChoiceSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        foreach ($snapshotCall in @($script:calls | Where-Object {
+            $_.Method -eq 'SNAPSHOT'
+        })) {
+            @($snapshotCall.RequestedAttributeLogicalNames | Sort-Object) |
+                Should -Be @($table.columns.logicalName | Sort-Object)
+        }
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0].Sequence | Should -BeGreaterThan $script:fullChoiceSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0].Sequence | Should -BeGreaterThan $script:fullChoiceSequence
+    }
+
+    It 'waits for initial string and date metadata completion before posting child components' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @()
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $script:tableSnapshotReads = 0
+        $script:partialTypedSequence = $null
+        $script:fullTypedSequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $script:tableSnapshotReads++
+            $snapshot = switch ($script:tableSnapshotReads) {
+                1 { $null }
+                2 {
+                    $candidate = New-TableMetadataSnapshot -Table $table
+                    $name = Get-SnapshotAttribute $candidate 'crmshow_name'
+                    $validFrom = Get-SnapshotAttribute $candidate `
+                        'crmshow_validfrom'
+                    $name.PSObject.Properties.Remove('MaxLength')
+                    $validFrom.PSObject.Properties.Remove('Format')
+                    $validFrom.PSObject.Properties.Remove(
+                        'DateTimeBehavior'
+                    )
+                    $candidate
+                }
+                default { New-TableMetadataSnapshot -Table $table }
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            if ($null -ne $snapshot) {
+                $name = Get-SnapshotAttribute $snapshot 'crmshow_name'
+                $validFrom = Get-SnapshotAttribute $snapshot `
+                    'crmshow_validfrom'
+                $isComplete = $null -ne $name.MaxLength -and
+                    $null -ne $validFrom.Format -and
+                    $null -ne $validFrom.DateTimeBehavior
+                if (-not $isComplete -and
+                    $null -eq $script:partialTypedSequence) {
+                    $script:partialTypedSequence = $script:calls[-1].Sequence
+                }
+                if ($isComplete -and
+                    $null -eq $script:fullTypedSequence) {
+                    $script:fullTypedSequence = $script:calls[-1].Sequence
+                }
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $script:tableSnapshotReads | Should -Be 3
+        $script:partialTypedSequence | Should -Not -BeNullOrEmpty
+        $script:fullTypedSequence | Should -Not -BeNullOrEmpty
+        $script:fullTypedSequence |
+            Should -BeGreaterThan $script:partialTypedSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0].Sequence | Should -BeGreaterThan $script:fullTypedSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0].Sequence | Should -BeGreaterThan $script:fullTypedSequence
+    }
+
+    It 'waits for complete Customer metadata before publishing child components' {
+        $table = $script:contract.tables[2] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_policyid',
+                'crmshow_partyid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -in @('crmshow_policyid', 'crmshow_partyid')
+        })
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_policyid',
+            'crmshow_partyid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_policyid',
+            'crmshow_partyid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $customer = @($table.columns | Where-Object {
+            $_.logicalName -eq 'crmshow_partyid'
+        })[0]
+        $customerRelationship = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq $customer.logicalName -and
+            $_.authoring -eq 'CreateCustomerRelationships'
+        })[0]
+        $expectedRelationshipSchemas = @($customer.lookup.targets |
+            ForEach-Object {
+                "$($customerRelationship.schemaName)_$_"
+            })
+        $script:tableCreated = $false
+        $script:customerCreateSeen = $false
+        $script:customerVisibilityReads = 0
+        $script:partialCustomerSequence = $null
+        $script:fullCustomerSequence = $null
+
+        Mock Start-Sleep {}
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            if (-not $script:tableCreated) {
+                return $null
+            }
+            if ($script:customerCreateSeen) {
+                $script:customerVisibilityReads++
+            }
+            $snapshot = if (-not $script:customerCreateSeen) {
+                New-TableMetadataSnapshot -Table $table
+            } elseif ($script:customerVisibilityReads -eq 1) {
+                $candidate = New-TableMetadataSnapshot -Table $table `
+                    -IncludeCustomerRelationships
+                $party = Get-SnapshotAttribute $candidate `
+                    $customer.logicalName
+                $party.PSObject.Properties.Remove('Targets')
+                (Get-SnapshotRelationship $candidate `
+                    $expectedRelationshipSchemas[0]).ReferencingAttribute =
+                        $null
+                $contactRelationship = Get-SnapshotRelationship $candidate `
+                    $expectedRelationshipSchemas[1]
+                $contactRelationship.CascadeConfiguration.Delete = $null
+                $candidate
+            } else {
+                New-TableMetadataSnapshot -Table $table `
+                    -IncludeCustomerRelationships
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            if ($script:customerCreateSeen -and $null -ne $snapshot) {
+                $party = Get-SnapshotAttribute $snapshot `
+                    $customer.logicalName
+                $accountRelationship = Get-SnapshotRelationship $snapshot `
+                    $expectedRelationshipSchemas[0]
+                $contactRelationship = Get-SnapshotRelationship $snapshot `
+                    $expectedRelationshipSchemas[1]
+                $isComplete = @($party.Targets).Count -eq
+                    @($customer.lookup.targets).Count -and
+                    -not [string]::IsNullOrWhiteSpace([string]$accountRelationship.ReferencingAttribute) -and
+                    -not [string]::IsNullOrWhiteSpace([string]$contactRelationship.CascadeConfiguration.Delete)
+                if (-not $isComplete -and
+                    $null -eq $script:partialCustomerSequence) {
+                    $script:partialCustomerSequence = `
+                        $script:calls[-1].Sequence
+                }
+                if ($isComplete -and
+                    $null -eq $script:fullCustomerSequence) {
+                    $script:fullCustomerSequence = `
+                        $script:calls[-1].Sequence
+                }
+            }
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -match '(?:^/savedqueries\?|^/systemforms\?)') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/EntityDefinitions') {
+                $script:tableCreated = $true
+                return [pscustomobject]@{}
+            }
+            if ($Method -eq 'POST' -and
+                $Path -eq '/CreateCustomerRelationships') {
+                $script:customerCreateSeen = $true
+                return [pscustomobject]@{}
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/savedqueries') {
+                return [pscustomobject]@{ savedqueryid = 'new-view' }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/systemforms') {
+                return [pscustomobject]@{ formid = 'new-form' }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        Invoke-TableReconciliation $table | Out-Null
+
+        $script:customerVisibilityReads | Should -Be 2
+        $script:partialCustomerSequence | Should -Not -BeNullOrEmpty
+        $script:fullCustomerSequence | Should -Not -BeNullOrEmpty
+        $script:fullCustomerSequence |
+            Should -BeGreaterThan $script:partialCustomerSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq '/CreateCustomerRelationships'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/savedqueries'
+        })[0].Sequence | Should -BeGreaterThan $script:fullCustomerSequence
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/systemforms'
+        })[0].Sequence | Should -BeGreaterThan $script:fullCustomerSequence
+    }
+
+    It 'times out partial initial typed metadata without creating duplicates or posting children' {
+        $table = $script:contract.tables[0] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @()
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            $snapshot = if ($script:calls.Count -eq 0) {
+                $null
+            } else {
+                $candidate = New-TableMetadataSnapshot -Table $table
+                $choice = Get-SnapshotAttribute $candidate `
+                    'crmshow_roletype'
+                $choice.PSObject.Properties.Remove('GlobalOptionSet')
+                $candidate
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw (
+            "*EventualConsistencyTimeout*$($table.logicalName)*180*"
+        )
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($table.logicalName)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @('/savedqueries', '/systemforms')
+        }) | Should -BeNullOrEmpty
+    }
+
+    It 'times out partial Customer metadata without retrying the action or posting children' {
+        $table = $script:contract.tables[2] |
+            ConvertTo-Json -Depth 100 | ConvertFrom-Json
+        $table.columns = @($table.columns | Where-Object {
+            $_.logicalName -in @(
+                'crmshow_name',
+                'crmshow_policyid',
+                'crmshow_partyid',
+                'crmshow_roletype',
+                'crmshow_validfrom'
+            )
+        })
+        $table.relationships = @($table.relationships | Where-Object {
+            $_.lookupColumn -in @('crmshow_policyid', 'crmshow_partyid')
+        })
+        $table.alternateKeys = @()
+        $table.businessRules = @()
+        $table.views = @($table.views[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.views[0].columns = @(
+            'crmshow_name',
+            'crmshow_policyid',
+            'crmshow_partyid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $table.forms = @($table.forms[0] |
+            ConvertTo-Json -Depth 20 | ConvertFrom-Json)
+        $table.forms[0].columns = @(
+            'crmshow_name',
+            'crmshow_policyid',
+            'crmshow_partyid',
+            'crmshow_roletype',
+            'crmshow_validfrom'
+        )
+        $customer = @($table.columns | Where-Object {
+            $_.logicalName -eq 'crmshow_partyid'
+        })[0]
+        $customerRelationship = @($table.relationships | Where-Object {
+            $_.lookupColumn -eq $customer.logicalName -and
+            $_.authoring -eq 'CreateCustomerRelationships'
+        })[0]
+        $expectedRelationshipSchemas = @($customer.lookup.targets |
+            ForEach-Object {
+                "$($customerRelationship.schemaName)_$_"
+            })
+        $script:tableCreated = $false
+        $script:customerCreateSeen = $false
+
+        $start = [datetime]'2026-08-09T12:00:00Z'
+        $script:clock = [System.Collections.Generic.Queue[datetime]]::new()
+        foreach ($value in @(
+            $start,
+            $start,
+            $start,
+            $start,
+            $start,
+            $start.AddSeconds(180)
+        )) {
+            $script:clock.Enqueue($value)
+        }
+
+        Mock Start-Sleep {}
+        Mock Get-Date { $script:clock.Dequeue() }
+        Mock Get-TableMetadataSnapshot {
+            param($LogicalName, $RequestedAttributeLogicalNames)
+            if (-not $script:tableCreated) {
+                return $null
+            }
+            $snapshot = if (-not $script:customerCreateSeen) {
+                New-TableMetadataSnapshot -Table $table
+            } else {
+                $candidate = New-TableMetadataSnapshot -Table $table `
+                    -IncludeCustomerRelationships
+                $party = Get-SnapshotAttribute $candidate `
+                    $customer.logicalName
+                $party.PSObject.Properties.Remove('Targets')
+                (Get-SnapshotRelationship $candidate `
+                    $expectedRelationshipSchemas[0]).ReferencingAttribute =
+                        $null
+                $contactRelationship = Get-SnapshotRelationship $candidate `
+                    $expectedRelationshipSchemas[1]
+                $contactRelationship.CascadeConfiguration.Delete = $null
+                $candidate
+            }
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = 'SNAPSHOT'
+                Path = $LogicalName
+                Body = $snapshot
+                Headers = $null
+                RequestedAttributeLogicalNames = @(
+                    $RequestedAttributeLogicalNames
+                )
+            })
+            return $snapshot
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Sequence = $script:calls.Count + 1
+                Method = $Method
+                Path = $Path
+                Body = $Body
+                Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -like "/GlobalOptionSetDefinitions(Name='*") {
+                return [pscustomobject]@{
+                    MetadataId = '11111111-1111-1111-1111-111111111111'
+                }
+            }
+            if ($Method -eq 'POST' -and $Path -eq '/EntityDefinitions') {
+                $script:tableCreated = $true
+                return [pscustomobject]@{}
+            }
+            if ($Method -eq 'POST' -and
+                $Path -eq '/CreateCustomerRelationships') {
+                $script:customerCreateSeen = $true
+                return [pscustomobject]@{}
+            }
+            if ($Method -eq 'GET') {
+                throw "Unsupported mocked endpoint: $Method $Path"
+            }
+            return [pscustomobject]@{}
+        }
+
+        {
+            Invoke-TableReconciliation $table
+        } | Should -Throw (
+            "*EventualConsistencyTimeout*" +
+            "$($table.logicalName)/$($customer.logicalName)*180*"
+        )
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq '/CreateCustomerRelationships'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/PublishXml'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -in @('/savedqueries', '/systemforms')
+        }) | Should -BeNullOrEmpty
     }
 
     It 'waits for a newly created scalar attribute on an existing table before publishing and posting children' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -4598,7 +4598,7 @@ function pac { throw 'pac was called' }
         $script:authoringWorkflow | Should -Not -Match '\${{\s*secrets\.'
     }
 
-    It 'captures, echoes, and classifies preflight JSON before mutation' {
+    It 'captures, sanitizes, and classifies preflight diagnostics before mutation' {
         $preflight = $script:authoringWorkflow.IndexOf(
             '- name: Run authoring preflight'
         )
@@ -4614,8 +4614,11 @@ function pac { throw 'pac was called' }
         $exitCapture = $script:authoringWorkflow.IndexOf(
             '$exitCode = $LASTEXITCODE'
         )
-        $logJson = $script:authoringWorkflow.IndexOf(
-            'Write-Host $preflightJson'
+        $sanitize = $script:authoringWorkflow.IndexOf(
+            '$preflightDiagnostics = Get-InsuranceAuthoringPreflightDiagnosticSummary'
+        )
+        $logDiagnostics = $script:authoringWorkflow.IndexOf(
+            'Write-Host $preflightDiagnostics'
         )
         $failure = $script:authoringWorkflow.IndexOf(
             'throw (Get-InsuranceAuthoringPreflightFailureMessage'
@@ -4626,13 +4629,20 @@ function pac { throw 'pac was called' }
         $preflight | Should -BeLessThan $metadata
         $capture | Should -BeGreaterOrEqual 0
         $capture | Should -BeLessThan $exitCapture
-        $exitCapture | Should -BeLessThan $logJson
-        $logJson | Should -BeLessThan $failure
+        $exitCapture | Should -BeLessThan $sanitize
+        $sanitize | Should -BeLessThan $logDiagnostics
+        $logDiagnostics | Should -BeLessThan $failure
         $script:authoringWorkflow | Should -Match 'Test-InsuranceAuthoringPreflight\.ps1'
         $script:authoringWorkflow | Should -Match (
             'Get-InsuranceAuthoringPreflightFailureMessage\.ps1'
         )
-        $script:authoringWorkflow | Should -Match 'Write-Host \$preflightJson'
+        $script:authoringWorkflow | Should -Match (
+            'Get-InsuranceAuthoringPreflightDiagnosticSummary'
+        )
+        $script:authoringWorkflow | Should -Match (
+            'Write-Host \$preflightDiagnostics'
+        )
+        $script:authoringWorkflow | Should -Not -Match 'Write-Host \$preflightJson'
         $script:authoringWorkflow | Should -Match (
             'throw \(Get-InsuranceAuthoringPreflightFailureMessage'
         )

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -4510,6 +4510,22 @@ Describe 'Publisher entry point safety' {
     BeforeAll {
         $script:authoringWorkflow = Get-Content (Join-Path $script:repoRoot `
             '.github/workflows/solution-author-dev.yml') -Raw
+        $script:validateJobBlock = [regex]::Match(
+            $script:authoringWorkflow,
+            '(?ms)^  validate:\r?\n.*?(?=^  author:\r?\n)'
+        ).Value
+        $script:authorJobBlock = [regex]::Match(
+            $script:authoringWorkflow,
+            '(?ms)^  author:\r?\n.*$'
+        ).Value
+
+        if ([string]::IsNullOrWhiteSpace($script:validateJobBlock)) {
+            throw 'Unable to locate validate job in authoring workflow.'
+        }
+
+        if ([string]::IsNullOrWhiteSpace($script:authorJobBlock)) {
+            throw 'Unable to locate author job in authoring workflow.'
+        }
     }
 
     It 'does not invoke az or pac when dot-sourced' {
@@ -4522,13 +4538,12 @@ function pac { throw 'pac was called' }
         & ([scriptblock]::Create($text))
     }
 
-    It 'allows manual dispatch only with exact top-level permissions' {
+    It 'allows manual dispatch only with minimal top-level permissions' {
         $script:authoringWorkflow | Should -Match (
             '(?ms)^on:\r?\n' +
             '\s+workflow_dispatch:\s*\{\}\s*\r?\n' +
             '\r?\npermissions:\r?\n' +
             '\s+contents:\s+read\r?\n' +
-            '\s+id-token:\s+write\r?\n' +
             '\r?\njobs:\r?\n'
         )
         $script:authoringWorkflow | Should -Not -Match (
@@ -4537,22 +4552,58 @@ function pac { throw 'pac was called' }
         )
     }
 
-    It 'pins the authoring job to ubuntu-latest in the dev environment' {
-        $script:authoringWorkflow | Should -Match (
-            '(?ms)jobs:\r?\n' +
-            '\s+author:\r?\n' +
+    It 'runs validate on ubuntu-latest without environment or cloud access' {
+        $script:validateJobBlock | Should -Match (
+            '(?ms)^  validate:\r?\n' +
             '\s+runs-on:\s+ubuntu-latest\r?\n' +
-            '\s+environment:\s+dev\r?\n'
+            '\s+permissions:\r?\n' +
+            '\s+contents:\s+read\r?\n'
+        )
+        $script:validateJobBlock | Should -Not -Match '(?m)^\s+environment:\s+'
+        $script:validateJobBlock | Should -Not -Match '(?m)^\s+env:\s*$'
+        $script:validateJobBlock | Should -Not -Match 'id-token:\s+write'
+        $script:validateJobBlock | Should -Not -Match 'azure/login@'
+        $script:validateJobBlock | Should -Not -Match 'powerplatform-actions/actions-install@'
+        $script:validateJobBlock | Should -Not -Match (
+            'Authenticate Power Platform CLI|auth create'
+        )
+        $script:validateJobBlock | Should -Not -Match (
+            'AZURE_CLIENT_ID|AZURE_TENANT_ID|POWER_PLATFORM_ENV_URL'
         )
     }
 
-    It 'checks out the reviewed commit without persisting credentials' {
-        $script:authoringWorkflow | Should -Match (
+    It 'runs author on ubuntu-latest in the dev environment only after validate with OIDC' {
+        $script:authorJobBlock | Should -Match (
+            '(?ms)^  author:\r?\n' +
+            '\s+needs:\s+validate\r?\n' +
+            '\s+runs-on:\s+ubuntu-latest\r?\n' +
+            '\s+environment:\s+dev\r?\n' +
+            '\s+permissions:\r?\n' +
+            '\s+contents:\s+read\r?\n' +
+            '\s+id-token:\s+write\r?\n'
+        )
+        $script:authorJobBlock | Should -Match (
+            [regex]::Escape('AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}')
+        )
+        $script:authorJobBlock | Should -Match (
+            [regex]::Escape('AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}')
+        )
+        $script:authorJobBlock | Should -Match (
+            [regex]::Escape(
+                'POWER_PLATFORM_ENV_URL: ${{ vars.POWER_PLATFORM_ENV_URL }}'
+            )
+        )
+    }
+
+    It 'checks out the reviewed commit without persisting credentials in both jobs' {
+        $checkoutMatches = [regex]::Matches(
+            $script:authoringWorkflow,
             '(?ms)- name: Check out reviewed commit\r?\n' +
             '\s+uses: actions/checkout@[0-9a-f]{40}\s+#\s+v[0-9][^\r\n]*\r?\n' +
             '\s+with:\r?\n' +
             '\s+persist-credentials:\s+false\r?\n'
         )
+        $checkoutMatches.Count | Should -Be 2
     }
 
     It 'pins every external action to a full commit SHA with a version comment' {
@@ -4561,7 +4612,7 @@ function pac { throw 'pac was called' }
             '(?m)^\s+uses:\s+(?<action>[^@\s#]+)@(?<ref>[^\s#]+)(?:\s+#\s+(?<comment>[^\r\n]+))?\s*$'
         )
 
-        $usesMatches.Count | Should -Be 4
+        $usesMatches.Count | Should -Be 5
         foreach ($match in $usesMatches) {
             $match.Groups['ref'].Value | Should -Match '^[0-9a-f]{40}$'
             $match.Groups['comment'].Value | Should -Match '^v[0-9]'
@@ -4572,24 +4623,34 @@ function pac { throw 'pac was called' }
         )
     }
 
-    It 'runs offline authoring suites before PAC authentication and any mutation' {
-        $tests = $script:authoringWorkflow.IndexOf(
+    It 'installs Pester only in validate from PSGallery without publisher bypass or trust mutation' {
+        $script:validateJobBlock | Should -Match '- name: Install Pester 6\.0\.1'
+        $script:validateJobBlock | Should -Match (
+            'Install-Module Pester -RequiredVersion 6\.0\.1 -Repository PSGallery -Scope CurrentUser -Force'
+        )
+        $script:authorJobBlock | Should -Not -Match (
+            'Install Pester 6\.0\.1|Install-Module Pester|Import-Module Pester'
+        )
+        $script:authoringWorkflow | Should -Not -Match (
+            'Set-PSRepository\s+-Name\s+PSGallery\s+-InstallationPolicy\s+Trusted'
+        )
+        $script:authoringWorkflow | Should -Not -Match '-SkipPublisherCheck'
+    }
+
+    It 'runs offline authoring suites only in validate before privileged authoring starts' {
+        $install = $script:validateJobBlock.IndexOf(
+            '- name: Install Pester 6.0.1'
+        )
+        $tests = $script:validateJobBlock.IndexOf(
             '- name: Run offline authoring contract tests'
         )
-        $pacAuth = $script:authoringWorkflow.IndexOf(
-            '- name: Authenticate Power Platform CLI'
-        )
-        $preflight = $script:authoringWorkflow.IndexOf(
-            '- name: Run authoring preflight'
-        )
-        $languages = $script:authoringWorkflow.IndexOf(
-            '- name: Reconcile Dataverse languages'
-        )
+        $install | Should -BeGreaterOrEqual 0
         $tests | Should -BeGreaterOrEqual 0
-        $tests | Should -BeLessThan $pacAuth
-        $pacAuth | Should -BeLessThan $preflight
-        $preflight | Should -BeLessThan $languages
-        $tests | Should -BeLessThan $languages
+        $install | Should -BeLessThan $tests
+        $script:validateJobBlock | Should -Match 'Invoke-Pester'
+        $script:authorJobBlock | Should -Not -Match (
+            'Invoke-Pester|Run offline authoring contract tests'
+        )
     }
 
     It 'includes the required targeted offline suites and then the full solution suite' {
@@ -4606,55 +4667,72 @@ function pac { throw 'pac was called' }
         )
 
         foreach ($suite in $expectedSuites) {
-            $script:authoringWorkflow | Should -Match ([regex]::Escape($suite))
+            $script:validateJobBlock | Should -Match ([regex]::Escape($suite))
         }
 
-        $targeted = $script:authoringWorkflow.IndexOf('-Path @(')
-        $full = $script:authoringWorkflow.IndexOf(
+        $targeted = $script:validateJobBlock.IndexOf('-Path @(')
+        $full = $script:validateJobBlock.IndexOf(
             "Invoke-Pester -Path (Join-Path `$root 'scripts/solution/tests')"
         )
         $targeted | Should -BeGreaterOrEqual 0
         $full | Should -BeGreaterThan $targeted
     }
 
-    It 'authenticates Azure and PAC with workload federation only' {
-        $script:authoringWorkflow | Should -Match (
+    It 'authenticates Azure and PAC with workload federation only after validate' {
+        $azureLogin = $script:authorJobBlock.IndexOf(
+            '- name: Sign in with workload identity'
+        )
+        $cliInstall = $script:authorJobBlock.IndexOf(
+            '- name: Install Power Platform CLI'
+        )
+        $pacAuth = $script:authorJobBlock.IndexOf(
+            '- name: Authenticate Power Platform CLI'
+        )
+        $preflight = $script:authorJobBlock.IndexOf(
+            '- name: Run authoring preflight'
+        )
+
+        $azureLogin | Should -BeGreaterOrEqual 0
+        $azureLogin | Should -BeLessThan $cliInstall
+        $cliInstall | Should -BeLessThan $pacAuth
+        $pacAuth | Should -BeLessThan $preflight
+        $script:authorJobBlock | Should -Match (
             [regex]::Escape('client-id: ${{ env.AZURE_CLIENT_ID }}')
         )
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match (
             [regex]::Escape('tenant-id: ${{ env.AZURE_TENANT_ID }}')
         )
-        $script:authoringWorkflow | Should -Match 'allow-no-subscriptions:\s+true'
-        $script:authoringWorkflow | Should -Match '--githubFederated'
-        $script:authoringWorkflow | Should -Match '--applicationId \$env:AZURE_CLIENT_ID'
-        $script:authoringWorkflow | Should -Match '--tenant \$env:AZURE_TENANT_ID'
-        $script:authoringWorkflow | Should -Not -Match 'client-secret|creds:|password'
-        $script:authoringWorkflow | Should -Not -Match '\${{\s*secrets\.'
+        $script:authorJobBlock | Should -Match 'allow-no-subscriptions:\s+true'
+        $script:authorJobBlock | Should -Match '--githubFederated'
+        $script:authorJobBlock | Should -Match '--applicationId \$env:AZURE_CLIENT_ID'
+        $script:authorJobBlock | Should -Match '--tenant \$env:AZURE_TENANT_ID'
+        $script:authorJobBlock | Should -Not -Match 'client-secret|creds:|password'
+        $script:authorJobBlock | Should -Not -Match '\${{\s*secrets\.'
     }
 
     It 'captures, sanitizes, and classifies preflight diagnostics before mutation' {
-        $preflight = $script:authoringWorkflow.IndexOf(
+        $preflight = $script:authorJobBlock.IndexOf(
             '- name: Run authoring preflight'
         )
-        $languages = $script:authoringWorkflow.IndexOf(
+        $languages = $script:authorJobBlock.IndexOf(
             '- name: Reconcile Dataverse languages'
         )
-        $metadata = $script:authoringWorkflow.IndexOf(
+        $metadata = $script:authorJobBlock.IndexOf(
             '- name: Reconcile demo-safe metadata'
         )
-        $capture = $script:authoringWorkflow.IndexOf(
+        $capture = $script:authorJobBlock.IndexOf(
             '$preflightJsonLines = & $pwsh'
         )
-        $exitCapture = $script:authoringWorkflow.IndexOf(
+        $exitCapture = $script:authorJobBlock.IndexOf(
             '$exitCode = $LASTEXITCODE'
         )
-        $sanitize = $script:authoringWorkflow.IndexOf(
+        $sanitize = $script:authorJobBlock.IndexOf(
             '$preflightDiagnostics = Get-InsuranceAuthoringPreflightDiagnosticSummary'
         )
-        $logDiagnostics = $script:authoringWorkflow.IndexOf(
+        $logDiagnostics = $script:authorJobBlock.IndexOf(
             'Write-Host $preflightDiagnostics'
         )
-        $failure = $script:authoringWorkflow.IndexOf(
+        $failure = $script:authorJobBlock.IndexOf(
             'throw (Get-InsuranceAuthoringPreflightFailureMessage'
         )
 
@@ -4666,69 +4744,69 @@ function pac { throw 'pac was called' }
         $exitCapture | Should -BeLessThan $sanitize
         $sanitize | Should -BeLessThan $logDiagnostics
         $logDiagnostics | Should -BeLessThan $failure
-        $script:authoringWorkflow | Should -Match 'Test-InsuranceAuthoringPreflight\.ps1'
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match 'Test-InsuranceAuthoringPreflight\.ps1'
+        $script:authorJobBlock | Should -Match (
             'Get-InsuranceAuthoringPreflightFailureMessage\.ps1'
         )
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match (
             'Get-InsuranceAuthoringPreflightDiagnosticSummary'
         )
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match (
             'Write-Host \$preflightDiagnostics'
         )
-        $script:authoringWorkflow | Should -Not -Match 'Write-Host \$preflightJson'
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Not -Match 'Write-Host \$preflightJson'
+        $script:authorJobBlock | Should -Match (
             'throw \(Get-InsuranceAuthoringPreflightFailureMessage'
         )
     }
 
     It 'reconciles only demo-safe metadata and never requests full or role authoring' {
-        $script:authoringWorkflow | Should -Match '- name: Reconcile demo-safe metadata'
-        $script:authoringWorkflow | Should -Match '-Scope Demo'
-        $script:authoringWorkflow | Should -Not -Match '-Scope (?:All|SecurityRoles)'
+        $script:authorJobBlock | Should -Match '- name: Reconcile demo-safe metadata'
+        $script:authorJobBlock | Should -Match '-Scope Demo'
+        $script:authorJobBlock | Should -Not -Match '-Scope (?:All|SecurityRoles)'
     }
 
     It 'validates convergence before exporting and uses the tested export script only' {
-        $validation = $script:authoringWorkflow.IndexOf(
+        $validation = $script:authorJobBlock.IndexOf(
             '- name: Validate complete demo convergence'
         )
-        $export = $script:authoringWorkflow.IndexOf(
+        $export = $script:authorJobBlock.IndexOf(
             '- name: Export managed and unmanaged solutions'
         )
 
         $validation | Should -BeGreaterOrEqual 0
         $validation | Should -BeLessThan $export
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match (
             'Test-InsuranceFoundationConvergence\.ps1'
         )
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match (
             'Export-InsuranceFoundationPackages\.ps1'
         )
-        $script:authoringWorkflow | Should -Not -Match 'pac solution export'
-        $script:authoringWorkflow | Should -Not -Match 'Verify exact authored package set'
+        $script:authorJobBlock | Should -Not -Match 'pac solution export'
+        $script:authorJobBlock | Should -Not -Match 'Verify exact authored package set'
     }
 
     It 'uploads the exact export directory after export with immutable retention' {
-        $export = $script:authoringWorkflow.IndexOf(
+        $export = $script:authorJobBlock.IndexOf(
             '- name: Export managed and unmanaged solutions'
         )
-        $upload = $script:authoringWorkflow.IndexOf(
+        $upload = $script:authorJobBlock.IndexOf(
             '- name: Upload authored solution packages'
         )
 
         $upload | Should -BeGreaterThan $export
-        $script:authoringWorkflow | Should -Match (
+        $script:authorJobBlock | Should -Match (
             [regex]::Escape(
                 'path: ${{ runner.temp }}/insurance-foundation-authoring'
             )
         )
-        $script:authoringWorkflow | Should -Not -Match (
+        $script:authorJobBlock | Should -Not -Match (
             [regex]::Escape(
                 'path: ${{ runner.temp }}/insurance-foundation-authoring/*.zip'
             )
         )
-        $script:authoringWorkflow | Should -Match 'if-no-files-found:\s+error'
-        $script:authoringWorkflow | Should -Match 'retention-days:\s+14'
+        $script:authorJobBlock | Should -Match 'if-no-files-found:\s+error'
+        $script:authorJobBlock | Should -Match 'retention-days:\s+14'
     }
 
     It 'avoids dangerous triggers, event interpolation, and credential inputs' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -331,6 +331,53 @@ Describe 'az rest transport' {
     }
 }
 
+Describe 'Insurance Foundation scope contract' {
+    It 'defaults both scope declarations to Demo and accepts all five supported scopes' {
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:publisherPath,
+            [ref]$tokens,
+            [ref]$errors
+        )
+
+        @($errors) | Should -BeNullOrEmpty
+        $expected = @('Foundation', 'DataModel', 'Demo', 'SecurityRoles', 'All')
+
+        $scriptScope = @($ast.ParamBlock.Parameters | Where-Object {
+            $_.Name.VariablePath.UserPath -eq 'Scope'
+        })[0]
+        $scriptScope | Should -Not -BeNullOrEmpty
+        $scriptValidateSet = @($scriptScope.Attributes | Where-Object {
+            $_.TypeName.FullName -eq 'ValidateSet'
+        })[0]
+        $scriptValidateSet | Should -Not -BeNullOrEmpty
+        @($scriptValidateSet.PositionalArguments | ForEach-Object {
+            $_.Extent.Text.Trim("'")
+        }) | Should -Be $expected
+        $scriptScope.DefaultValue.Extent.Text.Trim("'") | Should -Be 'Demo'
+
+        $reconciliation = $ast.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq 'Invoke-InsuranceFoundationReconciliation'
+        }, $true)
+        $reconciliation | Should -Not -BeNullOrEmpty
+        $functionScope = @($reconciliation.Body.ParamBlock.Parameters | Where-Object {
+            $_.Name.VariablePath.UserPath -eq 'Scope'
+        })[0]
+        $functionScope | Should -Not -BeNullOrEmpty
+        $functionValidateSet = @($functionScope.Attributes | Where-Object {
+            $_.TypeName.FullName -eq 'ValidateSet'
+        })[0]
+        $functionValidateSet | Should -Not -BeNullOrEmpty
+        @($functionValidateSet.PositionalArguments | ForEach-Object {
+            $_.Extent.Text.Trim("'")
+        }) | Should -Be $expected
+        $functionScope.DefaultValue.Extent.Text.Trim("'") | Should -Be 'Demo'
+    }
+}
+
 Describe 'Insurance Foundation reconciliation' {
     BeforeEach {
         $script:calls = [System.Collections.Generic.List[object]]::new()
@@ -481,6 +528,96 @@ Describe 'Insurance Foundation reconciliation' {
             '^/GlobalOptionSetDefinitions\(' +
             '[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\)$'
         )
+    }
+
+    It 'keeps Foundation scope choice-only and publishes under the foundation header' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract `
+            -Scope Foundation -Confirm:$false | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/GlobalOptionSetDefinitions'
+        }).Count | Should -Be 5
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -like '/EntityDefinitions*'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and
+            ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -eq '/PublishAllXml'
+        }).Headers.'MSCRM.SolutionUniqueName' | Should -Be 'crmshow_Foundation'
+    }
+
+    It 'keeps DataModel scope free of choice and role authoring and publishes under the data-model header' {
+        $script:choicesExist = $true
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract `
+            -Scope DataModel -Confirm:$false | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -like '/GlobalOptionSetDefinitions*'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and
+            ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 3
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -eq '/PublishAllXml'
+        }).Headers.'MSCRM.SolutionUniqueName' | Should -Be 'crmshow_DataModel'
+    }
+
+    It 'keeps Demo scope demo-safe while publishing under the data-model header' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract `
+            -Scope Demo -Confirm:$false | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/GlobalOptionSetDefinitions'
+        }).Count | Should -Be 5
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
+        }).Count | Should -Be 3
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and
+            ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -eq '/PublishAllXml'
+        }).Headers.'MSCRM.SolutionUniqueName' | Should -Be 'crmshow_DataModel'
+    }
+
+    It 'keeps SecurityRoles scope free of choice and data-model authoring and publishes under the foundation header' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract `
+            -Scope SecurityRoles -Confirm:$false | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -like '/GlobalOptionSetDefinitions*'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -like '/EntityDefinitions*'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and
+            ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+        }).Count | Should -BeGreaterThan 0
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -eq '/PublishAllXml'
+        }).Headers.'MSCRM.SolutionUniqueName' | Should -Be 'crmshow_Foundation'
+    }
+
+    It 'keeps All as the explicit privileged scope and publishes under the data-model header' {
+        Invoke-InsuranceFoundationReconciliation -Contract $script:contract `
+            -Scope All -Confirm:$false | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and
+            ($_.Path -eq '/roles' -or $_.Path -match 'PrivilegesRole$')
+        }).Count | Should -BeGreaterThan 0
+        @($script:calls | Where-Object {
+            $_.Method -ne 'GET' -and $_.Path -eq '/PublishAllXml'
+        }).Headers.'MSCRM.SolutionUniqueName' | Should -Be 'crmshow_DataModel'
     }
 
     It 'queries saved queries only through supported Web API properties' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -218,6 +218,67 @@ BeforeAll {
     }
 }
 
+Describe 'Test-InsuranceFoundationContract' {
+    AfterEach {
+        Remove-Item Function:\python -ErrorAction SilentlyContinue
+    }
+
+    It 'requires Python plus jsonschema when Test-Json is unavailable' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Test-Json' }
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'python' }
+
+        {
+            Test-InsuranceFoundationContract -Path $script:contractPath
+        } | Should -Throw '*Python*jsonschema*Test-Json*unavailable*'
+    }
+
+    It 'sanitizes a failing Python jsonschema prerequisite probe' {
+        function global:python {
+            param(
+                [Parameter(ValueFromRemainingArguments = $true)]
+                [string[]]$Arguments
+            )
+
+            $escape = [char]27
+            if (@($Arguments).Count -ge 2 -and
+                $Arguments[0] -ceq '-c' -and
+                $Arguments[1] -ceq 'import jsonschema') {
+                Write-Error (
+                    "::warning::jsonschema missing`r`nNo module named jsonschema`t" +
+                    "$escape[31mblocked$escape[0m"
+                ) -ErrorAction Continue
+                $global:LASTEXITCODE = 1
+                return
+            }
+
+            throw "Unexpected python invocation: $($Arguments -join ' ')"
+        }
+
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Test-Json' }
+        Mock Get-Command {
+            [pscustomobject]@{
+                Name = 'python'
+                Source = 'python'
+            }
+        } -ParameterFilter { $Name -eq 'python' }
+
+        $message = $null
+        try {
+            Test-InsuranceFoundationContract -Path $script:contractPath
+            throw 'Expected Python prerequisite failure.'
+        }
+        catch {
+            $message = $_.Exception.Message
+        }
+
+        script:Assert-SafeDiagnosticLine -Text $message -MaxLength 450
+        $message | Should -Match 'Python \+ jsonschema prerequisite check failed'
+        $message | Should -Match 'warning::jsonschema missing'
+        $message | Should -Match 'No module named jsonschema blocked'
+        $message | Should -Not -Match 'At line:|Traceback|File "<string>"'
+    }
+}
+
 Describe 'Insurance Foundation request builders' {
     It 'uses the owning solution and duplicate-detection headers' {
         $headers = Get-DataverseHeaders -SolutionUniqueName 'crmshow_DataModel'

--- a/scripts/solution/tests/ReviewedRefControls.Tests.ps1
+++ b/scripts/solution/tests/ReviewedRefControls.Tests.ps1
@@ -81,11 +81,12 @@ Describe 'GitHub environment reviewed-ref policies' {
 }
 
 Describe 'Main branch protection contract' {
-    It 'protects main with enforced admins, gate1, and conversation resolution' {
+    It 'protects main with enforced admins, linear history, gate1, and conversation resolution' {
         $script:githubModuleMain | Should -Match (
             '(?ms)resource\s+"github_branch_protection"\s+"main"\s*\{.*?' +
             'pattern\s*=\s*"main".*?' +
             'enforce_admins\s*=\s*true.*?' +
+            'required_linear_history\s*=\s*true.*?' +
             'require_conversation_resolution\s*=\s*true.*?' +
             'required_status_checks\s*\{.*?' +
             'strict\s*=\s*true.*?' +
@@ -97,6 +98,7 @@ Describe 'Main branch protection contract' {
     It 'requires pull requests on main without a mandatory independent approver in the demo repo' {
         $script:githubModuleMain | Should -Match (
             '(?ms)required_pull_request_reviews\s*\{.*?' +
+            'dismiss_stale_reviews\s*=\s*true.*?' +
             'required_approving_review_count\s*=\s*0.*?' +
             'pull_request_bypassers\s*=\s*\[\s*\].*?' +
             '\}'
@@ -129,7 +131,7 @@ Describe 'Solution CI gate1 contract' {
 }
 
 Describe 'Terraform bootstrap/import runbook' {
-    It 'documents GitHub auth prerequisites and reviewed-ref imports before first apply' {
+    It 'documents GitHub auth prerequisites and imports all live reviewed-ref controls before first apply' {
         $script:terraformReadme | Should -Match 'GH_TOKEN'
         $script:terraformReadme | Should -Match 'GITHUB_TOKEN'
         $script:terraformReadme | Should -Match (
@@ -139,31 +141,50 @@ Describe 'Terraform bootstrap/import runbook' {
             'module\.github\.github_repository_environment\.envs\["test"\]'
         )
         $script:terraformReadme | Should -Match (
+            'module\.github\.github_repository_environment_deployment_policy\.allowed_branches\["dev:main"\]'
+        )
+        $script:terraformReadme | Should -Match '56913774'
+        $script:terraformReadme | Should -Match (
             'module\.github\.github_repository_environment_deployment_policy\.allowed_branches\["test:main"\]'
         )
         $script:terraformReadme | Should -Match '56680080'
+        $script:terraformReadme | Should -Match (
+            'module\.github\.github_branch_protection\.main'
+        )
+        $script:terraformReadme | Should -Match 'CRMShowcase:main'
     }
 
-    It 'warns operators to inspect the plan for reviewer retention before apply' {
+    It 'records the live import evidence and plan checks operators must preserve before apply' {
         $script:terraformReadme | Should -Match 'no reviewer removal'
-        $script:terraformReadme | Should -Match '(?ms)dev:main.*create'
-        $script:terraformReadme | Should -Match '(?ms)branch protection.*create'
+        $script:terraformReadme | Should -Match 'live evidence on 2026-08-10'
+        $script:terraformReadme | Should -Match (
+            'recreated,\s*re-check the\s*current live policy ID'
+        )
+        $script:terraformReadme | Should -Match 'required_linear_history = true'
+        $script:terraformReadme | Should -Match 'dismiss_stale_reviews = true'
+        $script:terraformReadme | Should -Not -Match 'is a create, because DEV currently has no live deployment branch policy'
+        $script:terraformReadme | Should -Not -Match 'is a create unless the live repo'
         $script:terraformReadme | Should -Not -Match 'not scaffolded yet'
     }
 }
 
 Describe 'ADR-0004 reviewed-ref narrative' {
-    It 'records the current TEST reviewer exception and customer target state' {
+    It 'records the live reviewed-ref evidence and preserves the demo exceptions' {
+        $script:adr0004 | Should -Match '2026-08-10'
+        $script:adr0004 | Should -Match '56913774'
+        $script:adr0004 | Should -Match '56680080'
         $script:adr0004 | Should -Match 'urruegg'
         $script:adr0004 | Should -Match '46865858'
         $script:adr0004 | Should -Match 'prevent_self_review = false'
-        $script:adr0004 | Should -Match 'zero required reviewers'
+        $script:adr0004 | Should -Match 'required_linear_history = true'
+        $script:adr0004 | Should -Match 'dismiss_stale_reviews = true'
+        $script:adr0004 | Should -Match 'required_approving_review_count = 0'
         $script:adr0004 | Should -Match 'independent required reviewers'
     }
 
-    It 'distinguishes desired IaC from live branch-protection evidence' {
-        $script:adr0004 | Should -Match 'desired IaC'
-        $script:adr0004 | Should -Match 'not live evidence'
-        $script:adr0004 | Should -Match 'Terraform controller / maintainer session'
+    It 'no longer describes main branch protection as desired-only' {
+        $script:adr0004 | Should -Not -Match 'desired IaC'
+        $script:adr0004 | Should -Not -Match 'not live evidence'
+        $script:adr0004 | Should -Not -Match 'Terraform controller / maintainer session'
     }
 }

--- a/scripts/solution/tests/ReviewedRefControls.Tests.ps1
+++ b/scripts/solution/tests/ReviewedRefControls.Tests.ps1
@@ -6,6 +6,10 @@ BeforeAll {
         'infra/terraform/modules/github/main.tf') -Raw
     $script:terraformRoot = Get-Content (Join-Path $script:repoRoot `
         'infra/terraform/main.tf') -Raw
+    $script:terraformReadme = Get-Content (Join-Path $script:repoRoot `
+        'infra/terraform/README.md') -Raw
+    $script:adr0004 = Get-Content (Join-Path $script:repoRoot `
+        'docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md') -Raw
     $script:solutionCiWorkflow = Get-Content (Join-Path $script:repoRoot `
         '.github/workflows/solution-ci.yml') -Raw
 }
@@ -34,6 +38,29 @@ Describe 'GitHub environment reviewed-ref policies' {
         $script:githubModuleMain | Should -Match 'branch_pattern\s*=\s*each\.value\.branch_pattern'
     }
 
+    It 'supports optional reviewer user and team IDs in the module input contract' {
+        $script:githubModuleVariables | Should -Match (
+            'reviewer_user_ids\s*=\s*optional\(\s*set\(number\)\s*,\s*\[\s*\]\s*\)'
+        )
+        $script:githubModuleVariables | Should -Match (
+            'reviewer_team_ids\s*=\s*optional\(\s*set\(number\)\s*,\s*\[\s*\]\s*\)'
+        )
+    }
+
+    It 'emits a reviewers block only when reviewer IDs are configured' {
+        $script:githubModuleMain | Should -Match (
+            '(?ms)dynamic\s+"reviewers"\s*\{\s*' +
+            'for_each\s*=\s*length\(each\.value\.reviewer_user_ids\)\s*\+\s*' +
+            'length\(each\.value\.reviewer_team_ids\)\s*>\s*0\s*\?\s*\[each\.value\]\s*:\s*\[\]'
+        )
+        $script:githubModuleMain | Should -Match (
+            'users\s*=\s*length\(reviewers\.value\.reviewer_user_ids\)\s*==\s*0\s*\?\s*null\s*:\s*reviewers\.value\.reviewer_user_ids'
+        )
+        $script:githubModuleMain | Should -Match (
+            'teams\s*=\s*length\(reviewers\.value\.reviewer_team_ids\)\s*==\s*0\s*\?\s*null\s*:\s*reviewers\.value\.reviewer_team_ids'
+        )
+    }
+
     It 'pins the demo dev and test environments to main only' {
         $script:terraformRoot | Should -Match (
             '(?ms)dev\s*=\s*\{.*?allowed_branch_patterns\s*=\s*\[\s*"main"\s*\]'
@@ -41,6 +68,15 @@ Describe 'GitHub environment reviewed-ref policies' {
         $script:terraformRoot | Should -Match (
             '(?ms)test\s*=\s*\{.*?allowed_branch_patterns\s*=\s*\[\s*"main"\s*\]'
         )
+    }
+
+    It 'retains the demo TEST reviewer while leaving DEV without reviewers' {
+        $script:terraformRoot | Should -Match (
+            '(?ms)test\s*=\s*\{.*?reviewer_user_ids\s*=\s*\[\s*data\.github_user\.owner\.id\s*\].*?' +
+            'prevent_self_review\s*=\s*false'
+        )
+        ([regex]::Matches($script:terraformRoot, 'reviewer_user_ids\s*=')).Count |
+            Should -Be 1
     }
 }
 
@@ -89,5 +125,45 @@ Describe 'Solution CI gate1 contract' {
         $script:solutionCiWorkflow | Should -Match (
             '(?ms)^jobs:\r?\n\s+gate1:\r?\n\s+runs-on:\s+ubuntu-latest\r?\n\s+steps:'
         )
+    }
+}
+
+Describe 'Terraform bootstrap/import runbook' {
+    It 'documents GitHub auth prerequisites and reviewed-ref imports before first apply' {
+        $script:terraformReadme | Should -Match 'GH_TOKEN'
+        $script:terraformReadme | Should -Match 'GITHUB_TOKEN'
+        $script:terraformReadme | Should -Match (
+            'module\.github\.github_repository_environment\.envs\["dev"\]'
+        )
+        $script:terraformReadme | Should -Match (
+            'module\.github\.github_repository_environment\.envs\["test"\]'
+        )
+        $script:terraformReadme | Should -Match (
+            'module\.github\.github_repository_environment_deployment_policy\.allowed_branches\["test:main"\]'
+        )
+        $script:terraformReadme | Should -Match '56680080'
+    }
+
+    It 'warns operators to inspect the plan for reviewer retention before apply' {
+        $script:terraformReadme | Should -Match 'no reviewer removal'
+        $script:terraformReadme | Should -Match '(?ms)dev:main.*create'
+        $script:terraformReadme | Should -Match '(?ms)branch protection.*create'
+        $script:terraformReadme | Should -Not -Match 'not scaffolded yet'
+    }
+}
+
+Describe 'ADR-0004 reviewed-ref narrative' {
+    It 'records the current TEST reviewer exception and customer target state' {
+        $script:adr0004 | Should -Match 'urruegg'
+        $script:adr0004 | Should -Match '46865858'
+        $script:adr0004 | Should -Match 'prevent_self_review = false'
+        $script:adr0004 | Should -Match 'zero required reviewers'
+        $script:adr0004 | Should -Match 'independent required reviewers'
+    }
+
+    It 'distinguishes desired IaC from live branch-protection evidence' {
+        $script:adr0004 | Should -Match 'desired IaC'
+        $script:adr0004 | Should -Match 'not live evidence'
+        $script:adr0004 | Should -Match 'Terraform controller / maintainer session'
     }
 }

--- a/scripts/solution/tests/ReviewedRefControls.Tests.ps1
+++ b/scripts/solution/tests/ReviewedRefControls.Tests.ps1
@@ -1,0 +1,93 @@
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+    $script:githubModuleVariables = Get-Content (Join-Path $script:repoRoot `
+        'infra/terraform/modules/github/variables.tf') -Raw
+    $script:githubModuleMain = Get-Content (Join-Path $script:repoRoot `
+        'infra/terraform/modules/github/main.tf') -Raw
+    $script:terraformRoot = Get-Content (Join-Path $script:repoRoot `
+        'infra/terraform/main.tf') -Raw
+    $script:solutionCiWorkflow = Get-Content (Join-Path $script:repoRoot `
+        '.github/workflows/solution-ci.yml') -Raw
+}
+
+Describe 'GitHub environment reviewed-ref policies' {
+    It 'defaults allowed deployment branches to main in the GitHub module input contract' {
+        $script:githubModuleVariables | Should -Match (
+            'allowed_branch_patterns\s*=\s*optional\(\s*set\(string\)\s*,\s*\[\s*"main"\s*\]\s*\)'
+        )
+    }
+
+    It 'enables custom deployment branch policies on every repository environment' {
+        $script:githubModuleMain | Should -Match (
+            '(?ms)resource\s+"github_repository_environment"\s+"envs"\s*\{.*?' +
+            'deployment_branch_policy\s*\{\s*' +
+            'protected_branches\s*=\s*false\s*' +
+            'custom_branch_policies\s*=\s*true\s*' +
+            '\}'
+        )
+    }
+
+    It 'creates explicit deployment policies from allowed branch patterns' {
+        $script:githubModuleMain | Should -Match (
+            'resource\s+"github_repository_environment_deployment_policy"\s+"allowed_branches"'
+        )
+        $script:githubModuleMain | Should -Match 'branch_pattern\s*=\s*each\.value\.branch_pattern'
+    }
+
+    It 'pins the demo dev and test environments to main only' {
+        $script:terraformRoot | Should -Match (
+            '(?ms)dev\s*=\s*\{.*?allowed_branch_patterns\s*=\s*\[\s*"main"\s*\]'
+        )
+        $script:terraformRoot | Should -Match (
+            '(?ms)test\s*=\s*\{.*?allowed_branch_patterns\s*=\s*\[\s*"main"\s*\]'
+        )
+    }
+}
+
+Describe 'Main branch protection contract' {
+    It 'protects main with enforced admins, gate1, and conversation resolution' {
+        $script:githubModuleMain | Should -Match (
+            '(?ms)resource\s+"github_branch_protection"\s+"main"\s*\{.*?' +
+            'pattern\s*=\s*"main".*?' +
+            'enforce_admins\s*=\s*true.*?' +
+            'require_conversation_resolution\s*=\s*true.*?' +
+            'required_status_checks\s*\{.*?' +
+            'strict\s*=\s*true.*?' +
+            'contexts\s*=\s*\[\s*"gate1"\s*\].*?' +
+            '\}'
+        )
+    }
+
+    It 'requires pull requests on main without a mandatory independent approver in the demo repo' {
+        $script:githubModuleMain | Should -Match (
+            '(?ms)required_pull_request_reviews\s*\{.*?' +
+            'required_approving_review_count\s*=\s*0.*?' +
+            'pull_request_bypassers\s*=\s*\[\s*\].*?' +
+            '\}'
+        )
+    }
+
+    It 'disables force-push and deletion bypasses on main' {
+        $script:githubModuleMain | Should -Match 'allows_force_pushes\s*=\s*false'
+        $script:githubModuleMain | Should -Match 'force_push_bypassers\s*=\s*\[\s*\]'
+        $script:githubModuleMain | Should -Match 'allows_deletions\s*=\s*false'
+    }
+}
+
+Describe 'Solution CI gate1 contract' {
+    It 'runs on every pull request without path filters' {
+        $script:solutionCiWorkflow | Should -Match (
+            '(?ms)^on:\r?\n\s+pull_request:\s*\{\}\s*\r?\n(?:\s*#.*\r?\n)*\s+push:'
+        )
+    }
+
+    It 'does not allow a user-skippable gate1 bypass label' {
+        $script:solutionCiWorkflow | Should -Not -Match 'skip-solution-ci'
+    }
+
+    It 'does not put a job-level if guard in front of gate1' {
+        $script:solutionCiWorkflow | Should -Match (
+            '(?ms)^jobs:\r?\n\s+gate1:\r?\n\s+runs-on:\s+ubuntu-latest\r?\n\s+steps:'
+        )
+    }
+}

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -1,6 +1,7 @@
 BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
     $script:contractPath = Join-Path $script:repoRoot 'solution/schema/insurance-foundation.json'
+    $script:manifestPath = Join-Path $script:repoRoot 'solution/manifest.json'
     $script:preflightPath = Join-Path $script:repoRoot 'scripts/solution/Test-InsuranceAuthoringPreflight.ps1'
     $script:childPowerShellPath = if (Get-Command pwsh -ErrorAction SilentlyContinue) {
         (Get-Command pwsh -ErrorAction Stop).Source
@@ -8,8 +9,13 @@ BeforeAll {
     else {
         (Get-Command powershell -ErrorAction Stop).Source
     }
-    . $script:preflightPath -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath $script:contractPath
+    . $script:preflightPath `
+        -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+        -ContractPath $script:contractPath `
+        -ManifestPath $script:manifestPath
     $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+    $script:manifest = Get-Content -LiteralPath $script:manifestPath -Raw -Encoding UTF8 |
         ConvertFrom-Json
 
     function script:Assert-SafeDiagnosticLine {
@@ -26,37 +32,169 @@ BeforeAll {
         $Text.Length | Should -BeLessThan ($MaxLength + 1)
     }
 
-function script:New-PreflightEntryContract {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$RootPath
-    )
-
-    $contract = [ordered]@{
-        languages = @(1033, 1031, 1036, 1040)
-        solutions = @('crmshow_Foundation', 'crmshow_DataModel')
-        roles     = @(
-            [ordered]@{ name = 'CRM Showcase Insurance Reader' },
-            [ordered]@{ name = 'CRM Showcase Insurance Data Steward' }
+    function script:Clone-Object {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $InputObject
         )
+
+        return $InputObject | ConvertTo-Json -Depth 100 | ConvertFrom-Json
     }
 
-    $path = Join-Path $RootPath 'insurance-authoring-entry-contract.json'
-    Set-Content -LiteralPath $path -Value ($contract | ConvertTo-Json -Depth 10) -Encoding UTF8
-    return $path
-}
+    function script:New-PreflightSolutionRecord {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$SolutionId,
 
-function script:New-PreflightAzShim {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$RootPath
-    )
-    $shimScriptPath = Join-Path $RootPath 'az.ps1'
-    $shimCommandPath = Join-Path $RootPath 'az'
+            [Parameter(Mandatory)]
+            [string]$UniqueName,
 
-    $shimScript = @'
+            [Parameter(Mandatory)]
+            [string]$PublisherUniqueName,
+
+            [Parameter(Mandatory)]
+            [string]$CustomizationPrefix,
+
+            [Parameter(Mandatory)]
+            [int]$CustomizationOptionValuePrefix
+        )
+
+        return [pscustomobject]@{
+            solutionid = $SolutionId
+            uniquename = $UniqueName
+            publisherid = [pscustomobject]@{
+                uniquename                    = $PublisherUniqueName
+                customizationprefix           = $CustomizationPrefix
+                customizationoptionvalueprefix = $CustomizationOptionValuePrefix
+            }
+        }
+    }
+
+    function script:New-RoleVerificationResult {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Role,
+
+            [Parameter(Mandatory)]
+            [ValidateSet('Ready', 'ManualPrerequisite', 'ContractConflict')]
+            [string]$State,
+
+            [AllowNull()]
+            [object[]]$Details = @()
+        )
+
+        return [pscustomobject]@{
+            Role = $Role
+            State = $State
+            Missing = @()
+            Unexpected = @()
+            WrongDepth = @()
+            DuplicateExpected = @()
+            DuplicateActual = @()
+            Details = @($Details)
+        }
+    }
+
+    function script:New-RoleVerificationSummary {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [ValidateSet('Ready', 'ManualPrerequisite', 'ContractConflict')]
+            [string]$State,
+
+            [AllowNull()]
+            [object[]]$Results = @()
+        )
+
+        return [pscustomobject]@{
+            State = $State
+            MutationOccurred = $false
+            Results = @($Results)
+        }
+    }
+
+    function script:New-PreflightEntryContract {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath
+        )
+
+        $contract = [ordered]@{
+            languages = @(1033, 1031, 1036, 1040)
+            solutions = @('crmshow_Foundation', 'crmshow_DataModel')
+            tables = @(
+                [ordered]@{
+                    logicalName = 'crmshow_policyprojection'
+                    schemaName = 'crmshow_PolicyProjection'
+                }
+            )
+            roles = @(
+                [ordered]@{
+                    name = 'CRM Showcase Insurance Reader'
+                    solution = 'crmshow_Foundation'
+                    tablePrivileges = @(
+                        [ordered]@{
+                            table = 'account'
+                            depth = 'Organization'
+                            privileges = @('Read')
+                        },
+                        [ordered]@{
+                            table = 'crmshow_policyprojection'
+                            depth = 'Organization'
+                            privileges = @('Read')
+                        }
+                    )
+                    deniedPrivileges = @(
+                        'Delete', 'Assign', 'Share', 'Customize',
+                        'SecurityAdministration', 'BulkDelete',
+                        'AuditAdministration'
+                    )
+                },
+                [ordered]@{
+                    name = 'CRM Showcase Insurance Data Steward'
+                    solution = 'crmshow_Foundation'
+                    tablePrivileges = @(
+                        [ordered]@{
+                            table = 'account'
+                            depth = 'Organization'
+                            privileges = @('Read')
+                        },
+                        [ordered]@{
+                            table = 'crmshow_policyprojection'
+                            depth = 'Organization'
+                            privileges = @('Create', 'Read', 'Write')
+                        }
+                    )
+                    deniedPrivileges = @(
+                        'Delete', 'Assign', 'Share', 'Customize',
+                        'SecurityAdministration', 'BulkDelete',
+                        'AuditAdministration'
+                    )
+                }
+            )
+        }
+
+        $path = Join-Path $RootPath 'insurance-authoring-entry-contract.json'
+        Set-Content -LiteralPath $path `
+            -Value ($contract | ConvertTo-Json -Depth 20) `
+            -Encoding UTF8
+        return $path
+    }
+
+    function script:New-PreflightAzShim {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath
+        )
+        $shimScriptPath = Join-Path $RootPath 'az.ps1'
+        $shimCommandPath = Join-Path $RootPath 'az'
+
+        $shimScript = @'
 #!/usr/bin/env pwsh
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -90,7 +228,19 @@ function Write-Json {
         $Value
     )
 
-    $Value | ConvertTo-Json -Compress -Depth 10
+    $Value | ConvertTo-Json -Compress -Depth 20
+}
+
+$method = Get-ArgumentValue -InputArguments $Arguments -Name '--method'
+if ($method -cne 'get') {
+    Write-Error "Unexpected method: $method"
+    exit 1
+}
+
+$resource = Get-ArgumentValue -InputArguments $Arguments -Name '--resource'
+if ($resource -cne 'https://unit.crm.dynamics.com/') {
+    Write-Error "Unexpected resource URL: $resource"
+    exit 1
 }
 
 $url = Get-ArgumentValue -InputArguments $Arguments -Name '--url'
@@ -112,27 +262,167 @@ if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -eq 'TransportFailure') {
     exit 9
 }
 
-$roles = @(
-    [pscustomobject]@{
-        roleid = '00000000-0000-0000-0000-000000000001'
-        name   = 'CRM Showcase Insurance Reader'
-    }
-)
-if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ne 'MissingRoles') {
-    $roles += [pscustomobject]@{
-        roleid = '00000000-0000-0000-0000-000000000002'
-        name   = 'CRM Showcase Insurance Data Steward'
+$readerRoleId = '11111111-1111-1111-1111-111111111111'
+$stewardRoleId = '22222222-2222-2222-2222-222222222222'
+$foundationPublisher = [pscustomobject]@{
+    uniquename = 'CRMShowcase'
+    customizationprefix = 'crmshow'
+    customizationoptionvalueprefix = 10000
+}
+$dataModelPublisher = [pscustomobject]@{
+    uniquename = 'CRMShowcase'
+    customizationprefix = 'crmshow'
+    customizationoptionvalueprefix = 10000
+}
+if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -eq 'WrongPublisher') {
+    $dataModelPublisher = [pscustomobject]@{
+        uniquename = 'Contoso'
+        customizationprefix = 'crmshow'
+        customizationoptionvalueprefix = 10000
     }
 }
 
 switch ($path) {
-    '/WhoAmI' {
+    '/solutions?$select=solutionid,uniquename&$expand=publisherid($select=uniquename,customizationprefix,customizationoptionvalueprefix)&$filter=uniquename eq ''crmshow_Foundation'' or uniquename eq ''crmshow_DataModel''' {
         Write-Json ([pscustomobject]@{
-                UserId = '11111111-1111-1111-1111-111111111111'
+                value = @(
+                    [pscustomobject]@{
+                        solutionid = '33333333-3333-3333-3333-333333333333'
+                        uniquename = 'crmshow_Foundation'
+                        publisherid = $foundationPublisher
+                    },
+                    [pscustomobject]@{
+                        solutionid = '44444444-4444-4444-4444-444444444444'
+                        uniquename = 'crmshow_DataModel'
+                        publisherid = $dataModelPublisher
+                    }
+                )
             })
         exit 0
     }
-    '/systemusers(11111111-1111-1111-1111-111111111111)/systemuserroles_association?$select=name' {
+    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Reader'" {
+        Write-Json ([pscustomobject]@{
+                value = @([pscustomobject]@{
+                        roleid = $readerRoleId
+                        name = 'CRM Showcase Insurance Reader'
+                    })
+            })
+        exit 0
+    }
+    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
+        $roles = @()
+        if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ne 'MissingRoles') {
+            $roles += [pscustomobject]@{
+                roleid = $stewardRoleId
+                name = 'CRM Showcase Insurance Data Steward'
+            }
+        }
+        Write-Json ([pscustomobject]@{ value = @($roles) })
+        exit 0
+    }
+    "/solutioncomponents?`$select=solutioncomponentid&`$filter=objectid eq $readerRoleId&`$expand=solutionid(`$select=uniquename)" {
+        Write-Json ([pscustomobject]@{
+                value = @([pscustomobject]@{
+                        solutionid = [pscustomobject]@{
+                            uniquename = 'crmshow_Foundation'
+                        }
+                    })
+            })
+        exit 0
+    }
+    "/solutioncomponents?`$select=solutioncomponentid&`$filter=objectid eq $stewardRoleId&`$expand=solutionid(`$select=uniquename)" {
+        Write-Json ([pscustomobject]@{
+                value = @([pscustomobject]@{
+                        solutionid = [pscustomobject]@{
+                            uniquename = 'crmshow_Foundation'
+                        }
+                    })
+            })
+        exit 0
+    }
+    "/EntityDefinitions(LogicalName='account')?`$select=LogicalName,SchemaName,Privileges" {
+        Write-Json ([pscustomobject]@{
+                LogicalName = 'account'
+                SchemaName = 'Account'
+                Privileges = @([pscustomobject]@{
+                        Name = 'prvReadAccount'
+                        PrivilegeId = 'account-read'
+                    })
+            })
+        exit 0
+    }
+    "/EntityDefinitions(LogicalName='crmshow_policyprojection')?`$select=LogicalName,SchemaName,Privileges" {
+        Write-Json ([pscustomobject]@{
+                LogicalName = 'crmshow_policyprojection'
+                SchemaName = 'crmshow_PolicyProjection'
+                Privileges = @(
+                    [pscustomobject]@{
+                        Name = 'prvCreatecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-create'
+                    },
+                    [pscustomobject]@{
+                        Name = 'prvReadcrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-read'
+                    },
+                    [pscustomobject]@{
+                        Name = 'prvWritecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-write'
+                    }
+                )
+            })
+        exit 0
+    }
+    "/RetrieveRolePrivilegesRole(RoleId=$readerRoleId)" {
+        Write-Json ([pscustomobject]@{
+                RolePrivileges = @(
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadAccount'
+                        PrivilegeId = 'account-read'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadcrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-read'
+                        Depth = 'Global'
+                    }
+                )
+            })
+        exit 0
+    }
+    "/RetrieveRolePrivilegesRole(RoleId=$stewardRoleId)" {
+        Write-Json ([pscustomobject]@{
+                RolePrivileges = @(
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadAccount'
+                        PrivilegeId = 'account-read'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvCreatecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-create'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadcrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-read'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvWritecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-write'
+                        Depth = 'Global'
+                    }
+                )
+            })
+        exit 0
+    }
+    '/WhoAmI' {
+        Write-Json ([pscustomobject]@{
+                UserId = '55555555-5555-5555-5555-555555555555'
+            })
+        exit 0
+    }
+    '/systemusers(55555555-5555-5555-5555-555555555555)/systemuserroles_association?$select=name' {
         Write-Json ([pscustomobject]@{
                 value = @(
                     [pscustomobject]@{ name = 'System Customizer' }
@@ -146,21 +436,6 @@ switch ($path) {
             })
         exit 0
     }
-    '/solutions?$select=uniquename&$filter=uniquename eq ''crmshow_Foundation'' or uniquename eq ''crmshow_DataModel''' {
-        Write-Json ([pscustomobject]@{
-                value = @(
-                    [pscustomobject]@{ uniquename = 'crmshow_Foundation' },
-                    [pscustomobject]@{ uniquename = 'crmshow_DataModel' }
-                )
-            })
-        exit 0
-    }
-    '/roles?$select=roleid,name&$filter=_parentrootroleid_value eq null and (name eq ''CRM Showcase Insurance Reader'' or name eq ''CRM Showcase Insurance Data Steward'')' {
-        Write-Json ([pscustomobject]@{
-                value = @($roles)
-            })
-        exit 0
-    }
     default {
         Write-Error "Unexpected az rest URL: $url"
         exit 1
@@ -168,81 +443,81 @@ switch ($path) {
 }
 '@
 
-    $shimScript = $shimScript -replace "`r`n", "`n"
-    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        $shimScript = $shimScript -replace "`r`n", "`n"
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 
-    [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
-    [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
+        [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
+        [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
 
-    if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
-        & chmod +x -- $shimCommandPath
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to make az shim executable: $shimCommandPath"
+        if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
+            & chmod +x -- $shimCommandPath
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to make az shim executable: $shimCommandPath"
+            }
         }
     }
-}
 
-function script:Invoke-PreflightEntryScript {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [ValidateSet('Ready', 'MissingRoles', 'TransportFailure')]
-        [string]$Scenario
-    )
+    function script:Invoke-PreflightEntryScript {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [ValidateSet('Ready', 'MissingRoles', 'WrongPublisher', 'TransportFailure')]
+            [string]$Scenario
+        )
 
-    $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
-    $null = New-Item -ItemType Directory -Path $testRoot -Force
+        $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+        $null = New-Item -ItemType Directory -Path $testRoot -Force
 
-    $contractPath = script:New-PreflightEntryContract -RootPath $testRoot
-    script:New-PreflightAzShim -RootPath $testRoot
+        $contractPath = script:New-PreflightEntryContract -RootPath $testRoot
+        script:New-PreflightAzShim -RootPath $testRoot
 
-    $previousPath = $env:PATH
-    $previousScenario = [Environment]::GetEnvironmentVariable(
-        'TEST_INSURANCE_PREFLIGHT_SCENARIO',
-        'Process'
-    )
+        $previousPath = $env:PATH
+        $previousScenario = [Environment]::GetEnvironmentVariable(
+            'TEST_INSURANCE_PREFLIGHT_SCENARIO',
+            'Process'
+        )
 
-    try {
-        $pathSeparator = [System.IO.Path]::PathSeparator
-        $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
-            $testRoot
-        }
-        else {
-            "$testRoot$pathSeparator$previousPath"
-        }
-        $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $Scenario
-
-        $previousErrorActionPreference = $ErrorActionPreference
-        $ErrorActionPreference = 'Continue'
         try {
-            $output = & $script:childPowerShellPath `
-                -NoLogo `
-                -NoProfile `
-                -NonInteractive `
-                -File $script:preflightPath `
-                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-                -ContractPath $contractPath 2>&1
-            $exitCode = $LASTEXITCODE
+            $pathSeparator = [System.IO.Path]::PathSeparator
+            $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
+                $testRoot
+            }
+            else {
+                "$testRoot$pathSeparator$previousPath"
+            }
+            $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $Scenario
+
+            $previousErrorActionPreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            try {
+                $output = & $script:childPowerShellPath `
+                    -NoLogo `
+                    -NoProfile `
+                    -NonInteractive `
+                    -File $script:preflightPath `
+                    -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                    -ContractPath $contractPath 2>&1
+                $exitCode = $LASTEXITCODE
+            }
+            finally {
+                $ErrorActionPreference = $previousErrorActionPreference
+            }
         }
         finally {
-            $ErrorActionPreference = $previousErrorActionPreference
+            $env:PATH = $previousPath
+            if ($null -eq $previousScenario) {
+                Remove-Item Env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $previousScenario
+            }
         }
-    }
-    finally {
-        $env:PATH = $previousPath
-        if ($null -eq $previousScenario) {
-            Remove-Item Env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ErrorAction SilentlyContinue
-        }
-        else {
-            $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $previousScenario
-        }
-    }
 
-    return [pscustomobject]@{
-        ExitCode = $exitCode
-        Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+        }
     }
-}
 }
 
 Describe 'New-PreflightAzShim' {
@@ -303,8 +578,18 @@ else {
 }
 
 Describe 'Get-InsuranceAuthoringPhaseState' {
+    It 'returns ContractConflict ahead of every later non-ready state' {
+        Get-InsuranceAuthoringPhaseState `
+            -HasContractConflict $true `
+            -SchemaFeasible $false `
+            -SolutionsReady $false `
+            -RolesReady $false |
+            Should -Be 'ContractConflict'
+    }
+
     It 'returns UnsupportedInTenant when schema capability is not proven' {
         Get-InsuranceAuthoringPhaseState `
+            -HasContractConflict $false `
             -SolutionsReady $false `
             -SchemaFeasible $false `
             -RolesReady $false |
@@ -313,6 +598,7 @@ Describe 'Get-InsuranceAuthoringPhaseState' {
 
     It 'returns Precondition when required solutions are absent' {
         Get-InsuranceAuthoringPhaseState `
+            -HasContractConflict $false `
             -SolutionsReady $false `
             -SchemaFeasible $true `
             -RolesReady $true |
@@ -321,6 +607,7 @@ Describe 'Get-InsuranceAuthoringPhaseState' {
 
     It 'returns ManualPrerequisite when a reviewed custom role is absent' {
         Get-InsuranceAuthoringPhaseState `
+            -HasContractConflict $false `
             -SolutionsReady $true `
             -SchemaFeasible $true `
             -RolesReady $false |
@@ -329,10 +616,24 @@ Describe 'Get-InsuranceAuthoringPhaseState' {
 
     It 'returns Ready when schema, solutions and roles are ready' {
         Get-InsuranceAuthoringPhaseState `
+            -HasContractConflict $false `
             -SolutionsReady $true `
             -SchemaFeasible $true `
             -RolesReady $true |
             Should -Be 'Ready'
+    }
+}
+
+Describe 'Get-RequiredSolutionsPath' {
+    It 'selects reviewed solution identity and expanded publisher ownership' {
+        Get-RequiredSolutionsPath -SolutionUniqueName @(
+            'crmshow_Foundation',
+            'crmshow_DataModel'
+        ) | Should -Be (
+            "/solutions?`$select=solutionid,uniquename&" +
+            "`$expand=publisherid(`$select=uniquename,customizationprefix,customizationoptionvalueprefix)&" +
+            "`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'"
+        )
     }
 }
 
@@ -354,13 +655,16 @@ Describe 'Get-LanguagePreflightAction' {
 
 Describe 'Test-DemoSchemaAuthoringCapability' {
     It 'accepts System Customizer' {
-        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @('Basic User', 'System Customizer') |
-            Should -BeTrue
+        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @(
+            'Basic User',
+            'System Customizer'
+        ) | Should -BeTrue
     }
 
     It 'accepts System Administrator' {
-        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @('System Administrator') |
-            Should -BeTrue
+        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @(
+            'System Administrator'
+        ) | Should -BeTrue
     }
 
     It 'rejects unproven roles such as Basic User' {
@@ -443,17 +747,178 @@ Describe 'Invoke-PreflightDataverseRequest' {
     }
 }
 
+Describe 'Test-InsuranceAuthoringPreflightSolutions' {
+    BeforeEach {
+        $script:solutionsPath = (
+            "/solutions?`$select=solutionid,uniquename&" +
+            "`$expand=publisherid(`$select=uniquename,customizationprefix,customizationoptionvalueprefix)&" +
+            "`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'"
+        )
+        $script:solutionItems = @(
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '33333333-3333-3333-3333-333333333333' `
+                    -UniqueName 'crmshow_Foundation' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            ),
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '44444444-4444-4444-4444-444444444444' `
+                    -UniqueName 'crmshow_DataModel' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            )
+        )
+
+        Mock Invoke-PreflightDataverseRequest {
+            param($EnvironmentUrl, $Method, $Path)
+
+            if ($Method -ne 'GET') {
+                throw "Unexpected method: $Method"
+            }
+            if ($Path -ne $script:solutionsPath) {
+                throw "Unexpected solution path: $Path"
+            }
+
+            return [pscustomobject]@{
+                value = @($script:solutionItems)
+            }
+        }
+    }
+
+    It 'returns Ready when every contract solution exists once with the manifest publisher' {
+        $result = Test-InsuranceAuthoringPreflightSolutions `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Ready'
+        @($result.MissingSolutions) | Should -Be @()
+        @($result.SolutionConflicts) | Should -Be @()
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Path -eq $script:solutionsPath
+        }
+    }
+
+    It 'returns ContractConflict when a reviewed solution publisher differs from the manifest' {
+        $script:solutionItems = @(
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '33333333-3333-3333-3333-333333333333' `
+                    -UniqueName 'crmshow_Foundation' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            ),
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '44444444-4444-4444-4444-444444444444' `
+                    -UniqueName 'crmshow_DataModel' `
+                    -PublisherUniqueName 'Contoso' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            )
+        )
+
+        $result = Test-InsuranceAuthoringPreflightSolutions `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.MissingSolutions) | Should -Be @()
+        @($result.SolutionConflicts).Count | Should -Be 1
+        @($result.SolutionConflicts) | Should -Contain (
+            "Solution 'crmshow_DataModel' publisher metadata does not match solution/manifest.json: publisher.uniquename expected 'CRMShowcase' but was 'Contoso'."
+        )
+    }
+
+    It 'returns ContractConflict when a reviewed solution unique name is duplicated' {
+        $script:solutionItems = @(
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '33333333-3333-3333-3333-333333333333' `
+                    -UniqueName 'crmshow_Foundation' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            ),
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '99999999-9999-9999-9999-999999999999' `
+                    -UniqueName 'crmshow_Foundation' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            ),
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '44444444-4444-4444-4444-444444444444' `
+                    -UniqueName 'crmshow_DataModel' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            )
+        )
+
+        $result = Test-InsuranceAuthoringPreflightSolutions `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.SolutionConflicts) | Should -Contain (
+            "Solution 'crmshow_Foundation' returned 2 records; expected exactly one reviewed solution."
+        )
+    }
+}
+
 Describe 'Invoke-InsuranceAuthoringPreflight' {
     BeforeEach {
         $script:calls = [System.Collections.Generic.List[object]]::new()
         $script:userId = '11111111-1111-1111-1111-111111111111'
         $script:assignedRoleNames = @('System Customizer')
         $script:provisionedLanguages = @(1033, 1031, 1036, 1040)
-        $script:availableSolutions = @('crmshow_Foundation', 'crmshow_DataModel')
-        $script:availableRoles = @(
-            'CRM Showcase Insurance Reader',
-            'CRM Showcase Insurance Data Steward'
+        $script:solutionsPath = (
+            "/solutions?`$select=solutionid,uniquename&" +
+            "`$expand=publisherid(`$select=uniquename,customizationprefix,customizationoptionvalueprefix)&" +
+            "`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'"
         )
+        $script:solutionItems = @(
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '33333333-3333-3333-3333-333333333333' `
+                    -UniqueName 'crmshow_Foundation' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            ),
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '44444444-4444-4444-4444-444444444444' `
+                    -UniqueName 'crmshow_DataModel' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            )
+        )
+        $script:roleVerification = script:New-RoleVerificationSummary `
+            -State 'Ready' `
+            -Results @(
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Reader' `
+                        -State 'Ready'
+                ),
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Data Steward' `
+                        -State 'Ready'
+                )
+            )
 
         Mock Invoke-PreflightDataverseRequest {
             param($EnvironmentUrl, $Method, $Path)
@@ -465,6 +930,11 @@ Describe 'Invoke-InsuranceAuthoringPreflight' {
                 })
 
             switch ($Path) {
+                $script:solutionsPath {
+                    return [pscustomobject]@{
+                        value = @($script:solutionItems)
+                    }
+                }
                 '/WhoAmI' {
                     return [pscustomobject]@{ UserId = $script:userId }
                 }
@@ -480,109 +950,134 @@ Describe 'Invoke-InsuranceAuthoringPreflight' {
                         RetrieveProvisionedLanguages = @($script:provisionedLanguages)
                     }
                 }
-                "/solutions?`$select=uniquename&`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'" {
-                    return [pscustomobject]@{
-                        value = @($script:availableSolutions | ForEach-Object {
-                                [pscustomobject]@{ uniquename = $_ }
-                            })
-                    }
-                }
-                "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and (name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward')" {
-                    $index = 0
-                    return [pscustomobject]@{
-                        value = @($script:availableRoles | ForEach-Object {
-                                $index++
-                                [pscustomobject]@{
-                                    roleid = '00000000-0000-0000-0000-{0:D12}' -f $index
-                                    name   = $_
-                                }
-                            })
-                    }
-                }
                 default {
                     throw "Unexpected mocked preflight path: $Path"
                 }
             }
         }
+
+        Mock Invoke-InsuranceSecurityRoleVerification {
+            param($EnvironmentUrl, $Contract)
+
+            return $script:roleVerification
+        }
     }
 
-    It 'returns a ready result with GET-only transport and no mutation' {
+    It 'returns a ready result with GET-only transport, manifest ownership, and no mutation' {
         $result = Invoke-InsuranceAuthoringPreflight `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -Contract $script:contract
+            -Contract $script:contract `
+            -Manifest $script:manifest
 
         $result.State | Should -Be 'Ready'
         $result.UserId | Should -Be $script:userId
         $result.SolutionsReady | Should -BeTrue
+        @($result.MissingSolutions) | Should -Be @()
+        @($result.SolutionConflicts) | Should -Be @()
         $result.LanguagesReady | Should -BeTrue
         $result.LanguageAction | Should -Be 'None'
         $result.RolesReady | Should -BeTrue
         @($result.AssignedRoleNames) | Should -Be @('System Customizer')
         @($result.MissingRoles) | Should -Be @()
+        @($result.RoleConflicts) | Should -Be @()
         $result.MutationOccurred | Should -BeFalse
 
-        Should -Invoke Invoke-PreflightDataverseRequest -Times 5 -Exactly `
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 4 -Exactly `
             -ParameterFilter { $Method -eq 'GET' }
         Should -Invoke Invoke-PreflightDataverseRequest -Times 0 -Exactly `
             -ParameterFilter { $Method -ne 'GET' }
+        Should -Invoke Invoke-InsuranceSecurityRoleVerification -Times 1 -Exactly
         @($script:calls.Path) | Should -Be @(
+            $script:solutionsPath,
             '/WhoAmI',
             "/systemusers(11111111-1111-1111-1111-111111111111)/systemuserroles_association?`$select=name",
-            '/RetrieveProvisionedLanguages()',
-            "/solutions?`$select=uniquename&`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'",
-            "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and (name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward')"
+            '/RetrieveProvisionedLanguages()'
         )
     }
 
-    It 'keeps matching mocked root-role endpoint paths with escaped role names' {
-        $script:availableRoles = @('CRM Showcase Insurance Reader', 'CRM Showcase Insurance Data Steward')
-
-        $result = Invoke-InsuranceAuthoringPreflight `
-            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -Contract $script:contract
-
-        $result.RolesReady | Should -BeTrue
-        Should -Invoke Invoke-PreflightDataverseRequest -Times 1 -Exactly -ParameterFilter {
-            $Path -eq "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and (name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward')"
-        }
-    }
-
     It 'classifies a missing solution as Precondition' {
-        $script:availableSolutions = @('crmshow_Foundation')
+        $script:solutionItems = @(
+            script:New-PreflightSolutionRecord `
+                -SolutionId '33333333-3333-3333-3333-333333333333' `
+                -UniqueName 'crmshow_Foundation' `
+                -PublisherUniqueName 'CRMShowcase' `
+                -CustomizationPrefix 'crmshow' `
+                -CustomizationOptionValuePrefix 10000
+        )
 
         $result = Invoke-InsuranceAuthoringPreflight `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -Contract $script:contract
+            -Contract $script:contract `
+            -Manifest $script:manifest
 
         $result.State | Should -Be 'Precondition'
         $result.SolutionsReady | Should -BeFalse
+        @($result.MissingSolutions) | Should -Be @('crmshow_DataModel')
     }
 
     It 'classifies a missing reviewed role as ManualPrerequisite and reports MissingRoles' {
-        $script:availableRoles = @('CRM Showcase Insurance Reader')
+        $script:roleVerification = script:New-RoleVerificationSummary `
+            -State 'ManualPrerequisite' `
+            -Results @(
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Reader' `
+                        -State 'Ready'
+                ),
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Data Steward' `
+                        -State 'ManualPrerequisite' `
+                        -Details @(
+                            "Root security role 'CRM Showcase Insurance Data Steward' was not found."
+                        )
+                )
+            )
 
         $result = Invoke-InsuranceAuthoringPreflight `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -Contract $script:contract
+            -Contract $script:contract `
+            -Manifest $script:manifest
 
         $result.State | Should -Be 'ManualPrerequisite'
         $result.RolesReady | Should -BeFalse
         @($result.MissingRoles) | Should -Be @('CRM Showcase Insurance Data Steward')
+        @($result.RoleConflicts) | Should -Be @()
     }
 
     It 'classifies Basic User as UnsupportedInTenant even when reviewed roles are absent' {
         $script:assignedRoleNames = @('Basic User')
-        $script:availableRoles = @()
+        $script:roleVerification = script:New-RoleVerificationSummary `
+            -State 'ManualPrerequisite' `
+            -Results @(
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Reader' `
+                        -State 'ManualPrerequisite' `
+                        -Details @(
+                            "Root security role 'CRM Showcase Insurance Reader' was not found."
+                        )
+                ),
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Data Steward' `
+                        -State 'ManualPrerequisite' `
+                        -Details @(
+                            "Root security role 'CRM Showcase Insurance Data Steward' was not found."
+                        )
+                )
+            )
 
         $result = Invoke-InsuranceAuthoringPreflight `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -Contract $script:contract
+            -Contract $script:contract `
+            -Manifest $script:manifest
 
         $result.State | Should -Be 'UnsupportedInTenant'
         $result.RolesReady | Should -BeFalse
         @($result.MissingRoles) | Should -Be @(
-            'CRM Showcase Insurance Reader',
-            'CRM Showcase Insurance Data Steward'
+            'CRM Showcase Insurance Data Steward',
+            'CRM Showcase Insurance Reader'
         )
     }
 
@@ -591,12 +1086,89 @@ Describe 'Invoke-InsuranceAuthoringPreflight' {
 
         $result = Invoke-InsuranceAuthoringPreflight `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -Contract $script:contract
+            -Contract $script:contract `
+            -Manifest $script:manifest
 
         $result.State | Should -Be 'Ready'
         $result.LanguagesReady | Should -BeFalse
         $result.LanguageAction | Should -Be 'Reconcile'
         $result.MutationOccurred | Should -BeFalse
+    }
+
+    It 'returns ContractConflict and stops before schema or language checks on publisher mismatch' {
+        $script:solutionItems = @(
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '33333333-3333-3333-3333-333333333333' `
+                    -UniqueName 'crmshow_Foundation' `
+                    -PublisherUniqueName 'CRMShowcase' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            ),
+            (
+                script:New-PreflightSolutionRecord `
+                    -SolutionId '44444444-4444-4444-4444-444444444444' `
+                    -UniqueName 'crmshow_DataModel' `
+                    -PublisherUniqueName 'Contoso' `
+                    -CustomizationPrefix 'crmshow' `
+                    -CustomizationOptionValuePrefix 10000
+            )
+        )
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.SolutionConflicts) | Should -Contain (
+            "Solution 'crmshow_DataModel' publisher metadata does not match solution/manifest.json: publisher.uniquename expected 'CRMShowcase' but was 'Contoso'."
+        )
+        @($result.AssignedRoleNames) | Should -Be @()
+        $result.LanguageAction | Should -Be 'Skipped'
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 0 -Exactly -ParameterFilter {
+            $Path -eq '/WhoAmI'
+        }
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 0 -Exactly -ParameterFilter {
+            $Path -eq '/RetrieveProvisionedLanguages()'
+        }
+    }
+
+    It 'returns ContractConflict and exposes role conflict details before schema or language checks' {
+        $script:roleVerification = script:New-RoleVerificationSummary `
+            -State 'ContractConflict' `
+            -Results @(
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Reader' `
+                        -State 'Ready'
+                ),
+                (
+                    script:New-RoleVerificationResult `
+                        -Role 'CRM Showcase Insurance Data Steward' `
+                        -State 'ContractConflict' `
+                        -Details @(
+                            "Role 'CRM Showcase Insurance Data Steward' reviewed-solution membership expected 'crmshow_Foundation'; actual reviewed membership was 'crmshow_Foundation, crmshow_DataModel'."
+                        )
+                )
+            )
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        $result.RolesReady | Should -BeFalse
+        @($result.RoleConflicts) | Should -Be @(
+            "Role 'CRM Showcase Insurance Data Steward': Role 'CRM Showcase Insurance Data Steward' reviewed-solution membership expected 'crmshow_Foundation'; actual reviewed membership was 'crmshow_Foundation, crmshow_DataModel'."
+        )
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 0 -Exactly -ParameterFilter {
+            $Path -eq '/WhoAmI'
+        }
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 0 -Exactly -ParameterFilter {
+            $Path -eq '/RetrieveProvisionedLanguages()'
+        }
     }
 }
 
@@ -624,13 +1196,25 @@ Describe 'Preflight direct entry point' {
         @($result.MissingRoles) | Should -Be @('CRM Showcase Insurance Data Steward')
     }
 
+    It 'emits classified conflict JSON and exits three on reviewed publisher conflict' {
+        $invocation = script:Invoke-PreflightEntryScript -Scenario WrongPublisher
+
+        $invocation.ExitCode | Should -Be 3
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } | Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'ContractConflict'
+        $result.MutationOccurred | Should -BeFalse
+        @($result.SolutionConflicts).Count | Should -Be 1
+    }
+
     It 'emits a single safe error line and exits one on hostile az transport failure' {
         $invocation = script:Invoke-PreflightEntryScript -Scenario TransportFailure
 
         $invocation.ExitCode | Should -Be 1
-        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
+        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 500
         $invocation.Output | Should -Match 'Dataverse preflight transport failed'
-        $invocation.Output | Should -Match ([regex]::Escape('/WhoAmI'))
+        $invocation.Output | Should -Match '/solutions\?\$select=solutionid,uniquename'
         $invocation.Output | Should -Match (
             [regex]::Escape(
                 "'::warning::preflight transport Permission denied blocked"
@@ -644,9 +1228,10 @@ Describe 'Preflight entry point safety' {
     It 'does not invoke az when dot-sourced with unit arguments' {
         $text = @'
 function az { throw 'az was called' }
-. '__SCRIPT__' -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath '__CONTRACT__'
+. '__SCRIPT__' -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath '__CONTRACT__' -ManifestPath '__MANIFEST__'
 '@.Replace('__SCRIPT__', $script:preflightPath.Replace("'", "''")).
-            Replace('__CONTRACT__', $script:contractPath.Replace("'", "''"))
+            Replace('__CONTRACT__', $script:contractPath.Replace("'", "''")).
+            Replace('__MANIFEST__', $script:manifestPath.Replace("'", "''"))
 
         & ([scriptblock]::Create($text))
     }

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Invoke-InsuranceAuthoringPreflight' {
                             })
                     }
                 }
-                "/roles?`$select=roleid,name&`$filter=name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward'" {
+                "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and (name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward')" {
                     $index = 0
                     return [pscustomobject]@{
                         value = @($script:availableRoles | ForEach-Object {
@@ -213,8 +213,21 @@ Describe 'Invoke-InsuranceAuthoringPreflight' {
             "/systemusers(11111111-1111-1111-1111-111111111111)/systemuserroles_association?`$select=name",
             '/RetrieveProvisionedLanguages()',
             "/solutions?`$select=uniquename&`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'",
-            "/roles?`$select=roleid,name&`$filter=name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward'"
+            "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and (name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward')"
         )
+    }
+
+    It 'keeps matching mocked root-role endpoint paths with escaped role names' {
+        $script:availableRoles = @('CRM Showcase Insurance Reader', 'CRM Showcase Insurance Data Steward')
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.RolesReady | Should -BeTrue
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 1 -Exactly -ParameterFilter {
+            $Path -eq "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and (name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward')"
+        }
     }
 
     It 'classifies a missing solution as Precondition' {

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -2,9 +2,198 @@ BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
     $script:contractPath = Join-Path $script:repoRoot 'solution/schema/insurance-foundation.json'
     $script:preflightPath = Join-Path $script:repoRoot 'scripts/solution/Test-InsuranceAuthoringPreflight.ps1'
+    $script:childPowerShellPath = if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+        (Get-Command pwsh -ErrorAction Stop).Source
+    }
+    else {
+        (Get-Command powershell -ErrorAction Stop).Source
+    }
     . $script:preflightPath -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath $script:contractPath
     $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
         ConvertFrom-Json
+
+function script:New-PreflightEntryContract {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RootPath
+    )
+
+    $contract = [ordered]@{
+        languages = @(1033, 1031, 1036, 1040)
+        solutions = @('crmshow_Foundation', 'crmshow_DataModel')
+        roles     = @(
+            [ordered]@{ name = 'CRM Showcase Insurance Reader' },
+            [ordered]@{ name = 'CRM Showcase Insurance Data Steward' }
+        )
+    }
+
+    $path = Join-Path $RootPath 'insurance-authoring-entry-contract.json'
+    Set-Content -LiteralPath $path -Value ($contract | ConvertTo-Json -Depth 10) -Encoding UTF8
+    return $path
+}
+
+function script:New-PreflightAzShim {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RootPath
+    )
+    $shimScriptPath = Join-Path $RootPath 'az.ps1'
+
+    $shimScript = @'
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ArgumentValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$InputArguments,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $index = [Array]::IndexOf($InputArguments, $Name)
+    if ($index -lt 0 -or $index -ge ($InputArguments.Count - 1)) {
+        throw "Missing required argument: $Name"
+    }
+
+    return $InputArguments[$index + 1]
+}
+
+function Write-Json {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Value
+    )
+
+    $Value | ConvertTo-Json -Compress -Depth 10
+}
+
+$url = Get-ArgumentValue -InputArguments $Arguments -Name '--url'
+$prefix = '/api/data/v9.2'
+$prefixIndex = $url.IndexOf($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+if ($prefixIndex -ge 0) {
+    $path = $url.Substring($prefixIndex + $prefix.Length)
+}
+else {
+    $path = $url
+}
+
+$roles = @(
+    [pscustomobject]@{
+        roleid = '00000000-0000-0000-0000-000000000001'
+        name   = 'CRM Showcase Insurance Reader'
+    }
+)
+if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ne 'MissingRoles') {
+    $roles += [pscustomobject]@{
+        roleid = '00000000-0000-0000-0000-000000000002'
+        name   = 'CRM Showcase Insurance Data Steward'
+    }
+}
+
+switch ($path) {
+    '/WhoAmI' {
+        Write-Json ([pscustomobject]@{
+                UserId = '11111111-1111-1111-1111-111111111111'
+            })
+        exit 0
+    }
+    '/systemusers(11111111-1111-1111-1111-111111111111)/systemuserroles_association?$select=name' {
+        Write-Json ([pscustomobject]@{
+                value = @(
+                    [pscustomobject]@{ name = 'System Customizer' }
+                )
+            })
+        exit 0
+    }
+    '/RetrieveProvisionedLanguages()' {
+        Write-Json ([pscustomobject]@{
+                RetrieveProvisionedLanguages = @(1033, 1031, 1036, 1040)
+            })
+        exit 0
+    }
+    '/solutions?$select=uniquename&$filter=uniquename eq ''crmshow_Foundation'' or uniquename eq ''crmshow_DataModel''' {
+        Write-Json ([pscustomobject]@{
+                value = @(
+                    [pscustomobject]@{ uniquename = 'crmshow_Foundation' },
+                    [pscustomobject]@{ uniquename = 'crmshow_DataModel' }
+                )
+            })
+        exit 0
+    }
+    '/roles?$select=roleid,name&$filter=_parentrootroleid_value eq null and (name eq ''CRM Showcase Insurance Reader'' or name eq ''CRM Showcase Insurance Data Steward'')' {
+        Write-Json ([pscustomobject]@{
+                value = @($roles)
+            })
+        exit 0
+    }
+    default {
+        Write-Error "Unexpected az rest URL: $url"
+        exit 1
+    }
+}
+'@
+
+    Set-Content -LiteralPath $shimScriptPath -Value $shimScript -Encoding UTF8
+}
+
+function script:Invoke-PreflightEntryScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Ready', 'MissingRoles')]
+        [string]$Scenario
+    )
+
+    $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+    $null = New-Item -ItemType Directory -Path $testRoot -Force
+
+    $contractPath = script:New-PreflightEntryContract -RootPath $testRoot
+    script:New-PreflightAzShim -RootPath $testRoot
+
+    $previousPath = $env:PATH
+    $previousScenario = [Environment]::GetEnvironmentVariable(
+        'TEST_INSURANCE_PREFLIGHT_SCENARIO',
+        'Process'
+    )
+
+    try {
+        $env:PATH = "$testRoot;$previousPath"
+        $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $Scenario
+
+        $output = & $script:childPowerShellPath `
+            -NoLogo `
+            -NoProfile `
+            -NonInteractive `
+            -File $script:preflightPath `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -ContractPath $contractPath 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $env:PATH = $previousPath
+        if ($null -eq $previousScenario) {
+            Remove-Item Env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $previousScenario
+        }
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+    }
+}
 }
 
 Describe 'Get-InsuranceAuthoringPhaseState' {
@@ -267,6 +456,44 @@ Describe 'Invoke-InsuranceAuthoringPreflight' {
             'CRM Showcase Insurance Reader',
             'CRM Showcase Insurance Data Steward'
         )
+    }
+
+    It 'keeps State ready but reconciles when only LCID 1033 is provisioned' {
+        $script:provisionedLanguages = @(1033)
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
+        $result.LanguagesReady | Should -BeFalse
+        $result.LanguageAction | Should -Be 'Reconcile'
+        $result.MutationOccurred | Should -BeFalse
+    }
+}
+
+Describe 'Preflight direct entry point' {
+    It 'emits ready JSON and exits zero when preflight is ready' {
+        $invocation = script:Invoke-PreflightEntryScript -Scenario Ready
+
+        $invocation.ExitCode | Should -Be 0
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } | Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'Ready'
+        $result.MutationOccurred | Should -BeFalse
+    }
+
+    It 'emits classified non-ready JSON and exits two when root roles are missing' {
+        $invocation = script:Invoke-PreflightEntryScript -Scenario MissingRoles
+
+        $invocation.ExitCode | Should -Be 2
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } | Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'ManualPrerequisite'
+        $result.RolesReady | Should -BeFalse
+        @($result.MissingRoles) | Should -Be @('CRM Showcase Insurance Data Steward')
     }
 }
 

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -1,0 +1,270 @@
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:contractPath = Join-Path $script:repoRoot 'solution/schema/insurance-foundation.json'
+    $script:preflightPath = Join-Path $script:repoRoot 'scripts/solution/Test-InsuranceAuthoringPreflight.ps1'
+    . $script:preflightPath -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath $script:contractPath
+    $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+}
+
+Describe 'Get-InsuranceAuthoringPhaseState' {
+    It 'returns UnsupportedInTenant when schema capability is not proven' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $false `
+            -SchemaFeasible $false `
+            -RolesReady $false |
+            Should -Be 'UnsupportedInTenant'
+    }
+
+    It 'returns Precondition when required solutions are absent' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $false `
+            -SchemaFeasible $true `
+            -RolesReady $true |
+            Should -Be 'Precondition'
+    }
+
+    It 'returns ManualPrerequisite when a reviewed custom role is absent' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $true `
+            -SchemaFeasible $true `
+            -RolesReady $false |
+            Should -Be 'ManualPrerequisite'
+    }
+
+    It 'returns Ready when schema, solutions and roles are ready' {
+        Get-InsuranceAuthoringPhaseState `
+            -SolutionsReady $true `
+            -SchemaFeasible $true `
+            -RolesReady $true |
+            Should -Be 'Ready'
+    }
+}
+
+Describe 'Get-LanguagePreflightAction' {
+    It 'returns Reconcile when a required language is missing' {
+        Get-LanguagePreflightAction `
+            -Required @(1033, 1031, 1036, 1040) `
+            -Provisioned @(1033, 1031, 1036) |
+            Should -Be 'Reconcile'
+    }
+
+    It 'returns None when all required languages are provisioned' {
+        Get-LanguagePreflightAction `
+            -Required @('1033', '1031', '1036', '1040') `
+            -Provisioned @(1040, 1036, 1031, 1033) |
+            Should -Be 'None'
+    }
+}
+
+Describe 'Test-DemoSchemaAuthoringCapability' {
+    It 'accepts System Customizer' {
+        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @('Basic User', 'System Customizer') |
+            Should -BeTrue
+    }
+
+    It 'accepts System Administrator' {
+        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @('System Administrator') |
+            Should -BeTrue
+    }
+
+    It 'rejects unproven roles such as Basic User' {
+        Test-DemoSchemaAuthoringCapability -AssignedRoleNames @('Basic User') |
+            Should -BeFalse
+    }
+}
+
+Describe 'Invoke-PreflightDataverseRequest' {
+    AfterEach {
+        Remove-Item Function:\az -ErrorAction SilentlyContinue
+    }
+
+    It 'rejects non-GET methods' {
+        {
+            Invoke-PreflightDataverseRequest `
+                -Method POST `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -Path '/WhoAmI'
+        } | Should -Throw
+    }
+
+    It 'uses az rest GET against Dataverse v9.2 and parses JSON' {
+        $script:azArguments = @()
+        function global:az {
+            $script:azArguments = @($args)
+            $global:LASTEXITCODE = 0
+            '{"UserId":"11111111-1111-1111-1111-111111111111"}'
+        }
+
+        $result = Invoke-PreflightDataverseRequest `
+            -Method GET `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Path '/WhoAmI'
+
+        $result.UserId | Should -Be '11111111-1111-1111-1111-111111111111'
+        $script:azArguments | Should -Be @(
+            'rest',
+            '--method', 'get',
+            '--url', 'https://unit.crm.dynamics.com/api/data/v9.2/WhoAmI',
+            '--resource', 'https://unit.crm.dynamics.com/',
+            '--only-show-errors'
+        )
+    }
+
+    It 'throws a transport error with the GET path and az output on nonzero exit' {
+        function global:az {
+            $global:LASTEXITCODE = 9
+            'Permission denied'
+        }
+
+        {
+            Invoke-PreflightDataverseRequest `
+                -Method GET `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -Path '/WhoAmI'
+        } | Should -Throw '*GET /WhoAmI*Permission denied*'
+    }
+}
+
+Describe 'Invoke-InsuranceAuthoringPreflight' {
+    BeforeEach {
+        $script:calls = [System.Collections.Generic.List[object]]::new()
+        $script:userId = '11111111-1111-1111-1111-111111111111'
+        $script:assignedRoleNames = @('System Customizer')
+        $script:provisionedLanguages = @(1033, 1031, 1036, 1040)
+        $script:availableSolutions = @('crmshow_Foundation', 'crmshow_DataModel')
+        $script:availableRoles = @(
+            'CRM Showcase Insurance Reader',
+            'CRM Showcase Insurance Data Steward'
+        )
+
+        Mock Invoke-PreflightDataverseRequest {
+            param($EnvironmentUrl, $Method, $Path)
+
+            [void]$script:calls.Add([pscustomobject]@{
+                    EnvironmentUrl = $EnvironmentUrl
+                    Method         = $Method
+                    Path           = $Path
+                })
+
+            switch ($Path) {
+                '/WhoAmI' {
+                    return [pscustomobject]@{ UserId = $script:userId }
+                }
+                "/systemusers($($script:userId))/systemuserroles_association?`$select=name" {
+                    return [pscustomobject]@{
+                        value = @($script:assignedRoleNames | ForEach-Object {
+                                [pscustomobject]@{ name = $_ }
+                            })
+                    }
+                }
+                '/RetrieveProvisionedLanguages()' {
+                    return [pscustomobject]@{
+                        RetrieveProvisionedLanguages = @($script:provisionedLanguages)
+                    }
+                }
+                "/solutions?`$select=uniquename&`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'" {
+                    return [pscustomobject]@{
+                        value = @($script:availableSolutions | ForEach-Object {
+                                [pscustomobject]@{ uniquename = $_ }
+                            })
+                    }
+                }
+                "/roles?`$select=roleid,name&`$filter=name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward'" {
+                    $index = 0
+                    return [pscustomobject]@{
+                        value = @($script:availableRoles | ForEach-Object {
+                                $index++
+                                [pscustomobject]@{
+                                    roleid = '00000000-0000-0000-0000-{0:D12}' -f $index
+                                    name   = $_
+                                }
+                            })
+                    }
+                }
+                default {
+                    throw "Unexpected mocked preflight path: $Path"
+                }
+            }
+        }
+    }
+
+    It 'returns a ready result with GET-only transport and no mutation' {
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
+        $result.UserId | Should -Be $script:userId
+        $result.SolutionsReady | Should -BeTrue
+        $result.LanguagesReady | Should -BeTrue
+        $result.LanguageAction | Should -Be 'None'
+        $result.RolesReady | Should -BeTrue
+        @($result.AssignedRoleNames) | Should -Be @('System Customizer')
+        @($result.MissingRoles) | Should -Be @()
+        $result.MutationOccurred | Should -BeFalse
+
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 5 -Exactly `
+            -ParameterFilter { $Method -eq 'GET' }
+        Should -Invoke Invoke-PreflightDataverseRequest -Times 0 -Exactly `
+            -ParameterFilter { $Method -ne 'GET' }
+        @($script:calls.Path) | Should -Be @(
+            '/WhoAmI',
+            "/systemusers(11111111-1111-1111-1111-111111111111)/systemuserroles_association?`$select=name",
+            '/RetrieveProvisionedLanguages()',
+            "/solutions?`$select=uniquename&`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_DataModel'",
+            "/roles?`$select=roleid,name&`$filter=name eq 'CRM Showcase Insurance Reader' or name eq 'CRM Showcase Insurance Data Steward'"
+        )
+    }
+
+    It 'classifies a missing solution as Precondition' {
+        $script:availableSolutions = @('crmshow_Foundation')
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Precondition'
+        $result.SolutionsReady | Should -BeFalse
+    }
+
+    It 'classifies a missing reviewed role as ManualPrerequisite and reports MissingRoles' {
+        $script:availableRoles = @('CRM Showcase Insurance Reader')
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ManualPrerequisite'
+        $result.RolesReady | Should -BeFalse
+        @($result.MissingRoles) | Should -Be @('CRM Showcase Insurance Data Steward')
+    }
+
+    It 'classifies Basic User as UnsupportedInTenant even when reviewed roles are absent' {
+        $script:assignedRoleNames = @('Basic User')
+        $script:availableRoles = @()
+
+        $result = Invoke-InsuranceAuthoringPreflight `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'UnsupportedInTenant'
+        $result.RolesReady | Should -BeFalse
+        @($result.MissingRoles) | Should -Be @(
+            'CRM Showcase Insurance Reader',
+            'CRM Showcase Insurance Data Steward'
+        )
+    }
+}
+
+Describe 'Preflight entry point safety' {
+    It 'does not invoke az when dot-sourced with unit arguments' {
+        $text = @'
+function az { throw 'az was called' }
+. '__SCRIPT__' -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath '__CONTRACT__'
+'@.Replace('__SCRIPT__', $script:preflightPath.Replace("'", "''")).
+            Replace('__CONTRACT__', $script:contractPath.Replace("'", "''"))
+
+        & ([scriptblock]::Create($text))
+    }
+}

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -738,9 +738,10 @@ Describe 'Invoke-PreflightDataverseRequest' {
                 "Dataverse preflight transport failed (GET /WhoAmI); az rest exited with code 9."
             )
         )
+        $message | Should -Match 'Output:'
         $message | Should -Match (
             [regex]::Escape(
-                "Output: '::warning::preflight transport Permission denied blocked"
+                '::warning::preflight transport Permission denied blocked'
             )
         )
         $message | Should -Not -Match 'At line:|--method|--url|--resource'
@@ -1215,9 +1216,10 @@ Describe 'Preflight direct entry point' {
         script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 500
         $invocation.Output | Should -Match 'Dataverse preflight transport failed'
         $invocation.Output | Should -Match '/solutions\?\$select=solutionid,uniquename'
+        $invocation.Output | Should -Match 'Output:'
         $invocation.Output | Should -Match (
             [regex]::Escape(
-                "'::warning::preflight transport Permission denied blocked"
+                '::warning::preflight transport Permission denied blocked'
             )
         )
         $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -12,6 +12,20 @@ BeforeAll {
     $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
         ConvertFrom-Json
 
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+
 function script:New-PreflightEntryContract {
     [CmdletBinding()]
     param(
@@ -89,6 +103,15 @@ else {
     $path = $url
 }
 
+$escape = [char]27
+if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -eq 'TransportFailure') {
+    Write-Error (
+        "::warning::preflight transport`r`nPermission denied`t" +
+        "$escape[31mblocked$escape[0m"
+    ) -ErrorAction Continue
+    exit 9
+}
+
 $roles = @(
     [pscustomobject]@{
         roleid = '00000000-0000-0000-0000-000000000001'
@@ -163,7 +186,7 @@ function script:Invoke-PreflightEntryScript {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('Ready', 'MissingRoles')]
+        [ValidateSet('Ready', 'MissingRoles', 'TransportFailure')]
         [string]$Scenario
     )
 
@@ -189,14 +212,21 @@ function script:Invoke-PreflightEntryScript {
         }
         $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $Scenario
 
-        $output = & $script:childPowerShellPath `
-            -NoLogo `
-            -NoProfile `
-            -NonInteractive `
-            -File $script:preflightPath `
-            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-            -ContractPath $contractPath 2>&1
-        $exitCode = $LASTEXITCODE
+        $previousErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        try {
+            $output = & $script:childPowerShellPath `
+                -NoLogo `
+                -NoProfile `
+                -NonInteractive `
+                -File $script:preflightPath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -ContractPath $contractPath 2>&1
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
     }
     finally {
         $env:PATH = $previousPath
@@ -376,18 +406,40 @@ Describe 'Invoke-PreflightDataverseRequest' {
         )
     }
 
-    It 'throws a transport error with the GET path and az output on nonzero exit' {
+    It 'sanitizes hostile az output on nonzero exit' {
+        $escape = [char]27
         function global:az {
+            Write-Error (
+                "::warning::preflight transport`r`nPermission denied`t" +
+                "$escape[31mblocked$escape[0m"
+            ) -ErrorAction Continue
             $global:LASTEXITCODE = 9
-            'Permission denied'
         }
 
-        {
+        $message = $null
+        try {
             Invoke-PreflightDataverseRequest `
                 -Method GET `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -Path '/WhoAmI'
-        } | Should -Throw '*GET /WhoAmI*Permission denied*'
+            throw 'Expected transport failure.'
+        }
+        catch {
+            $message = $_.Exception.Message
+        }
+
+        script:Assert-SafeDiagnosticLine -Text $message -MaxLength 400
+        $message | Should -Match (
+            [regex]::Escape(
+                "Dataverse preflight transport failed (GET /WhoAmI); az rest exited with code 9."
+            )
+        )
+        $message | Should -Match (
+            [regex]::Escape(
+                "Output: '::warning::preflight transport Permission denied blocked"
+            )
+        )
+        $message | Should -Not -Match 'At line:|--method|--url|--resource'
     }
 }
 
@@ -570,6 +622,21 @@ Describe 'Preflight direct entry point' {
         $result.State | Should -Be 'ManualPrerequisite'
         $result.RolesReady | Should -BeFalse
         @($result.MissingRoles) | Should -Be @('CRM Showcase Insurance Data Steward')
+    }
+
+    It 'emits a single safe error line and exits one on hostile az transport failure' {
+        $invocation = script:Invoke-PreflightEntryScript -Scenario TransportFailure
+
+        $invocation.ExitCode | Should -Be 1
+        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
+        $invocation.Output | Should -Match 'Dataverse preflight transport failed'
+        $invocation.Output | Should -Match ([regex]::Escape('/WhoAmI'))
+        $invocation.Output | Should -Match (
+            [regex]::Escape(
+                "'::warning::preflight transport Permission denied blocked"
+            )
+        )
+        $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'
     }
 }
 

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -40,8 +40,10 @@ function script:New-PreflightAzShim {
         [string]$RootPath
     )
     $shimScriptPath = Join-Path $RootPath 'az.ps1'
+    $shimCommandPath = Join-Path $RootPath 'az'
 
     $shimScript = @'
+#!/usr/bin/env pwsh
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]]$Arguments
@@ -143,7 +145,18 @@ switch ($path) {
 }
 '@
 
-    Set-Content -LiteralPath $shimScriptPath -Value $shimScript -Encoding UTF8
+    $shimScript = $shimScript -replace "`r`n", "`n"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+    [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
+    [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
+
+    if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
+        & chmod +x -- $shimCommandPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to make az shim executable: $shimCommandPath"
+        }
+    }
 }
 
 function script:Invoke-PreflightEntryScript {
@@ -167,7 +180,13 @@ function script:Invoke-PreflightEntryScript {
     )
 
     try {
-        $env:PATH = "$testRoot;$previousPath"
+        $pathSeparator = [System.IO.Path]::PathSeparator
+        $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
+            $testRoot
+        }
+        else {
+            "$testRoot$pathSeparator$previousPath"
+        }
         $env:TEST_INSURANCE_PREFLIGHT_SCENARIO = $Scenario
 
         $output = & $script:childPowerShellPath `
@@ -194,6 +213,63 @@ function script:Invoke-PreflightEntryScript {
         Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
     }
 }
+}
+
+Describe 'New-PreflightAzShim' {
+    It 'creates a shim that resolves ahead of any real Azure CLI on Windows and Ubuntu pwsh' {
+        $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+        $null = New-Item -ItemType Directory -Path $testRoot -Force
+
+        script:New-PreflightAzShim -RootPath $testRoot
+
+        $powershellShimPath = Join-Path $testRoot 'az.ps1'
+        $unixShimPath = Join-Path $testRoot 'az'
+        $unixShimBytes = [System.IO.File]::ReadAllBytes($unixShimPath)
+        $unixShimText = [System.Text.Encoding]::UTF8.GetString($unixShimBytes)
+
+        Test-Path -LiteralPath $powershellShimPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $unixShimPath -PathType Leaf | Should -BeTrue
+        $unixShimText.StartsWith("#!/usr/bin/env pwsh`n") | Should -BeTrue
+        $unixShimText.Contains("`r") | Should -BeFalse
+        if ($unixShimBytes.Length -ge 3) {
+            ($unixShimBytes[0] -eq 0xEF -and
+                $unixShimBytes[1] -eq 0xBB -and
+                $unixShimBytes[2] -eq 0xBF) | Should -BeFalse
+        }
+
+        $previousPath = $env:PATH
+        try {
+            $pathSeparator = [System.IO.Path]::PathSeparator
+            $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
+                $testRoot
+            }
+            else {
+                "$testRoot$pathSeparator$previousPath"
+            }
+
+            $resolved = & $script:childPowerShellPath `
+                -NoLogo `
+                -NoProfile `
+                -NonInteractive `
+                -Command @'
+$command = Get-Command az -ErrorAction Stop
+if ([string]::IsNullOrWhiteSpace($command.Source)) {
+    $command.Definition
+}
+else {
+    $command.Source
+}
+'@
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            $env:PATH = $previousPath
+        }
+
+        $exitCode | Should -Be 0
+        $resolvedPath = ($resolved | Out-String).Trim()
+        Split-Path -Path $resolvedPath -Parent | Should -Be $testRoot
+    }
 }
 
 Describe 'Get-InsuranceAuthoringPhaseState' {

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -18,6 +18,20 @@ BeforeAll {
     $script:manifest = Get-Manifest -Path $script:manifestPath -Validate
     $script:languages = @('1033', '1031', '1036', '1040')
 
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+
     function script:Clone-Object {
         [CmdletBinding()]
         param(
@@ -1071,7 +1085,11 @@ else {
 }
 
 if ($env:TEST_INSURANCE_CONVERGENCE_SCENARIO -eq 'TransportFailure') {
-    Write-Error 'Synthetic az transport failure.'
+    $escape = [char]27
+    Write-Error (
+        "::warning::convergence transport`r`nSynthetic az transport failure.`t" +
+        "$escape[31mblocked$escape[0m"
+    ) -ErrorAction Continue
     exit 1
 }
 
@@ -2736,7 +2754,15 @@ Describe 'Convergence direct entry point' {
         $invocation = script:Invoke-ConvergenceEntryScript -Scenario TransportFailure
 
         $invocation.ExitCode | Should -Be 1
-        $invocation.Output | Should -Match 'Synthetic az transport failure|Dataverse convergence transport failed'
+        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
+        $invocation.Output | Should -Match 'Dataverse convergence transport failed'
+        $invocation.Output | Should -Match '/RetrieveProvisionedLanguages\(\)'
+        $invocation.Output | Should -Match (
+            [regex]::Escape(
+                "'::warning::convergence transport Synthetic az transport failure. blocked"
+            )
+        )
+        $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'
         { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
             Should -Throw
     }

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -506,15 +506,20 @@ BeforeAll {
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [string]$SolutionUniqueName
+            [string[]]$SolutionUniqueName
         )
 
         return [pscustomobject]@{
-            value = @([pscustomobject]@{
-                    solutionid = [pscustomobject]@{
-                        uniquename = $SolutionUniqueName
+            value = @(
+                @(Get-UniqueConvergenceStrings -Value $SolutionUniqueName) |
+                    ForEach-Object {
+                        [pscustomobject]@{
+                            solutionid = [pscustomobject]@{
+                                uniquename = [string]$_
+                            }
+                        }
                     }
-                })
+            )
         }
     }
 
@@ -2321,6 +2326,94 @@ Describe 'Unexpected metadata reverse inventory' {
         $result.State | Should -Be 'ContractConflict'
         @($result.Unexpected) | Should -Contain 'crmshow_DataModel/view/crmshow_policyprojection/Active Policy Projections'
         @($result.Unexpected) | Should -Contain 'crmshow_DataModel/form/crmshow_policyprojection/Information'
+    }
+
+    It 'accepts a declared CRM Showcase Insurance Reader root role when reviewed membership matches exactly' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $readerRoleId = [string]$fixture.IdMap['role:CRM Showcase Insurance Reader']
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $readerRoleId)] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_Foundation'
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Ready'
+        @($result.Unexpected) | Should -Be @()
+        @($result.Details | Where-Object {
+                $_ -match 'CRM Showcase Insurance Reader'
+            }) | Should -Be @()
+    }
+
+    It 'ignores declared CRM Showcase Insurance Reader memberships outside reviewed solutions' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $readerRoleId = [string]$fixture.IdMap['role:CRM Showcase Insurance Reader']
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $readerRoleId)] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName @(
+                'crmshow_Foundation',
+                'crmshow_Unreviewed'
+            )
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Ready'
+        @($result.Unexpected) | Should -Be @()
+    }
+
+    It 'classifies a declared CRM Showcase Insurance Reader root role in Foundation and DataModel as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $readerRoleId = [string]$fixture.IdMap['role:CRM Showcase Insurance Reader']
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $readerRoleId)] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName @(
+                'crmshow_Foundation',
+                'crmshow_DataModel'
+            )
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/role/CRM Showcase Insurance Reader'
+        @($result.Details) -join ' ' | Should -Match 'unexpected reviewed solution membership ''crmshow_DataModel'''
+    }
+
+    It 'classifies a declared CRM Showcase Insurance Reader root role only in DataModel as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $readerRoleId = [string]$fixture.IdMap['role:CRM Showcase Insurance Reader']
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $readerRoleId)] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_DataModel'
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/role/CRM Showcase Insurance Reader'
+        @($result.Details) -join ' ' | Should -Match 'missing reviewed solution membership ''crmshow_Foundation'''
+        @($result.Details) -join ' ' | Should -Match 'actual reviewed solution membership: crmshow_DataModel'
     }
 
     It 'classifies an additional CRM Showcase Insurance Foundation root role as ContractConflict' {

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -3,7 +3,12 @@ BeforeAll {
     $script:contractPath = Join-Path $script:repoRoot 'solution/schema/insurance-foundation.json'
     $script:manifestPath = Join-Path $script:repoRoot 'solution/manifest.json'
     $script:convergencePath = Join-Path $script:repoRoot 'scripts/solution/Test-InsuranceFoundationConvergence.ps1'
-    $script:childPowerShellPath = (Get-Command powershell -ErrorAction Stop).Source
+    $script:childPowerShellPath = if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+        (Get-Command pwsh -ErrorAction Stop).Source
+    }
+    else {
+        (Get-Command powershell -ErrorAction Stop).Source
+    }
     . (Join-Path $script:repoRoot 'scripts/solution/Get-Manifest.ps1')
     . $script:convergencePath `
         -EnvironmentUrl 'https://unit.crm.dynamics.com' `
@@ -348,6 +353,47 @@ BeforeAll {
         }
     }
 
+    function script:New-LocalizedRecordResponse {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Text
+        )
+
+        return [pscustomobject]@{
+            Label = [pscustomobject](ConvertTo-LocalizedLabel $Text)
+        }
+    }
+
+    function script:Add-LocalizedFieldResponses {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [hashtable]$Responses,
+
+            [Parameter(Mandatory)]
+            [string]$EntityLogicalName,
+
+            [Parameter(Mandatory)]
+            [string]$IdProperty,
+
+            [Parameter(Mandatory)]
+            [string]$RecordId,
+
+            [Parameter(Mandatory)]
+            $LocalizedFields
+        )
+
+        foreach ($field in @($LocalizedFields.Keys | Sort-Object)) {
+            $Responses[(Get-ConvergenceRetrieveLocLabelsPath `
+                    -EntityLogicalName $EntityLogicalName `
+                    -IdProperty $IdProperty `
+                    -RecordId $RecordId `
+                    -AttributeName ([string]$field))] =
+                script:New-LocalizedRecordResponse -Text $LocalizedFields[$field]
+        }
+    }
+
     function script:Get-SchemaMap {
         [CmdletBinding()]
         param(
@@ -594,6 +640,12 @@ BeforeAll {
                 }
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+                script:Add-LocalizedFieldResponses `
+                    -Responses $responses `
+                    -EntityLogicalName 'savedquery' `
+                    -IdProperty 'savedqueryid' `
+                    -RecordId $savedQuery.savedqueryid `
+                    -LocalizedFields $ruleRequest.LocalizedFields
             }
 
             foreach ($view in @($table.views)) {
@@ -613,6 +665,12 @@ BeforeAll {
                 }
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+                script:Add-LocalizedFieldResponses `
+                    -Responses $responses `
+                    -EntityLogicalName 'savedquery' `
+                    -IdProperty 'savedqueryid' `
+                    -RecordId $savedQuery.savedqueryid `
+                    -LocalizedFields $viewRequest.LocalizedFields
             }
 
             foreach ($form in @($table.forms)) {
@@ -629,6 +687,12 @@ BeforeAll {
                 }
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+                script:Add-LocalizedFieldResponses `
+                    -Responses $responses `
+                    -EntityLogicalName 'systemform' `
+                    -IdProperty 'formid' `
+                    -RecordId $systemForm.formid `
+                    -LocalizedFields $formRequest.LocalizedFields
             }
         }
 
@@ -777,6 +841,11 @@ else {
     $path = $url
 }
 
+if ($env:TEST_INSURANCE_CONVERGENCE_SCENARIO -eq 'TransportFailure') {
+    Write-Error 'Synthetic az transport failure.'
+    exit 1
+}
+
 $map = Get-Content -LiteralPath '__MAP__' -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
 $property = $map.PSObject.Properties[$path]
 if ($null -eq $property) {
@@ -792,20 +861,33 @@ Write-Json $property.Value
 
         [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
         [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
+
+        if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
+            & chmod +x -- $shimCommandPath
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to make az shim executable: $shimCommandPath"
+            }
+        }
     }
 
     function script:Invoke-ConvergenceEntryScript {
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict')]
+            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict', 'TransportFailure')]
             [string]$Scenario
         )
 
+        $fixtureScenario = if ($Scenario -eq 'TransportFailure') {
+            'Ready'
+        }
+        else {
+            $Scenario
+        }
         $fixture = script:New-ReadyConvergenceResponseMap `
             -Contract $script:contract `
             -Manifest $script:manifest `
-            -Scenario $Scenario
+            -Scenario $fixtureScenario
 
         $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
         $null = New-Item -ItemType Directory -Path $testRoot -Force
@@ -819,6 +901,10 @@ Write-Json $property.Value
             -ResponseMapPath $responseMapPath
 
         $previousPath = $env:PATH
+        $previousScenario = [Environment]::GetEnvironmentVariable(
+            'TEST_INSURANCE_CONVERGENCE_SCENARIO',
+            'Process'
+        )
         try {
             $pathSeparator = [System.IO.Path]::PathSeparator
             $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
@@ -827,18 +913,49 @@ Write-Json $property.Value
             else {
                 "$testRoot$pathSeparator$previousPath"
             }
+            $env:TEST_INSURANCE_CONVERGENCE_SCENARIO = $Scenario
 
-            $output = & $script:childPowerShellPath `
-                -NoLogo `
-                -NoProfile `
-                -NonInteractive `
-                -File $script:convergencePath `
-                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-                -ContractPath $script:contractPath 2>&1
-            $exitCode = $LASTEXITCODE
+            $stdoutPath = Join-Path $testRoot 'stdout.txt'
+            $stderrPath = Join-Path $testRoot 'stderr.txt'
+            $process = Start-Process `
+                -FilePath $script:childPowerShellPath `
+                -ArgumentList @(
+                    '-NoLogo',
+                    '-NoProfile',
+                    '-NonInteractive',
+                    '-File', $script:convergencePath,
+                    '-EnvironmentUrl', 'https://unit.crm.dynamics.com',
+                    '-ContractPath', $script:contractPath
+                ) `
+                -Wait `
+                -PassThru `
+                -RedirectStandardOutput $stdoutPath `
+                -RedirectStandardError $stderrPath
+            $stdout = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) {
+                Get-Content -LiteralPath $stdoutPath -Raw -Encoding UTF8
+            }
+            else {
+                ''
+            }
+            $stderr = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) {
+                Get-Content -LiteralPath $stderrPath -Raw -Encoding UTF8
+            }
+            else {
+                ''
+            }
+            $output = @($stdout, $stderr) | Where-Object {
+                -not [string]::IsNullOrWhiteSpace([string]$_)
+            }
+            $exitCode = $process.ExitCode
         }
         finally {
             $env:PATH = $previousPath
+            if ($null -eq $previousScenario) {
+                Remove-Item Env:TEST_INSURANCE_CONVERGENCE_SCENARIO -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_INSURANCE_CONVERGENCE_SCENARIO = $previousScenario
+            }
         }
 
         return [pscustomobject]@{
@@ -918,6 +1035,23 @@ Describe 'Convergence path builders' {
                 '/systemforms?' +
                 "`$select=formid,name,description,objecttypecode,type,formxml&" +
                 "`$filter=name eq 'O''Reilly Form' and objecttypecode eq 'crmshow_o''reilly' and type eq 2"
+            )
+
+        $expectedEntityMoniker = [System.Uri]::EscapeDataString(
+            ([ordered]@{
+                    '@odata.type' = 'Microsoft.Dynamics.CRM.savedquery'
+                    savedqueryid  = '11111111-1111-1111-1111-111111111111'
+                } | ConvertTo-Json -Compress)
+        )
+        Get-ConvergenceRetrieveLocLabelsPath `
+            -EntityLogicalName 'savedquery' `
+            -IdProperty 'savedqueryid' `
+            -RecordId '11111111-1111-1111-1111-111111111111' `
+            -AttributeName "na'me" | Should -Be (
+                '/RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?' +
+                "@p1=$expectedEntityMoniker&" +
+                "@p2='na''me'&" +
+                '@p3=true'
             )
     }
 }
@@ -1077,7 +1211,7 @@ Describe 'Component-level convergence checks' {
             }).Count | Should -Be 1
     }
 
-    It 'accepts server-normalized view XML with a savedqueryid attribute' {
+    It 'accepts server-normalized view XML with exact four-language localized labels' {
         $table = script:Clone-Object -InputObject $script:contract.tables[0]
         $view = $table.views[0]
         $request = New-ViewRequest -Table $table -View $view -ObjectTypeCode 10427
@@ -1091,7 +1225,7 @@ Describe 'Component-level convergence checks' {
             -SavedQueryId (script:New-FakeGuid -Index 6)
         $savedQuery.fetchxml = $storedFetchXml
 
-        script:Register-ConvergenceTransportMock -Responses @{
+        $responses = @{
             (Get-ConvergenceSavedQueryPath `
                 -TableLogicalName $table.logicalName `
                 -Label ([string]$view.metadata.label.'1033')) = [pscustomobject]@{
@@ -1100,6 +1234,13 @@ Describe 'Component-level convergence checks' {
             (Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid) =
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
         }
+        script:Add-LocalizedFieldResponses `
+            -Responses $responses `
+            -EntityLogicalName 'savedquery' `
+            -IdProperty 'savedqueryid' `
+            -RecordId $savedQuery.savedqueryid `
+            -LocalizedFields $request.LocalizedFields
+        script:Register-ConvergenceTransportMock -Responses $responses
 
         $result = Test-InsuranceFoundationView `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
@@ -1108,9 +1249,69 @@ Describe 'Component-level convergence checks' {
             -ObjectTypeCode 10427
 
         $result.State | Should -Be 'Ready'
+        Should -Invoke Invoke-ConvergenceDataverseRequest -Times 2 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Path -like '/RetrieveLocLabels*'
+        }
     }
 
-    It 'accepts platform-normalized form ids and localized field labels' {
+    It 'classifies a view localized-field conflict when translations are missing or wrong' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $view = $table.views[0]
+        $request = New-ViewRequest -Table $table -View $view -ObjectTypeCode 10427
+        $savedQuery = script:New-SavedQuerySnapshot `
+            -Request $request `
+            -Table $table `
+            -SavedQueryId (script:New-FakeGuid -Index 16)
+
+        $nameResponse = script:New-LocalizedRecordResponse -Text $request.LocalizedFields.name
+        $nameResponse.Label.LocalizedLabels = @($nameResponse.Label.LocalizedLabels | Where-Object {
+                [int]$_.LanguageCode -ne 1040
+            })
+        $descriptionResponse = script:New-LocalizedRecordResponse -Text $request.LocalizedFields.description
+        @($descriptionResponse.Label.LocalizedLabels | Where-Object {
+                [int]$_.LanguageCode -eq 1031
+            })[0].Label = 'Wrong localized description'
+
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceSavedQueryPath `
+                -TableLogicalName $table.logicalName `
+                -Label ([string]$view.metadata.label.'1033')) = [pscustomobject]@{
+                value = @($savedQuery)
+            }
+            (Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid) =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+            (Get-ConvergenceRetrieveLocLabelsPath `
+                -EntityLogicalName 'savedquery' `
+                -IdProperty 'savedqueryid' `
+                -RecordId $savedQuery.savedqueryid `
+                -AttributeName 'name') = $nameResponse
+            (Get-ConvergenceRetrieveLocLabelsPath `
+                -EntityLogicalName 'savedquery' `
+                -IdProperty 'savedqueryid' `
+                -RecordId $savedQuery.savedqueryid `
+                -AttributeName 'description') = $descriptionResponse
+        }
+
+        $result = Test-InsuranceFoundationView `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Table $table `
+            -View $view `
+            -ObjectTypeCode 10427
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'name' -and
+                $_.Language -eq '1040' -and
+                $null -eq $_.Actual
+            }).Count | Should -Be 1
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'description' -and
+                $_.Language -eq '1031' -and
+                $_.Actual -eq 'Wrong localized description'
+            }).Count | Should -Be 1
+    }
+
+    It 'accepts platform-normalized form ids with exact four-language localized labels' {
         $table = script:Clone-Object -InputObject $script:contract.tables[0]
         $form = $table.forms[0]
         $request = New-FormRequest -Table $table -Form $form
@@ -1131,7 +1332,7 @@ Describe 'Component-level convergence checks' {
                 )
         }
 
-        script:Register-ConvergenceTransportMock -Responses @{
+        $responses = @{
             (Get-ConvergenceSystemFormPath `
                 -TableLogicalName $table.logicalName `
                 -Label ([string]$form.metadata.label.'1033')) = [pscustomobject]@{
@@ -1140,6 +1341,13 @@ Describe 'Component-level convergence checks' {
             (Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid) =
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
         }
+        script:Add-LocalizedFieldResponses `
+            -Responses $responses `
+            -EntityLogicalName 'systemform' `
+            -IdProperty 'formid' `
+            -RecordId $systemForm.formid `
+            -LocalizedFields $request.LocalizedFields
+        script:Register-ConvergenceTransportMock -Responses $responses
 
         $result = Test-InsuranceFoundationForm `
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
@@ -1147,6 +1355,67 @@ Describe 'Component-level convergence checks' {
             -Form $form
 
         $result.State | Should -Be 'Ready'
+        Should -Invoke Invoke-ConvergenceDataverseRequest -Times 2 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Path -like '/RetrieveLocLabels*'
+        }
+    }
+
+    It 'classifies a form localized-field conflict when translations are missing or wrong' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $form = $table.forms[0]
+        $request = New-FormRequest -Table $table -Form $form
+        $systemForm = script:New-FormSnapshot `
+            -Request $request `
+            -Table $table `
+            -FormId (script:New-FakeGuid -Index 17)
+
+        $nameResponse = script:New-LocalizedRecordResponse -Text $request.LocalizedFields.name
+        @($nameResponse.Label.LocalizedLabels | Where-Object {
+                [int]$_.LanguageCode -eq 1036
+            })[0].Label = 'Wrong localized form name'
+        $descriptionResponse = script:New-LocalizedRecordResponse -Text $request.LocalizedFields.description
+        $descriptionResponse.Label.LocalizedLabels = @(
+            $descriptionResponse.Label.LocalizedLabels | Where-Object {
+                [int]$_.LanguageCode -ne 1040
+            }
+        )
+
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceSystemFormPath `
+                -TableLogicalName $table.logicalName `
+                -Label ([string]$form.metadata.label.'1033')) = [pscustomobject]@{
+                value = @($systemForm)
+            }
+            (Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid) =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+            (Get-ConvergenceRetrieveLocLabelsPath `
+                -EntityLogicalName 'systemform' `
+                -IdProperty 'formid' `
+                -RecordId $systemForm.formid `
+                -AttributeName 'name') = $nameResponse
+            (Get-ConvergenceRetrieveLocLabelsPath `
+                -EntityLogicalName 'systemform' `
+                -IdProperty 'formid' `
+                -RecordId $systemForm.formid `
+                -AttributeName 'description') = $descriptionResponse
+        }
+
+        $result = Test-InsuranceFoundationForm `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Table $table `
+            -Form $form
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'name' -and
+                $_.Language -eq '1036' -and
+                $_.Actual -eq 'Wrong localized form name'
+            }).Count | Should -Be 1
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'description' -and
+                $_.Language -eq '1040' -and
+                $null -eq $_.Actual
+            }).Count | Should -Be 1
     }
 
     It 'classifies a role prerequisite through the reused role verifier result' {
@@ -1304,6 +1573,15 @@ Describe 'Convergence direct entry point' {
         @($result.Results | Where-Object {
                 $_.Component -eq 'roles' -and $_.State -eq 'ContractConflict'
             }).Count | Should -Be 1
+    }
+
+    It 'emits error output and exits one when az returns a non-classified transport failure' {
+        $invocation = script:Invoke-ConvergenceEntryScript -Scenario TransportFailure
+
+        $invocation.ExitCode | Should -Be 1
+        $invocation.Output | Should -Match 'Synthetic az transport failure|Dataverse convergence transport failed'
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Throw
     }
 }
 

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -518,6 +518,46 @@ BeforeAll {
         }
     }
 
+    function script:New-SolutionInventoryEntry {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$ObjectId,
+
+            [Parameter(Mandatory)]
+            [int]$ComponentType,
+
+            [string]$SolutionComponentId,
+
+            [string]$RootSolutionComponentId,
+
+            [AllowNull()]
+            [int]$RootComponentBehavior
+        )
+
+        $resolvedObjectId = ([string]$ObjectId).Trim('{}')
+        $resolvedSolutionComponentId = if ([string]::IsNullOrWhiteSpace($SolutionComponentId)) {
+            $resolvedObjectId
+        }
+        else {
+            ([string]$SolutionComponentId).Trim('{}')
+        }
+        $resolvedRootSolutionComponentId = if ([string]::IsNullOrWhiteSpace($RootSolutionComponentId)) {
+            $null
+        }
+        else {
+            ([string]$RootSolutionComponentId).Trim('{}')
+        }
+
+        return [pscustomobject]@{
+            solutioncomponentid          = $resolvedSolutionComponentId
+            objectid                     = $resolvedObjectId
+            componenttype                = [int]$ComponentType
+            rootcomponentbehavior        = $RootComponentBehavior
+            _rootsolutioncomponentid_value = $resolvedRootSolutionComponentId
+        }
+    }
+
     function script:New-EntityInventorySnapshot {
         [CmdletBinding()]
         param(
@@ -662,10 +702,11 @@ BeforeAll {
                 $choiceSnapshot
             $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $choiceSnapshot.MetadataId)] =
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$choice.solution)
-            [void]$solutionInventory[[string]$choice.solution].Add([pscustomobject]@{
-                    objectid      = [string]$choiceSnapshot.MetadataId
-                    componenttype = 9
-                })
+            [void]$solutionInventory[[string]$choice.solution].Add(
+                (script:New-SolutionInventoryEntry `
+                    -ObjectId ([string]$choiceSnapshot.MetadataId) `
+                    -ComponentType 9)
+            )
         }
 
         foreach ($extension in @($Contract.nativeExtensions)) {
@@ -713,10 +754,11 @@ BeforeAll {
                 [pscustomobject]@{ value = @($tableSnapshot) }
             $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $tableSnapshot.MetadataId)] =
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
-            [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
-                    objectid      = [string]$tableSnapshot.MetadataId
-                    componenttype = 1
-                })
+            [void]$solutionInventory[[string]$table.solution].Add(
+                (script:New-SolutionInventoryEntry `
+                    -ObjectId ([string]$tableSnapshot.MetadataId) `
+                    -ComponentType 1)
+            )
 
             $inventoryAttributes = foreach ($column in @($table.columns)) {
                 script:New-AttributeInventorySnapshot `
@@ -779,10 +821,11 @@ BeforeAll {
                     $savedQuery
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
-                [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
-                        objectid      = [string]$savedQuery.savedqueryid
-                        componenttype = 26
-                    })
+                [void]$solutionInventory[[string]$table.solution].Add(
+                    (script:New-SolutionInventoryEntry `
+                        -ObjectId ([string]$savedQuery.savedqueryid) `
+                        -ComponentType 26)
+                )
                 script:Add-LocalizedFieldResponses `
                     -Responses $responses `
                     -EntityLogicalName 'savedquery' `
@@ -810,10 +853,11 @@ BeforeAll {
                     $savedQuery
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
-                [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
-                        objectid      = [string]$savedQuery.savedqueryid
-                        componenttype = 26
-                    })
+                [void]$solutionInventory[[string]$table.solution].Add(
+                    (script:New-SolutionInventoryEntry `
+                        -ObjectId ([string]$savedQuery.savedqueryid) `
+                        -ComponentType 26)
+                )
                 script:Add-LocalizedFieldResponses `
                     -Responses $responses `
                     -EntityLogicalName 'savedquery' `
@@ -838,10 +882,11 @@ BeforeAll {
                     $systemForm
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
-                [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
-                        objectid      = [string]$systemForm.formid
-                        componenttype = 60
-                    })
+                [void]$solutionInventory[[string]$table.solution].Add(
+                    (script:New-SolutionInventoryEntry `
+                        -ObjectId ([string]$systemForm.formid) `
+                        -ComponentType 60)
+                )
                 script:Add-LocalizedFieldResponses `
                     -Responses $responses `
                     -EntityLogicalName 'systemform' `
@@ -1059,11 +1104,11 @@ Write-Json $property.Value
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict', 'TransportFailure', 'RetrieveLocLabelsUnsupported')]
+            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict', 'MissingRoleAndUnexpectedView', 'TransportFailure', 'RetrieveLocLabelsUnsupported')]
             [string]$Scenario
         )
 
-        $fixtureScenario = if ($Scenario -in @('TransportFailure', 'RetrieveLocLabelsUnsupported')) {
+        $fixtureScenario = if ($Scenario -in @('MissingRoleAndUnexpectedView', 'TransportFailure', 'RetrieveLocLabelsUnsupported')) {
             'Ready'
         }
         else {
@@ -1073,6 +1118,39 @@ Write-Json $property.Value
             -Contract $script:contract `
             -Manifest $script:manifest `
             -Scenario $fixtureScenario
+
+        if ($Scenario -eq 'MissingRoleAndUnexpectedView') {
+            $missingRole = @($script:contract.roles | Where-Object {
+                    [string]$_.name -ceq 'CRM Showcase Insurance Data Steward'
+                })[0]
+            $fixture.Responses[(Get-InsuranceSecurityRolePath -RoleName ([string]$missingRole.name))] =
+                [pscustomobject]@{
+                    value = @()
+                }
+
+            $table = @($script:contract.tables | Where-Object {
+                    [string]$_.logicalName -ceq 'crmshow_policyprojection'
+                })[0]
+            $viewId = script:New-FakeGuid -Index 9721
+            $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+                -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+                -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+            $fixture.Responses[$inventoryPath].value = @(
+                $fixture.Responses[$inventoryPath].value +
+                (script:New-SolutionInventoryEntry `
+                    -ObjectId $viewId `
+                    -ComponentType 26)
+            )
+            $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
+                [pscustomobject]@{
+                    savedqueryid     = $viewId
+                    name             = 'Unexpected Policy Projection View'
+                    description      = 'Unexpected custom view.'
+                    returnedtypecode = [string]$table.logicalName
+                    fetchxml         = '<fetch version="1.0"><entity name="crmshow_policyprojection"><attribute name="crmshow_name" /></entity></fetch>'
+                    layoutxml        = '<grid name="resultset" object="10428"><row name="crmshow_policyprojection" id="crmshow_policyprojectionid"><cell name="crmshow_name" width="150" /></row></grid>'
+                }
+        }
 
         $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
         $null = New-Item -ItemType Directory -Path $testRoot -Force
@@ -1160,24 +1238,36 @@ Describe 'New-ConvergenceSummary' {
             Should -Be 'Ready'
     }
 
-    It 'preserves the first blocking classification in result order' {
+    It 'lets ContractConflict dominate later in result order' {
         $summary = New-ConvergenceSummary -Results @(
             [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
             [pscustomobject]@{ Component='tables'; State='ContractConflict' }
         )
 
-        $summary.State | Should -Be 'ManualPrerequisite'
+        $summary.State | Should -Be 'ContractConflict'
         $summary.BlockingComponents | Should -Be @('roles', 'tables')
+    }
+
+    It 'uses deterministic safety precedence when no contract conflict exists' {
+        $summary = New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
+            [pscustomobject]@{ Component='languages'; State='Precondition' },
+            [pscustomobject]@{ Component='tables'; State='UnsupportedInTenant' },
+            [pscustomobject]@{ Component='choices'; State='Ready' }
+        )
+
+        $summary.State | Should -Be 'UnsupportedInTenant'
+        $summary.BlockingComponents | Should -Be @('roles', 'languages', 'tables')
     }
 
     It 'keeps all blocking components and MutationOccurred false' {
         $summary = New-ConvergenceSummary -Results @(
-            [pscustomobject]@{ Component='languages'; State='Precondition' },
             [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
-            [pscustomobject]@{ Component='choices'; State='Ready' }
+            [pscustomobject]@{ Component='languages'; State='Precondition' }
         )
 
-        $summary.BlockingComponents | Should -Be @('languages', 'roles')
+        $summary.State | Should -Be 'Precondition'
+        $summary.BlockingComponents | Should -Be @('roles', 'languages')
         $summary.MutationOccurred | Should -BeFalse
     }
 }
@@ -1288,7 +1378,7 @@ Describe 'Convergence path builders' {
         Get-ConvergenceSolutionInventoryPath `
             -SolutionId '{11111111-1111-1111-1111-111111111111}' `
             -ComponentType @(60, 1, 9, 26, 1) | Should -Be (
-                "/solutioncomponents?`$select=objectid,componenttype&" +
+                "/solutioncomponents?`$select=solutioncomponentid,objectid,componenttype,rootcomponentbehavior,_rootsolutioncomponentid_value&" +
                 "`$filter=_solutionid_value eq 11111111-1111-1111-1111-111111111111 and (componenttype eq 1 or componenttype eq 9 or componenttype eq 26 or componenttype eq 60)"
             )
 
@@ -1809,7 +1899,7 @@ Describe 'Component-level convergence checks' {
 }
 
 Describe 'Table classification propagation' {
-    It 'preserves the first blocking child classification when direct checks are exact' {
+    It 'lets ContractConflict dominate blocking child classifications when direct checks are exact' {
         $fixture = script:New-ReadyConvergenceResponseMap `
             -Contract $script:contract `
             -Manifest $script:manifest `
@@ -1885,7 +1975,7 @@ Describe 'Table classification propagation' {
             -EnvironmentUrl 'https://unit.crm.dynamics.com' `
             -Table $table
 
-        $result.State | Should -Be 'UnsupportedInTenant'
+        $result.State | Should -Be 'ContractConflict'
         @($result.Children | Where-Object {
                 $_.State -ne 'Ready'
             } | ForEach-Object {
@@ -2060,10 +2150,9 @@ Describe 'Unexpected metadata reverse inventory' {
             -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
         $fixture.Responses[$inventoryPath].value = @(
             $fixture.Responses[$inventoryPath].value +
-            [pscustomobject]@{
-                objectid      = $viewId
-                componenttype = 26
-            }
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $viewId `
+                -ComponentType 26)
         )
         $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
             [pscustomobject]@{
@@ -2096,10 +2185,9 @@ Describe 'Unexpected metadata reverse inventory' {
             -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
         $fixture.Responses[$inventoryPath].value = @(
             $fixture.Responses[$inventoryPath].value +
-            [pscustomobject]@{
-                objectid      = $formId
-                componenttype = 60
-            }
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $formId `
+                -ComponentType 60)
         )
         $fixture.Responses[(Get-ConvergenceSystemFormByIdPath -FormId $formId)] =
             [pscustomobject]@{
@@ -2121,7 +2209,121 @@ Describe 'Unexpected metadata reverse inventory' {
         @($result.Unexpected) | Should -Contain 'crmshow_DataModel/form/crmshow_policyprojection/Unexpected Policy Projection Form'
     }
 
-    It 'classifies an additional CRM Showcase Insurance root role as ContractConflict' {
+    It 'ignores transitive generated Information and default-active components included through the table root' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $table = @($script:contract.tables | Where-Object {
+                [string]$_.logicalName -ceq 'crmshow_policyprojection'
+            })[0]
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $tableRootEntry = @($fixture.Responses[$inventoryPath].value | Where-Object {
+                [int]$_.componenttype -eq 1 -and
+                [string]$_.objectid -ceq [string]$fixture.IdMap["table:$($table.logicalName)"]
+            })[0]
+        $tableRootSolutionComponentId = if ($null -eq $tableRootEntry.solutioncomponentid) {
+            [string]$tableRootEntry.objectid
+        }
+        else {
+            [string]$tableRootEntry.solutioncomponentid
+        }
+        $viewId = script:New-FakeGuid -Index 9709
+        $formId = script:New-FakeGuid -Index 9710
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $viewId `
+                -ComponentType 26 `
+                -RootSolutionComponentId $tableRootSolutionComponentId `
+                -RootComponentBehavior 0) +
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $formId `
+                -ComponentType 60 `
+                -RootSolutionComponentId $tableRootSolutionComponentId `
+                -RootComponentBehavior 0)
+        )
+        $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
+            [pscustomobject]@{
+                savedqueryid     = $viewId
+                name             = 'Active Policy Projections'
+                description      = 'Platform-generated default active view.'
+                returnedtypecode = [string]$table.logicalName
+                fetchxml         = '<fetch version="1.0"><entity name="crmshow_policyprojection"><attribute name="crmshow_name" /></entity></fetch>'
+                layoutxml        = '<grid name="resultset" object="10428"><row name="crmshow_policyprojection" id="crmshow_policyprojectionid"><cell name="crmshow_name" width="150" /></row></grid>'
+            }
+        $fixture.Responses[(Get-ConvergenceSystemFormByIdPath -FormId $formId)] =
+            [pscustomobject]@{
+                formid         = $formId
+                name           = 'Information'
+                description    = 'Platform-generated default main form.'
+                objecttypecode = [string]$table.logicalName
+                type           = 2
+                formxml        = '<form><tabs><tab name="general"><columns><column width="100%"><sections><section name="general"><rows><row><cell><control id="crmshow_name" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="crmshow_name" /></cell></row></rows></section></sections></column></columns></tab></tabs></form>'
+            }
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Ready'
+        @($result.Unexpected) | Should -Be @()
+    }
+
+    It 'still flags explicitly owned Information and default-active components' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $viewId = script:New-FakeGuid -Index 9711
+        $formId = script:New-FakeGuid -Index 9712
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $viewId `
+                -ComponentType 26) +
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $formId `
+                -ComponentType 60)
+        )
+        $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
+            [pscustomobject]@{
+                savedqueryid     = $viewId
+                name             = 'Active Policy Projections'
+                description      = 'Explicit extra custom view.'
+                returnedtypecode = 'crmshow_policyprojection'
+                fetchxml         = '<fetch version="1.0"><entity name="crmshow_policyprojection"><attribute name="crmshow_name" /></entity></fetch>'
+                layoutxml        = '<grid name="resultset" object="10428"><row name="crmshow_policyprojection" id="crmshow_policyprojectionid"><cell name="crmshow_name" width="150" /></row></grid>'
+            }
+        $fixture.Responses[(Get-ConvergenceSystemFormByIdPath -FormId $formId)] =
+            [pscustomobject]@{
+                formid         = $formId
+                name           = 'Information'
+                description    = 'Explicit extra custom form.'
+                objecttypecode = 'crmshow_policyprojection'
+                type           = 2
+                formxml        = '<form><tabs><tab name="general"><columns><column width="100%"><sections><section name="general"><rows><row><cell><control id="crmshow_name" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="crmshow_name" /></cell></row></rows></section></sections></column></columns></tab></tabs></form>'
+            }
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/view/crmshow_policyprojection/Active Policy Projections'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/form/crmshow_policyprojection/Information'
+    }
+
+    It 'classifies an additional CRM Showcase Insurance Foundation root role as ContractConflict' {
         $fixture = script:New-ReadyConvergenceResponseMap `
             -Contract $script:contract `
             -Manifest $script:manifest `
@@ -2154,7 +2356,40 @@ Describe 'Unexpected metadata reverse inventory' {
         @($result.Unexpected) | Should -Contain 'crmshow_Foundation/role/CRM Showcase Insurance Escalation'
     }
 
-    It 'ignores system-generated table children and unrelated platform roles or views' {
+    It 'classifies an additional CRM Showcase Insurance DataModel root role as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $roleId = script:New-FakeGuid -Index 9713
+        $rolesPath = Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance '
+        $fixture.Responses[$rolesPath].value = @(
+            $fixture.Responses[$rolesPath].value +
+            [pscustomobject]@{
+                roleid = $roleId
+                name = 'CRM Showcase Insurance DataModel Reviewer'
+                _parentrootroleid_value = $null
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceRoleByIdPath -RoleId $roleId)] = [pscustomobject]@{
+            roleid = $roleId
+            name = 'CRM Showcase Insurance DataModel Reviewer'
+            _parentrootroleid_value = $null
+        }
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $roleId)] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_DataModel'
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/role/CRM Showcase Insurance DataModel Reviewer'
+    }
+
+    It 'ignores system-generated table children and unrelated roles or views outside reviewed solutions' {
         $fixture = script:New-ReadyConvergenceResponseMap `
             -Contract $script:contract `
             -Manifest $script:manifest `
@@ -2187,8 +2422,15 @@ Describe 'Unexpected metadata reverse inventory' {
                 roleid = script:New-FakeGuid -Index 9706
                 name = 'System Administrator'
                 _parentrootroleid_value = $null
+            } +
+            [pscustomobject]@{
+                roleid = script:New-FakeGuid -Index 9714
+                name = 'CRM Showcase Insurance Archive'
+                _parentrootroleid_value = $null
             }
         )
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId (script:New-FakeGuid -Index 9714))] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_Unreviewed'
 
         $viewId = script:New-FakeGuid -Index 9707
         $formId = script:New-FakeGuid -Index 9708
@@ -2197,14 +2439,12 @@ Describe 'Unexpected metadata reverse inventory' {
             -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
         $fixture.Responses[$inventoryPath].value = @(
             $fixture.Responses[$inventoryPath].value +
-            [pscustomobject]@{
-                objectid      = $viewId
-                componenttype = 26
-            } +
-            [pscustomobject]@{
-                objectid      = $formId
-                componenttype = 60
-            }
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $viewId `
+                -ComponentType 26) +
+            (script:New-SolutionInventoryEntry `
+                -ObjectId $formId `
+                -ComponentType 60)
         )
         $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
             [pscustomobject]@{
@@ -2363,6 +2603,24 @@ Describe 'Convergence direct entry point' {
         $result.State | Should -Be 'ContractConflict'
         @($result.Results | Where-Object {
                 $_.Component -eq 'roles' -and $_.State -eq 'ContractConflict'
+            }).Count | Should -Be 1
+    }
+
+    It 'emits contract-conflict JSON and exits three when drift coexists with a manual prerequisite' {
+        $invocation = script:Invoke-ConvergenceEntryScript -Scenario MissingRoleAndUnexpectedView
+
+        $invocation.ExitCode | Should -Be 3
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Results | Where-Object {
+                $_.Component -eq 'roles' -and $_.State -eq 'ManualPrerequisite'
+            }).Count | Should -Be 1
+        @($result.Results | Where-Object {
+                $_.Component -eq 'unexpectedMetadata' -and
+                $_.State -eq 'ContractConflict'
             }).Count | Should -Be 1
     }
 

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -2757,9 +2757,10 @@ Describe 'Convergence direct entry point' {
         script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
         $invocation.Output | Should -Match 'Dataverse convergence transport failed'
         $invocation.Output | Should -Match '/RetrieveProvisionedLanguages\(\)'
+        $invocation.Output | Should -Match 'Output:'
         $invocation.Output | Should -Match (
             [regex]::Escape(
-                "'::warning::convergence transport Synthetic az transport failure. blocked"
+                '::warning::convergence transport Synthetic az transport failure. blocked'
             )
         )
         $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -975,13 +975,14 @@ Describe 'New-ConvergenceSummary' {
             Should -Be 'Ready'
     }
 
-    It 'prefers ContractConflict over ManualPrerequisite regardless of array order' {
+    It 'preserves the first blocking classification in result order' {
         $summary = New-ConvergenceSummary -Results @(
             [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
             [pscustomobject]@{ Component='tables'; State='ContractConflict' }
         )
 
-        $summary.State | Should -Be 'ContractConflict'
+        $summary.State | Should -Be 'ManualPrerequisite'
+        $summary.BlockingComponents | Should -Be @('roles', 'tables')
     }
 
     It 'keeps all blocking components and MutationOccurred false' {
@@ -993,6 +994,34 @@ Describe 'New-ConvergenceSummary' {
 
         $summary.BlockingComponents | Should -Be @('languages', 'roles')
         $summary.MutationOccurred | Should -BeFalse
+    }
+}
+
+Describe 'Test-ConvergenceRetrieveLocLabelsUnsupportedError' {
+    It 'returns true for known endpoint-not-supported semantics' {
+        $errorRecord = $null
+        try {
+            throw "Dataverse convergence transport failed (GET /RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?@p1=x&@p2='name'&@p3=true); az rest exited with code 1. The requested resource does not support HTTP method 'GET'."
+        }
+        catch {
+            $errorRecord = $_
+        }
+
+        Test-ConvergenceRetrieveLocLabelsUnsupportedError -ErrorRecord $errorRecord |
+            Should -BeTrue
+    }
+
+    It 'does not mask ordinary bad requests as UnsupportedInTenant' {
+        $errorRecord = $null
+        try {
+            throw "Dataverse convergence transport failed (GET /RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?@p1=x&@p2='name'&@p3=true); az rest exited with code 1. 400 Bad Request. Request message has unresolved parameters."
+        }
+        catch {
+            $errorRecord = $_
+        }
+
+        Test-ConvergenceRetrieveLocLabelsUnsupportedError -ErrorRecord $errorRecord |
+            Should -BeFalse
     }
 }
 
@@ -1036,12 +1065,11 @@ Describe 'Convergence path builders' {
                 "`$select=formid,name,description,objecttypecode,type,formxml&" +
                 "`$filter=name eq 'O''Reilly Form' and objecttypecode eq 'crmshow_o''reilly' and type eq 2"
             )
+    }
 
+    It 'builds savedquery RetrieveLocLabels paths with @odata.id entity monikers' {
         $expectedEntityMoniker = [System.Uri]::EscapeDataString(
-            ([ordered]@{
-                    '@odata.type' = 'Microsoft.Dynamics.CRM.savedquery'
-                    savedqueryid  = '11111111-1111-1111-1111-111111111111'
-                } | ConvertTo-Json -Compress)
+            '{"@odata.id":"savedqueries(11111111-1111-1111-1111-111111111111)"}'
         )
         Get-ConvergenceRetrieveLocLabelsPath `
             -EntityLogicalName 'savedquery' `
@@ -1053,6 +1081,59 @@ Describe 'Convergence path builders' {
                 "@p2='na''me'&" +
                 '@p3=true'
             )
+    }
+
+    It 'builds systemform RetrieveLocLabels paths with @odata.id entity monikers' {
+        $expectedEntityMoniker = [System.Uri]::EscapeDataString(
+            '{"@odata.id":"systemforms(22222222-2222-2222-2222-222222222222)"}'
+        )
+        Get-ConvergenceRetrieveLocLabelsPath `
+            -EntityLogicalName 'systemform' `
+            -IdProperty 'formid' `
+            -RecordId '{22222222-2222-2222-2222-222222222222}' `
+            -AttributeName 'description' | Should -Be (
+                '/RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?' +
+                "@p1=$expectedEntityMoniker&" +
+                "@p2='description'&" +
+                '@p3=true'
+            )
+    }
+}
+
+Describe 'Convergence fixture paths' {
+    It 'registers savedquery and systemform localized-label paths with @odata.id monikers' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+
+        $table = $script:contract.tables[0]
+        $view = $table.views[0]
+        $form = $table.forms[0]
+
+        $viewId = [string]$fixture.IdMap["view:$($table.logicalName)/$($view.name)"]
+        $formId = [string]$fixture.IdMap["form:$($table.logicalName)/$($form.name)"]
+        $expectedViewEntityMoniker = [System.Uri]::EscapeDataString(
+            '{"@odata.id":"savedqueries(' + $viewId + ')"}'
+        )
+        $expectedFormEntityMoniker = [System.Uri]::EscapeDataString(
+            '{"@odata.id":"systemforms(' + $formId + ')"}'
+        )
+        $expectedViewPath = (
+            '/RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?' +
+            "@p1=$expectedViewEntityMoniker&" +
+            "@p2='name'&" +
+            '@p3=true'
+        )
+        $expectedFormPath = (
+            '/RetrieveLocLabels(EntityMoniker=@p1,AttributeName=@p2,IncludeUnpublished=@p3)?' +
+            "@p1=$expectedFormEntityMoniker&" +
+            "@p2='name'&" +
+            '@p3=true'
+        )
+
+        $fixture.Responses.ContainsKey($expectedViewPath) | Should -BeTrue
+        $fixture.Responses.ContainsKey($expectedFormPath) | Should -BeTrue
     }
 }
 
@@ -1311,6 +1392,52 @@ Describe 'Component-level convergence checks' {
             }).Count | Should -Be 1
     }
 
+    It 'rethrows ordinary RetrieveLocLabels bad requests for views' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $view = $table.views[0]
+        $request = New-ViewRequest -Table $table -View $view -ObjectTypeCode 10427
+        $savedQuery = script:New-SavedQuerySnapshot `
+            -Request $request `
+            -Table $table `
+            -SavedQueryId (script:New-FakeGuid -Index 18)
+        $savedQueryPath = Get-ConvergenceSavedQueryPath `
+            -TableLogicalName $table.logicalName `
+            -Label ([string]$view.metadata.label.'1033')
+        $solutionMembershipPath = Get-ConvergenceSolutionMembershipPath `
+            -ComponentId $savedQuery.savedqueryid
+        $solutionMembership = script:New-SolutionMembershipResponse `
+            -SolutionUniqueName ([string]$table.solution)
+
+        Mock Invoke-ConvergenceDataverseRequest {
+            param($Method, $EnvironmentUrl, $Path, $Headers)
+
+            if ($Method -cne 'GET') {
+                throw "Unexpected mocked method: $Method"
+            }
+            if ($Path -eq $savedQueryPath) {
+                return [pscustomobject]@{
+                    value = @($savedQuery)
+                }
+            }
+            if ($Path -eq $solutionMembershipPath) {
+                return $solutionMembership
+            }
+            if ($Path -like '/RetrieveLocLabels*') {
+                throw "Dataverse convergence transport failed (GET $Path); az rest exited with code 1. 400 Bad Request. Request message has unresolved parameters."
+            }
+
+            throw "Unexpected mocked path: $Path"
+        }
+
+        {
+            Test-InsuranceFoundationView `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -Table $table `
+                -View $view `
+                -ObjectTypeCode 10427
+        } | Should -Throw '*400 Bad Request*'
+    }
+
     It 'accepts platform-normalized form ids with exact four-language localized labels' {
         $table = script:Clone-Object -InputObject $script:contract.tables[0]
         $form = $table.forms[0]
@@ -1486,6 +1613,19 @@ Describe 'Invoke-InsuranceFoundationConvergence' {
         @($result.Results.Component) | Should -Contain 'account/crmshow_accounttype'
         @($result.Results.Component) | Should -Contain 'crmshow_policyprojection'
         @($result.Results.Component) | Should -Contain 'roles'
+        @($result.Results.Component) | Should -Be (
+            @('languages', 'solutions') +
+            @($script:contract.choices | ForEach-Object {
+                    [string]$_.logicalName
+                }) +
+            @($script:contract.nativeExtensions | ForEach-Object {
+                    "$($_.table)/$($_.logicalName)"
+                }) +
+            @($script:contract.tables | ForEach-Object {
+                    [string]$_.logicalName
+                }) +
+            @('roles')
+        )
 
         $policyProjection = @($result.Results | Where-Object {
                 $_.Component -eq 'crmshow_policyprojection'

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -1,0 +1,1320 @@
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:contractPath = Join-Path $script:repoRoot 'solution/schema/insurance-foundation.json'
+    $script:manifestPath = Join-Path $script:repoRoot 'solution/manifest.json'
+    $script:convergencePath = Join-Path $script:repoRoot 'scripts/solution/Test-InsuranceFoundationConvergence.ps1'
+    $script:childPowerShellPath = (Get-Command powershell -ErrorAction Stop).Source
+    . (Join-Path $script:repoRoot 'scripts/solution/Get-Manifest.ps1')
+    . $script:convergencePath `
+        -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+        -ContractPath $script:contractPath
+    $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json -ErrorAction Stop
+    $script:manifest = Get-Manifest -Path $script:manifestPath -Validate
+    $script:languages = @('1033', '1031', '1036', '1040')
+
+    function script:Clone-Object {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $InputObject
+        )
+
+        return $InputObject | ConvertTo-Json -Depth 100 | ConvertFrom-Json
+    }
+
+    function script:New-FakeGuid {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [int]$Index
+        )
+
+        return ('00000000-0000-0000-0000-{0:d12}' -f $Index)
+    }
+
+    function script:Get-ComponentIdMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $index = 1
+        $map = @{}
+
+        foreach ($choice in @($Contract.choices)) {
+            $map["choice:$($choice.logicalName)"] = script:New-FakeGuid -Index $index
+            $index++
+        }
+
+        foreach ($extension in @($Contract.nativeExtensions)) {
+            $map["extension:$($extension.table)/$($extension.logicalName)"] =
+                script:New-FakeGuid -Index $index
+            $index++
+        }
+
+        foreach ($table in @($Contract.tables)) {
+            $map["table:$($table.logicalName)"] = script:New-FakeGuid -Index $index
+            $index++
+            foreach ($column in @($table.columns)) {
+                $map["column:$($table.logicalName)/$($column.logicalName)"] =
+                    script:New-FakeGuid -Index $index
+                $index++
+            }
+            foreach ($rule in @($table.businessRules)) {
+                $map["ruleview:$($table.logicalName)/$($rule.name)"] =
+                    script:New-FakeGuid -Index $index
+                $index++
+            }
+            foreach ($view in @($table.views)) {
+                $map["view:$($table.logicalName)/$($view.name)"] =
+                    script:New-FakeGuid -Index $index
+                $index++
+            }
+            foreach ($form in @($table.forms)) {
+                $map["form:$($table.logicalName)/$($form.name)"] =
+                    script:New-FakeGuid -Index $index
+                $index++
+            }
+        }
+
+        foreach ($role in @($Contract.roles)) {
+            $map["role:$($role.name)"] = script:New-FakeGuid -Index $index
+            $index++
+        }
+
+        return $map
+    }
+
+    function script:Get-ObjectTypeCodeMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $map = @{}
+        $base = 10427
+        for ($index = 0; $index -lt @($Contract.tables).Count; $index++) {
+            $table = $Contract.tables[$index]
+            $map[[string]$table.logicalName] = $base + $index
+        }
+
+        return $map
+    }
+
+    function script:Get-ColumnAttributeTypeName {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Column
+        )
+
+        return @{
+            Text         = 'String'
+            DateOnly     = 'DateTime'
+            DateTime     = 'DateTime'
+            GlobalChoice = 'Picklist'
+            Lookup       = 'Lookup'
+            Customer     = 'Customer'
+        }[[string]$Column.type]
+    }
+
+    function script:New-BaseAttributeSnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Column,
+
+            [Parameter(Mandatory)]
+            [string]$MetadataId
+        )
+
+        return [pscustomobject][ordered]@{
+            MetadataId   = $MetadataId
+            LogicalName  = [string]$Column.logicalName
+            SchemaName   = [string]$Column.schemaName
+            AttributeType = script:Get-ColumnAttributeTypeName -Column $Column
+            DisplayName  = ConvertTo-LocalizedLabel $Column.metadata.label
+            Description  = ConvertTo-LocalizedLabel $Column.metadata.description
+        }
+    }
+
+    function script:New-TypedAttributeSnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Column,
+
+            [Parameter(Mandatory)]
+            [string]$MetadataId
+        )
+
+        $attribute = [ordered]@{
+            MetadataId    = $MetadataId
+            LogicalName   = [string]$Column.logicalName
+            SchemaName    = [string]$Column.schemaName
+            AttributeType = script:Get-ColumnAttributeTypeName -Column $Column
+            DisplayName   = ConvertTo-LocalizedLabel $Column.metadata.label
+            Description   = ConvertTo-LocalizedLabel $Column.metadata.description
+            RequiredLevel = ConvertTo-RequiredLevel ([bool]$Column.required)
+            IsAuditEnabled = @{ Value = [bool]$Column.auditing }
+        }
+
+        switch ([string]$Column.type) {
+            'Text' {
+                $attribute.MaxLength = [int]$Column.maxLength
+            }
+            'DateOnly' {
+                $attribute.Format = 'DateOnly'
+                $attribute.DateTimeBehavior = @{ Value = 'DateOnly' }
+            }
+            'DateTime' {
+                $attribute.Format = 'DateAndTime'
+                $attribute.DateTimeBehavior = @{ Value = 'TimeZoneIndependent' }
+            }
+            'GlobalChoice' {
+                $attribute.GlobalOptionSet = [pscustomobject]@{
+                    Name = [string]$Column.choice
+                }
+            }
+            'Lookup' {
+                $attribute.Targets = @($Column.lookup.targets)
+            }
+            'Customer' {
+                $attribute.AttributeType = 'Customer'
+                $attribute.Targets = @($Column.lookup.targets)
+            }
+        }
+
+        return [pscustomobject]$attribute
+    }
+
+    function script:New-RelationshipSnapshots {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Table
+        )
+
+        $relationships = [System.Collections.Generic.List[object]]::new()
+        foreach ($relationship in @($Table.relationships)) {
+            if ([string]$relationship.authoring -eq 'CreateCustomerRelationships') {
+                $column = @($Table.columns | Where-Object {
+                        $_.logicalName -eq $relationship.lookupColumn
+                    })[0]
+                foreach ($expected in @(Get-ExpectedCustomerRelationships `
+                            -Table $Table `
+                            -Column $column)) {
+                    [void]$relationships.Add([pscustomobject]@{
+                            SchemaName          = [string]$expected.SchemaName
+                            ReferencedEntity    = [string]$expected.ReferencedEntity
+                            ReferencingEntity   = [string]$Table.logicalName
+                            ReferencingAttribute = [string]$column.logicalName
+                            CascadeConfiguration = [pscustomobject](
+                                Get-ExpectedOrdinaryRelationshipCascade `
+                                    -ReferencedEntity ([string]$expected.ReferencedEntity)
+                            )
+                        })
+                }
+                continue
+            }
+
+            $target = [string]$relationship.referencedTables[0]
+            [void]$relationships.Add([pscustomobject]@{
+                    SchemaName          = [string]$relationship.schemaName
+                    ReferencedEntity    = $target
+                    ReferencingEntity   = [string]$Table.logicalName
+                    ReferencingAttribute = [string]$relationship.lookupColumn
+                    CascadeConfiguration = [pscustomobject](
+                        Get-ExpectedOrdinaryRelationshipCascade `
+                            -ReferencedEntity $target
+                    )
+                })
+        }
+
+        return @($relationships)
+    }
+
+    function script:New-TableSnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Table,
+
+            [Parameter(Mandatory)]
+            [hashtable]$IdMap,
+
+            [Parameter(Mandatory)]
+            [int]$ObjectTypeCode
+        )
+
+        $attributes = foreach ($column in @($Table.columns)) {
+            script:New-BaseAttributeSnapshot `
+                -Column $column `
+                -MetadataId $IdMap["column:$($Table.logicalName)/$($column.logicalName)"]
+        }
+
+        return [pscustomobject][ordered]@{
+            MetadataId          = $IdMap["table:$($Table.logicalName)"]
+            LogicalName         = [string]$Table.logicalName
+            SchemaName          = [string]$Table.schemaName
+            OwnershipType       = [string]$Table.ownership
+            PrimaryNameAttribute = 'crmshow_name'
+            IsAuditEnabled      = @{ Value = [bool]$Table.auditing }
+            DisplayName         = ConvertTo-LocalizedLabel $Table.metadata.label
+            Description         = ConvertTo-LocalizedLabel $Table.metadata.description
+            ObjectTypeCode      = $ObjectTypeCode
+            Attributes          = @($attributes)
+            ManyToOneRelationships = @(script:New-RelationshipSnapshots -Table $Table)
+        }
+    }
+
+    function script:New-ChoiceSnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Choice,
+
+            [Parameter(Mandatory)]
+            [string]$MetadataId
+        )
+
+        $options = [System.Collections.Generic.List[object]]::new()
+        for ($index = 0; $index -lt @($Choice.options).Count; $index++) {
+            $option = $Choice.options[$index]
+            [void]$options.Add([pscustomobject]@{
+                    Value       = 100000000 + $index
+                    Label       = ConvertTo-LocalizedLabel $option.metadata.label
+                    Description = ConvertTo-LocalizedLabel $option.metadata.description
+                })
+        }
+
+        return [pscustomobject][ordered]@{
+            MetadataId   = $MetadataId
+            Name         = [string]$Choice.logicalName
+            IsGlobal     = $true
+            OptionSetType = 'Picklist'
+            DisplayName  = ConvertTo-LocalizedLabel $Choice.metadata.label
+            Description  = ConvertTo-LocalizedLabel $Choice.metadata.description
+            Options      = @($options)
+        }
+    }
+
+    function script:New-SavedQuerySnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Request,
+
+            [Parameter(Mandatory)]
+            $Table,
+
+            [Parameter(Mandatory)]
+            [string]$SavedQueryId
+        )
+
+        return [pscustomobject][ordered]@{
+            savedqueryid     = $SavedQueryId
+            name             = [string]$Request.Body.name
+            description      = [string]$Request.Body.description
+            returnedtypecode = [string]$Table.logicalName
+            fetchxml         = [string]$Request.Body.fetchxml
+            layoutxml        = [string]$Request.Body.layoutxml
+        }
+    }
+
+    function script:New-FormSnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Request,
+
+            [Parameter(Mandatory)]
+            $Table,
+
+            [Parameter(Mandatory)]
+            [string]$FormId
+        )
+
+        return [pscustomobject][ordered]@{
+            formid         = $FormId
+            name           = [string]$Request.Body.name
+            description    = [string]$Request.Body.description
+            objecttypecode = [string]$Table.logicalName
+            type           = 2
+            formxml        = [string]$Request.Body.formxml
+        }
+    }
+
+    function script:Get-SchemaMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $map = @{
+            account = 'Account'
+            contact = 'Contact'
+        }
+
+        foreach ($table in @($Contract.tables)) {
+            $map[[string]$table.logicalName] = [string]$table.schemaName
+        }
+
+        return $map
+    }
+
+    function script:Get-MetadataPrivilegeMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $schemaMap = script:Get-SchemaMap -Contract $Contract
+        $map = @{}
+        foreach ($role in @($Contract.roles)) {
+            foreach ($tablePrivilege in @($role.tablePrivileges)) {
+                $logicalName = [string]$tablePrivilege.table
+                if (-not $map.ContainsKey($logicalName)) {
+                    $map[$logicalName] = @()
+                }
+
+                $schemaName = [string]$schemaMap[$logicalName]
+                foreach ($verb in @($tablePrivilege.privileges)) {
+                    $map[$logicalName] += [pscustomobject]@{
+                        Name        = "prv$verb$schemaName"
+                        PrivilegeId = "$logicalName-$verb"
+                    }
+                }
+            }
+        }
+
+        foreach ($logicalName in @($map.Keys)) {
+            $unique = @()
+            foreach ($privilege in @($map[$logicalName])) {
+                if (@($unique.Name | Where-Object { $_ -ceq $privilege.Name }).Count -gt 0) {
+                    continue
+                }
+
+                $unique += $privilege
+            }
+
+            $map[$logicalName] = @($unique)
+        }
+
+        return $map
+    }
+
+    function script:Get-ExpectedPrivilegesForRole {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Role,
+
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $schemaMap = script:Get-SchemaMap -Contract $Contract
+        $expected = foreach ($tablePrivilege in @($Role.tablePrivileges)) {
+            $schemaName = [string]$schemaMap[[string]$tablePrivilege.table]
+            foreach ($verb in @($tablePrivilege.privileges)) {
+                [pscustomobject]@{
+                    Name        = "prv$verb$schemaName"
+                    PrivilegeId = "$($tablePrivilege.table)-$verb"
+                    Depth       = 'Global'
+                }
+            }
+        }
+
+        return @($expected)
+    }
+
+    function script:Get-ActualRolePrivileges {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Role,
+
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        return @(
+            script:Get-ExpectedPrivilegesForRole -Role $Role -Contract $Contract |
+                ForEach-Object {
+                    [pscustomobject]@{
+                        PrivilegeName = $_.Name
+                        PrivilegeId   = $_.PrivilegeId
+                        Depth         = $_.Depth
+                    }
+                }
+        )
+    }
+
+    function script:New-SolutionMembershipResponse {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$SolutionUniqueName
+        )
+
+        return [pscustomobject]@{
+            value = @([pscustomobject]@{
+                    solutionid = [pscustomobject]@{
+                        uniquename = $SolutionUniqueName
+                    }
+                })
+        }
+    }
+
+    function script:New-ReadyConvergenceResponseMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract,
+
+            [Parameter(Mandatory)]
+            $Manifest,
+
+            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict')]
+            [string]$Scenario = 'Ready'
+        )
+
+        $idMap = script:Get-ComponentIdMap -Contract $Contract
+        $objectTypeCodes = script:Get-ObjectTypeCodeMap -Contract $Contract
+        $schemaMap = script:Get-SchemaMap -Contract $Contract
+        $metadataPrivileges = script:Get-MetadataPrivilegeMap -Contract $Contract
+        $responses = @{}
+
+        $provisionedLanguages = if ($Scenario -eq 'MissingLanguage') {
+            @(1033, 1031, 1036)
+        }
+        else {
+            @($Contract.languages | ForEach-Object { [int]$_ })
+        }
+        $responses[(Get-ConvergenceLanguagesPath)] = [pscustomobject]@{
+            RetrieveProvisionedLanguages = @($provisionedLanguages)
+        }
+
+        $solutions = @(
+            [pscustomobject]@{
+                solutionid  = script:New-FakeGuid -Index 9001
+                uniquename  = 'crmshow_Foundation'
+                publisherid = [pscustomobject]@{
+                    uniquename                    = [string]$Manifest.publisher.uniqueName
+                    customizationprefix           = [string]$Manifest.publisher.prefix
+                    customizationoptionvalueprefix = [int]$Manifest.publisher.customizationOptionValuePrefix
+                }
+            },
+            [pscustomobject]@{
+                solutionid  = script:New-FakeGuid -Index 9002
+                uniquename  = 'crmshow_DataModel'
+                publisherid = [pscustomobject]@{
+                    uniquename                    = [string]$Manifest.publisher.uniqueName
+                    customizationprefix           = [string]$Manifest.publisher.prefix
+                    customizationoptionvalueprefix = [int]$Manifest.publisher.customizationOptionValuePrefix
+                }
+            }
+        )
+        $responses[(Get-ConvergenceSolutionsPath -SolutionUniqueName @($Contract.solutions))] = [pscustomobject]@{
+            value = @($solutions)
+        }
+
+        foreach ($choice in @($Contract.choices)) {
+            $choiceSnapshot = script:New-ChoiceSnapshot `
+                -Choice $choice `
+                -MetadataId $idMap["choice:$($choice.logicalName)"]
+            $responses[(Get-ConvergenceGlobalChoicePath -ChoiceLogicalName $choice.logicalName)] =
+                $choiceSnapshot
+            $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $choiceSnapshot.MetadataId)] =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$choice.solution)
+        }
+
+        foreach ($extension in @($Contract.nativeExtensions)) {
+            $attribute = script:New-TypedAttributeSnapshot `
+                -Column $extension `
+                -MetadataId $idMap["extension:$($extension.table)/$($extension.logicalName)"]
+            $responses[(Get-ConvergenceTypedAttributePath -TableLogicalName $extension.table -Column $extension)] =
+                [pscustomobject]@{ value = @($attribute) }
+            $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $attribute.MetadataId)] =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$extension.solution)
+        }
+
+        foreach ($table in @($Contract.tables)) {
+            $tableSnapshot = script:New-TableSnapshot `
+                -Table $table `
+                -IdMap $idMap `
+                -ObjectTypeCode $objectTypeCodes[[string]$table.logicalName]
+            $responses[(Get-ConvergenceTableMetadataPath `
+                    -LogicalName $table.logicalName `
+                    -RequestedAttributeLogicalNames @($table.columns.logicalName))] =
+                [pscustomobject]@{ value = @($tableSnapshot) }
+            $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $tableSnapshot.MetadataId)] =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+
+            foreach ($column in @($table.columns)) {
+                $typedAttribute = script:New-TypedAttributeSnapshot `
+                    -Column $column `
+                    -MetadataId $idMap["column:$($table.logicalName)/$($column.logicalName)"]
+                $responses[(Get-ConvergenceTypedAttributePath -TableLogicalName $table.logicalName -Column $column)] =
+                    [pscustomobject]@{ value = @($typedAttribute) }
+            }
+
+            foreach ($key in @($table.alternateKeys)) {
+                $responses[(Get-ConvergenceKeyPath `
+                        -TableLogicalName $table.logicalName `
+                        -SchemaName $key.schemaName)] = [pscustomobject]@{
+                    value = @([pscustomobject]@{
+                            MetadataId   = script:New-FakeGuid -Index 9500
+                            SchemaName   = [string]$key.schemaName
+                            KeyAttributes = @($key.columns)
+                        })
+                }
+            }
+
+            foreach ($rule in @($table.businessRules)) {
+                $ruleRequest = New-InvalidDateViewRequest `
+                    -Table $table `
+                    -Rule $rule `
+                    -ObjectTypeCode $objectTypeCodes[[string]$table.logicalName]
+                $savedQuery = script:New-SavedQuerySnapshot `
+                    -Request $ruleRequest `
+                    -Table $table `
+                    -SavedQueryId $idMap["ruleview:$($table.logicalName)/$($rule.name)"]
+                $ruleLabel = [string]$rule.metadata.label.'1033'
+                $responses[(Get-ConvergenceSavedQueryPath `
+                        -TableLogicalName $table.logicalName `
+                        -Label $ruleLabel)] = [pscustomobject]@{
+                    value = @($savedQuery)
+                }
+                $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
+                    script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+            }
+
+            foreach ($view in @($table.views)) {
+                $viewRequest = New-ViewRequest `
+                    -Table $table `
+                    -View $view `
+                    -ObjectTypeCode $objectTypeCodes[[string]$table.logicalName]
+                $savedQuery = script:New-SavedQuerySnapshot `
+                    -Request $viewRequest `
+                    -Table $table `
+                    -SavedQueryId $idMap["view:$($table.logicalName)/$($view.name)"]
+                $viewLabel = [string]$view.metadata.label.'1033'
+                $responses[(Get-ConvergenceSavedQueryPath `
+                        -TableLogicalName $table.logicalName `
+                        -Label $viewLabel)] = [pscustomobject]@{
+                    value = @($savedQuery)
+                }
+                $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
+                    script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+            }
+
+            foreach ($form in @($table.forms)) {
+                $formRequest = New-FormRequest -Table $table -Form $form
+                $systemForm = script:New-FormSnapshot `
+                    -Request $formRequest `
+                    -Table $table `
+                    -FormId $idMap["form:$($table.logicalName)/$($form.name)"]
+                $formLabel = [string]$form.metadata.label.'1033'
+                $responses[(Get-ConvergenceSystemFormPath `
+                        -TableLogicalName $table.logicalName `
+                        -Label $formLabel)] = [pscustomobject]@{
+                    value = @($systemForm)
+                }
+                $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid)] =
+                    script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+            }
+        }
+
+        foreach ($logicalName in @($metadataPrivileges.Keys)) {
+            $responses[(Get-InsuranceRoleEntityPrivilegesPath -LogicalName $logicalName)] =
+                [pscustomobject]@{
+                    LogicalName = [string]$logicalName
+                    SchemaName  = [string]$schemaMap[$logicalName]
+                    Privileges  = @($metadataPrivileges[$logicalName])
+                }
+        }
+
+        foreach ($role in @($Contract.roles)) {
+            $roleId = $idMap["role:$($role.name)"]
+            $roleName = if ($Scenario -eq 'RoleNameCaseConflict' -and
+                [string]$role.name -eq 'CRM Showcase Insurance Data Steward') {
+                ([string]$role.name).ToLowerInvariant()
+            }
+            else {
+                [string]$role.name
+            }
+
+            $responses[(Get-InsuranceSecurityRolePath -RoleName $role.name)] =
+                [pscustomobject]@{
+                    value = @([pscustomobject]@{
+                            roleid = $roleId
+                            name   = $roleName
+                        })
+                }
+            $responses[(Get-InsuranceSecurityRoleSolutionMembershipPath -RoleId $roleId)] =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$role.solution)
+            $responses[(Get-InsuranceSecurityRolePrivilegesPath -RoleId $roleId)] =
+                [pscustomobject]@{
+                    RolePrivileges = @(
+                        script:Get-ActualRolePrivileges -Role $role -Contract $Contract
+                    )
+                }
+        }
+
+        return [pscustomobject]@{
+            Responses       = $responses
+            IdMap           = $idMap
+            ObjectTypeCodes = $objectTypeCodes
+        }
+    }
+
+    function script:Register-ConvergenceTransportMock {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [hashtable]$Responses
+        )
+
+        $script:calls = [System.Collections.Generic.List[object]]::new()
+        $script:responseMap = $Responses
+
+        Mock Invoke-ConvergenceDataverseRequest {
+            param($Method, $EnvironmentUrl, $Path, $Headers)
+
+            [void]$script:calls.Add([pscustomobject]@{
+                    Method         = $Method
+                    EnvironmentUrl = $EnvironmentUrl
+                    Path           = $Path
+                })
+
+            if ($Method -cne 'GET') {
+                throw "Unexpected mocked method: $Method"
+            }
+            if (-not $script:responseMap.ContainsKey($Path)) {
+                throw "Unexpected mocked path: $Path"
+            }
+
+            return $script:responseMap[$Path]
+        }
+    }
+
+    function script:New-ConvergenceAzShim {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath,
+
+            [Parameter(Mandatory)]
+            [string]$ResponseMapPath
+        )
+
+        $shimScriptPath = Join-Path $RootPath 'az.ps1'
+        $shimCommandPath = Join-Path $RootPath 'az'
+
+        $shimScript = @'
+#!/usr/bin/env pwsh
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ArgumentValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$InputArguments,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $index = [Array]::IndexOf($InputArguments, $Name)
+    if ($index -lt 0 -or $index -ge ($InputArguments.Count - 1)) {
+        throw "Missing required argument: $Name"
+    }
+
+    return $InputArguments[$index + 1]
+}
+
+function Write-Json {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Value
+    )
+
+    $Value | ConvertTo-Json -Compress -Depth 100
+}
+
+$method = Get-ArgumentValue -InputArguments $Arguments -Name '--method'
+if ($method -cne 'get') {
+    Write-Error "Unexpected method: $method"
+    exit 1
+}
+
+$resource = Get-ArgumentValue -InputArguments $Arguments -Name '--resource'
+if ($resource -cne 'https://unit.crm.dynamics.com/') {
+    Write-Error "Unexpected resource URL: $resource"
+    exit 1
+}
+
+$url = Get-ArgumentValue -InputArguments $Arguments -Name '--url'
+$prefix = '/api/data/v9.2'
+$prefixIndex = $url.IndexOf($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+if ($prefixIndex -ge 0) {
+    $path = $url.Substring($prefixIndex + $prefix.Length)
+}
+else {
+    $path = $url
+}
+
+$map = Get-Content -LiteralPath '__MAP__' -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+$property = $map.PSObject.Properties[$path]
+if ($null -eq $property) {
+    Write-Error "Unexpected az rest URL: $url"
+    exit 1
+}
+
+Write-Json $property.Value
+'@.Replace('__MAP__', $ResponseMapPath.Replace("'", "''"))
+
+        $shimScript = $shimScript -replace "`r`n", "`n"
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+        [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
+        [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
+    }
+
+    function script:Invoke-ConvergenceEntryScript {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict')]
+            [string]$Scenario
+        )
+
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario $Scenario
+
+        $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+        $null = New-Item -ItemType Directory -Path $testRoot -Force
+
+        $responseMapPath = Join-Path $testRoot 'responses.json'
+        $fixture.Responses | ConvertTo-Json -Depth 100 |
+            Set-Content -LiteralPath $responseMapPath -Encoding UTF8
+
+        script:New-ConvergenceAzShim `
+            -RootPath $testRoot `
+            -ResponseMapPath $responseMapPath
+
+        $previousPath = $env:PATH
+        try {
+            $pathSeparator = [System.IO.Path]::PathSeparator
+            $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
+                $testRoot
+            }
+            else {
+                "$testRoot$pathSeparator$previousPath"
+            }
+
+            $output = & $script:childPowerShellPath `
+                -NoLogo `
+                -NoProfile `
+                -NonInteractive `
+                -File $script:convergencePath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -ContractPath $script:contractPath 2>&1
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            $env:PATH = $previousPath
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output   = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+        }
+    }
+}
+
+Describe 'New-ConvergenceSummary' {
+    It 'is Ready only when every component is Ready' {
+        New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='choices'; State='Ready' },
+            [pscustomobject]@{ Component='tables'; State='Ready' },
+            [pscustomobject]@{ Component='roles'; State='Ready' }
+        ) | Select-Object -ExpandProperty State |
+            Should -Be 'Ready'
+    }
+
+    It 'prefers ContractConflict over ManualPrerequisite regardless of array order' {
+        $summary = New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
+            [pscustomobject]@{ Component='tables'; State='ContractConflict' }
+        )
+
+        $summary.State | Should -Be 'ContractConflict'
+    }
+
+    It 'keeps all blocking components and MutationOccurred false' {
+        $summary = New-ConvergenceSummary -Results @(
+            [pscustomobject]@{ Component='languages'; State='Precondition' },
+            [pscustomobject]@{ Component='roles'; State='ManualPrerequisite' },
+            [pscustomobject]@{ Component='choices'; State='Ready' }
+        )
+
+        $summary.BlockingComponents | Should -Be @('languages', 'roles')
+        $summary.MutationOccurred | Should -BeFalse
+    }
+}
+
+Describe 'Convergence path builders' {
+    It 'escapes apostrophes in solution, choice, key, view and form paths' {
+        Get-ConvergenceSolutionsPath -SolutionUniqueName @(
+            "crmshow_Foundation",
+            "crmshow_O'Reilly"
+        ) | Should -Be (
+            "/solutions?`$select=solutionid,uniquename&" +
+            "`$expand=publisherid(`$select=uniquename,customizationprefix,customizationoptionvalueprefix)&" +
+            "`$filter=uniquename eq 'crmshow_Foundation' or uniquename eq 'crmshow_O''Reilly'"
+        )
+
+        Get-ConvergenceGlobalChoicePath -ChoiceLogicalName "crmshow_o'reilly" |
+            Should -Be (
+                "/GlobalOptionSetDefinitions(Name='crmshow_o''reilly')/" +
+                'Microsoft.Dynamics.CRM.OptionSetMetadata'
+            )
+
+        Get-ConvergenceKeyPath `
+            -TableLogicalName "crmshow_o'reilly" `
+            -SchemaName "crmshow_Key'Odata" | Should -Be (
+                "/EntityDefinitions(LogicalName='crmshow_o''reilly')/Keys?" +
+                "`$select=MetadataId,SchemaName,KeyAttributes&" +
+                "`$filter=SchemaName eq 'crmshow_Key''Odata'"
+            )
+
+        Get-ConvergenceSavedQueryPath `
+            -TableLogicalName "crmshow_o'reilly" `
+            -Label "O'Reilly View" | Should -Be (
+                '/savedqueries?' +
+                "`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml&" +
+                "`$filter=name eq 'O''Reilly View' and returnedtypecode eq 'crmshow_o''reilly'"
+            )
+
+        Get-ConvergenceSystemFormPath `
+            -TableLogicalName "crmshow_o'reilly" `
+            -Label "O'Reilly Form" | Should -Be (
+                '/systemforms?' +
+                "`$select=formid,name,description,objecttypecode,type,formxml&" +
+                "`$filter=name eq 'O''Reilly Form' and objecttypecode eq 'crmshow_o''reilly' and type eq 2"
+            )
+    }
+}
+
+Describe 'Component-level convergence checks' {
+    It 'classifies a missing language as Precondition' {
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceLanguagesPath) = [pscustomobject]@{
+                RetrieveProvisionedLanguages = @(1033, 1031, 1036)
+            }
+        }
+
+        $result = Test-InsuranceFoundationLanguages `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Precondition'
+        @($result.Missing) | Should -Be @('1040')
+    }
+
+    It 'classifies a missing solution as Precondition' {
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceSolutionsPath -SolutionUniqueName @($script:contract.solutions)) =
+                [pscustomobject]@{
+                    value = @([pscustomobject]@{
+                            solutionid = script:New-FakeGuid -Index 1
+                            uniquename = 'crmshow_Foundation'
+                            publisherid = [pscustomobject]@{
+                                uniquename                    = [string]$script:manifest.publisher.uniqueName
+                                customizationprefix           = [string]$script:manifest.publisher.prefix
+                                customizationoptionvalueprefix = [int]$script:manifest.publisher.customizationOptionValuePrefix
+                            }
+                        })
+                }
+        }
+
+        $result = Test-InsuranceFoundationSolutions `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Precondition'
+        @($result.Missing) | Should -Be @('crmshow_DataModel')
+    }
+
+    It 'classifies a choice option mismatch as ContractConflict' {
+        $choice = script:Clone-Object -InputObject $script:contract.choices[0]
+        $choiceSnapshot = script:New-ChoiceSnapshot `
+            -Choice $choice `
+            -MetadataId (script:New-FakeGuid -Index 2)
+        $choiceSnapshot.Options[0].Label = ConvertTo-LocalizedLabel ([pscustomobject]@{
+                '1033' = 'Wrong'
+                '1031' = 'Falsch'
+                '1036' = 'Faux'
+                '1040' = 'Errato'
+            })
+
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceGlobalChoicePath -ChoiceLogicalName $choice.logicalName) = $choiceSnapshot
+            (Get-ConvergenceSolutionMembershipPath -ComponentId $choiceSnapshot.MetadataId) =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$choice.solution)
+        }
+
+        $result = Test-InsuranceFoundationChoice `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Choice $choice
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'Label' -and $_.Code -eq 'Household'
+            }).Count | Should -Be 4
+    }
+
+    It 'classifies a column mismatch as ContractConflict' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $snapshot = [pscustomobject]@{
+            Attributes = @(
+                script:New-TypedAttributeSnapshot `
+                    -Column $table.columns[0] `
+                    -MetadataId (script:New-FakeGuid -Index 3)
+            )
+        }
+        $snapshot.Attributes[0].RequiredLevel = @{ Value = 'None' }
+
+        $result = Test-InsuranceFoundationTableColumn `
+            -Table $table `
+            -Column $table.columns[0] `
+            -Snapshot $snapshot
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'RequiredLevel'
+            }).Count | Should -Be 1
+    }
+
+    It 'classifies a relationship cascade mismatch as ContractConflict' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[1]
+        $relationship = @($table.relationships | Where-Object {
+                $_.authoring -ne 'CreateCustomerRelationships'
+            })[0]
+        $snapshot = [pscustomobject]@{
+            Attributes = @(
+                script:New-TypedAttributeSnapshot `
+                    -Column (@($table.columns | Where-Object {
+                            $_.logicalName -eq $relationship.lookupColumn
+                        })[0]) `
+                    -MetadataId (script:New-FakeGuid -Index 4)
+            )
+            ManyToOneRelationships = @([pscustomobject]@{
+                    SchemaName          = [string]$relationship.schemaName
+                    ReferencedEntity    = [string]$relationship.referencedTables[0]
+                    ReferencingEntity   = [string]$table.logicalName
+                    ReferencingAttribute = [string]$relationship.lookupColumn
+                    CascadeConfiguration = [pscustomobject]@{
+                        Assign   = 'NoCascade'
+                        Delete   = 'Cascade'
+                        Merge    = 'Cascade'
+                        Reparent = 'NoCascade'
+                        Share    = 'NoCascade'
+                        Unshare  = 'NoCascade'
+                    }
+                })
+        }
+
+        $result = Test-InsuranceFoundationOrdinaryRelationship `
+            -Table $table `
+            -Relationship $relationship `
+            -Snapshot $snapshot
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) -join ' ' | Should -Match 'cascade conflict'
+    }
+
+    It 'classifies a key mismatch as ContractConflict' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $key = $table.alternateKeys[0]
+
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceKeyPath -TableLogicalName $table.logicalName -SchemaName $key.schemaName) =
+                [pscustomobject]@{
+                    value = @([pscustomobject]@{
+                            MetadataId   = script:New-FakeGuid -Index 5
+                            SchemaName   = [string]$key.schemaName
+                            KeyAttributes = @('crmshow_accountid')
+                        })
+                }
+        }
+
+        $result = Test-InsuranceFoundationAlternateKey `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Table $table `
+            -Key $key
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Differences | Where-Object {
+                $_.Property -eq 'KeyAttributes'
+            }).Count | Should -Be 1
+    }
+
+    It 'accepts server-normalized view XML with a savedqueryid attribute' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $view = $table.views[0]
+        $request = New-ViewRequest -Table $table -View $view -ObjectTypeCode 10427
+        $storedFetchXml = $request.Body.fetchxml.Replace(
+            '<fetch ',
+            '<fetch savedqueryid="fd79983c-bf93-f111-8075-000d3a30c0f4" '
+        )
+        $savedQuery = script:New-SavedQuerySnapshot `
+            -Request $request `
+            -Table $table `
+            -SavedQueryId (script:New-FakeGuid -Index 6)
+        $savedQuery.fetchxml = $storedFetchXml
+
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceSavedQueryPath `
+                -TableLogicalName $table.logicalName `
+                -Label ([string]$view.metadata.label.'1033')) = [pscustomobject]@{
+                value = @($savedQuery)
+            }
+            (Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid) =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+        }
+
+        $result = Test-InsuranceFoundationView `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Table $table `
+            -View $view `
+            -ObjectTypeCode 10427
+
+        $result.State | Should -Be 'Ready'
+    }
+
+    It 'accepts platform-normalized form ids and localized field labels' {
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $form = $table.forms[0]
+        $request = New-FormRequest -Table $table -Form $form
+        $systemForm = [pscustomobject]@{
+            formid         = script:New-FakeGuid -Index 7
+            name           = [string]$request.Body.name
+            description    = [string]$request.Body.description
+            objecttypecode = [string]$table.logicalName
+            type           = 2
+            formxml        = ([string]$request.Body.formxml).
+                Replace(
+                    '<tab name="general">',
+                    '<tab name="general" id="{11111111-1111-1111-1111-111111111111}">'
+                ).
+                Replace(
+                    '<section name="general">',
+                    '<section name="general" id="{22222222-2222-2222-2222-222222222222}">'
+                )
+        }
+
+        script:Register-ConvergenceTransportMock -Responses @{
+            (Get-ConvergenceSystemFormPath `
+                -TableLogicalName $table.logicalName `
+                -Label ([string]$form.metadata.label.'1033')) = [pscustomobject]@{
+                value = @($systemForm)
+            }
+            (Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid) =
+                script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+        }
+
+        $result = Test-InsuranceFoundationForm `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Table $table `
+            -Form $form
+
+        $result.State | Should -Be 'Ready'
+    }
+
+    It 'classifies a role prerequisite through the reused role verifier result' {
+        Mock Invoke-InsuranceSecurityRoleVerification {
+            [pscustomobject]@{
+                State            = 'ManualPrerequisite'
+                MutationOccurred = $false
+                Results          = @(
+                    [pscustomobject]@{
+                        Role             = 'CRM Showcase Insurance Reader'
+                        State            = 'Ready'
+                        Missing          = @()
+                        Unexpected       = @()
+                        WrongDepth       = @()
+                        DuplicateExpected = @()
+                        DuplicateActual  = @()
+                        Details          = @()
+                    },
+                    [pscustomobject]@{
+                        Role             = 'CRM Showcase Insurance Data Steward'
+                        State            = 'ManualPrerequisite'
+                        Missing          = @()
+                        Unexpected       = @()
+                        WrongDepth       = @()
+                        DuplicateExpected = @()
+                        DuplicateActual  = @()
+                        Details          = @('Root security role missing.')
+                    }
+                )
+            }
+        }
+
+        $result = Test-InsuranceFoundationRoles `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ManualPrerequisite'
+        @($result.Children | Where-Object {
+                $_.State -eq 'ManualPrerequisite'
+            }).Count | Should -Be 1
+    }
+}
+
+Describe 'Invoke-InsuranceFoundationConvergence' {
+    BeforeEach {
+        Mock Invoke-PlannedRequest {}
+        Mock Invoke-ChoiceReconciliation {}
+        Mock Invoke-TableReconciliation {}
+        Mock Invoke-RoleReconciliation {}
+    }
+
+    It 'returns a representative exact Ready result with GET-only transport and no mutation' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Invoke-InsuranceFoundationConvergence `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -ContractPath $script:contractPath
+
+        $result.State | Should -Be 'Ready'
+        $result.MutationOccurred | Should -BeFalse
+        @($result.BlockingComponents) | Should -Be @()
+        @($result.Results.Component) | Should -Contain 'languages'
+        @($result.Results.Component) | Should -Contain 'crmshow_accounttype'
+        @($result.Results.Component) | Should -Contain 'account/crmshow_accounttype'
+        @($result.Results.Component) | Should -Contain 'crmshow_policyprojection'
+        @($result.Results.Component) | Should -Contain 'roles'
+
+        $policyProjection = @($result.Results | Where-Object {
+                $_.Component -eq 'crmshow_policyprojection'
+            })[0]
+        @($policyProjection.Children.Component) | Should -Contain (
+            'crmshow_policyprojection/view/crmshow_policyprojectionadminview'
+        )
+        @($policyProjection.Children.Component) | Should -Contain (
+            'crmshow_policyprojection/form/crmshow_policyprojectionadminform'
+        )
+
+        Should -Invoke Invoke-ConvergenceDataverseRequest -Times 0 -Exactly -ParameterFilter {
+            $Method -ne 'GET'
+        }
+        Should -Invoke Invoke-PlannedRequest -Times 0 -Exactly
+        Should -Invoke Invoke-ChoiceReconciliation -Times 0 -Exactly
+        Should -Invoke Invoke-TableReconciliation -Times 0 -Exactly
+        Should -Invoke Invoke-RoleReconciliation -Times 0 -Exactly
+    }
+
+    It 'validates the contract before any online reads' {
+        Mock Test-InsuranceFoundationContract {
+            throw 'Synthetic contract failure.'
+        }
+        Mock Invoke-ConvergenceDataverseRequest {}
+
+        $result = Invoke-InsuranceFoundationConvergence `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -ContractPath $script:contractPath
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Results.Component) | Should -Be @('contract')
+        Should -Invoke Invoke-ConvergenceDataverseRequest -Times 0 -Exactly
+    }
+
+    It 'rethrows transport failures' {
+        Mock Invoke-ConvergenceDataverseRequest {
+            throw 'Dataverse convergence transport failed (GET /RetrieveProvisionedLanguages()); az rest exited with code 1.'
+        }
+
+        {
+            Invoke-InsuranceFoundationConvergence `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -ContractPath $script:contractPath
+        } | Should -Throw '*transport failed*'
+    }
+}
+
+Describe 'Convergence direct entry point' {
+    It 'emits ready JSON and exits zero when convergence is Ready' {
+        $invocation = script:Invoke-ConvergenceEntryScript -Scenario Ready
+
+        $invocation.ExitCode | Should -Be 0
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'Ready'
+        $result.MutationOccurred | Should -BeFalse
+    }
+
+    It 'emits classified precondition JSON and exits two when a required language is missing' {
+        $invocation = script:Invoke-ConvergenceEntryScript -Scenario MissingLanguage
+
+        $invocation.ExitCode | Should -Be 2
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'Precondition'
+        @($result.Results | Where-Object {
+                $_.Component -eq 'languages' -and $_.State -eq 'Precondition'
+            }).Count | Should -Be 1
+    }
+
+    It 'emits classified contract-conflict JSON and exits three on exact role-name mismatch' {
+        $invocation = script:Invoke-ConvergenceEntryScript -Scenario RoleNameCaseConflict
+
+        $invocation.ExitCode | Should -Be 3
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Results | Where-Object {
+                $_.Component -eq 'roles' -and $_.State -eq 'ContractConflict'
+            }).Count | Should -Be 1
+    }
+}
+
+Describe 'Convergence entry point safety' {
+    It 'does not invoke az when dot-sourced with unit arguments' {
+        $text = @'
+function az { throw 'az was called' }
+. '__SCRIPT__' -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath '__CONTRACT__'
+'@.Replace('__SCRIPT__', $script:convergencePath.Replace("'", "''")).
+            Replace('__CONTRACT__', $script:contractPath.Replace("'", "''"))
+
+        & ([scriptblock]::Create($text))
+    }
+}

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -518,6 +518,77 @@ BeforeAll {
         }
     }
 
+    function script:New-EntityInventorySnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$MetadataId,
+
+            [Parameter(Mandatory)]
+            [string]$LogicalName,
+
+            [Parameter(Mandatory)]
+            [string]$SchemaName
+        )
+
+        return [pscustomobject]@{
+            MetadataId  = $MetadataId
+            LogicalName = $LogicalName
+            SchemaName  = $SchemaName
+        }
+    }
+
+    function script:New-AttributeInventorySnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Column,
+
+            [Parameter(Mandatory)]
+            [string]$MetadataId,
+
+            [string]$AttributeOf
+        )
+
+        $attribute = script:New-BaseAttributeSnapshot `
+            -Column $Column `
+            -MetadataId $MetadataId
+        $attribute | Add-Member -NotePropertyName AttributeOf -NotePropertyValue $AttributeOf
+        return $attribute
+    }
+
+    function script:New-TableUnexpectedChildrenSnapshot {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$LogicalName,
+
+            [Parameter(Mandatory)]
+            [string]$SchemaName,
+
+            [Parameter(Mandatory)]
+            [string]$PrimaryIdAttribute,
+
+            [AllowNull()]
+            [object[]]$Attributes = @(),
+
+            [AllowNull()]
+            [object[]]$ManyToOneRelationships = @(),
+
+            [AllowNull()]
+            [object[]]$Keys = @()
+        )
+
+        return [pscustomobject]@{
+            LogicalName            = $LogicalName
+            SchemaName             = $SchemaName
+            PrimaryIdAttribute     = $PrimaryIdAttribute
+            Attributes             = @($Attributes)
+            ManyToOneRelationships = @($ManyToOneRelationships)
+            Keys                   = @($Keys)
+        }
+    }
+
     function script:New-ReadyConvergenceResponseMap {
         [CmdletBinding()]
         param(
@@ -536,6 +607,7 @@ BeforeAll {
         $schemaMap = script:Get-SchemaMap -Contract $Contract
         $metadataPrivileges = script:Get-MetadataPrivilegeMap -Contract $Contract
         $responses = @{}
+        $publisherPrefix = Get-ConvergencePublisherLogicalPrefix -Manifest $Manifest
 
         $provisionedLanguages = if ($Scenario -eq 'MissingLanguage') {
             @(1033, 1031, 1036)
@@ -567,6 +639,15 @@ BeforeAll {
                 }
             }
         )
+        $solutionIds = @{
+            crmshow_Foundation = [string]$solutions[0].solutionid
+            crmshow_DataModel  = [string]$solutions[1].solutionid
+        }
+        $solutionInventory = @{
+            crmshow_Foundation = [System.Collections.Generic.List[object]]::new()
+            crmshow_DataModel  = [System.Collections.Generic.List[object]]::new()
+        }
+        $rootRoles = [System.Collections.Generic.List[object]]::new()
         $responses[(Get-ConvergenceSolutionsPath -SolutionUniqueName @($Contract.solutions))] = [pscustomobject]@{
             value = @($solutions)
         }
@@ -577,8 +658,14 @@ BeforeAll {
                 -MetadataId $idMap["choice:$($choice.logicalName)"]
             $responses[(Get-ConvergenceGlobalChoicePath -ChoiceLogicalName $choice.logicalName)] =
                 $choiceSnapshot
+            $responses[(Get-ConvergenceGlobalChoiceByMetadataIdPath -MetadataId $choiceSnapshot.MetadataId)] =
+                $choiceSnapshot
             $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $choiceSnapshot.MetadataId)] =
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$choice.solution)
+            [void]$solutionInventory[[string]$choice.solution].Add([pscustomobject]@{
+                    objectid      = [string]$choiceSnapshot.MetadataId
+                    componenttype = 9
+                })
         }
 
         foreach ($extension in @($Contract.nativeExtensions)) {
@@ -591,17 +678,67 @@ BeforeAll {
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$extension.solution)
         }
 
+        foreach ($tableLogicalName in @('account', 'contact')) {
+            $nativeExtensions = @($Contract.nativeExtensions | Where-Object {
+                    [string]$_.table -ceq $tableLogicalName
+                })
+            $nativeAttributes = foreach ($extension in @($nativeExtensions)) {
+                script:New-AttributeInventorySnapshot `
+                    -Column $extension `
+                    -MetadataId $idMap["extension:$($extension.table)/$($extension.logicalName)"]
+            }
+            $responses[(Get-ConvergenceTableUnexpectedChildrenPath `
+                    -LogicalName $tableLogicalName `
+                    -PublisherPrefix $publisherPrefix)] =
+                script:New-TableUnexpectedChildrenSnapshot `
+                    -LogicalName $tableLogicalName `
+                    -SchemaName ([string]$schemaMap[$tableLogicalName]) `
+                    -PrimaryIdAttribute ($tableLogicalName + 'id') `
+                    -Attributes @($nativeAttributes)
+        }
+
         foreach ($table in @($Contract.tables)) {
             $tableSnapshot = script:New-TableSnapshot `
                 -Table $table `
                 -IdMap $idMap `
                 -ObjectTypeCode $objectTypeCodes[[string]$table.logicalName]
+            $responses[(Get-ConvergenceEntityByMetadataIdPath -MetadataId $tableSnapshot.MetadataId)] =
+                (script:New-EntityInventorySnapshot `
+                    -MetadataId $tableSnapshot.MetadataId `
+                    -LogicalName ([string]$table.logicalName) `
+                    -SchemaName ([string]$table.schemaName))
             $responses[(Get-ConvergenceTableMetadataPath `
                     -LogicalName $table.logicalName `
                     -RequestedAttributeLogicalNames @($table.columns.logicalName))] =
                 [pscustomobject]@{ value = @($tableSnapshot) }
             $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $tableSnapshot.MetadataId)] =
                 script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+            [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
+                    objectid      = [string]$tableSnapshot.MetadataId
+                    componenttype = 1
+                })
+
+            $inventoryAttributes = foreach ($column in @($table.columns)) {
+                script:New-AttributeInventorySnapshot `
+                    -Column $column `
+                    -MetadataId $idMap["column:$($table.logicalName)/$($column.logicalName)"]
+            }
+            $inventoryKeys = foreach ($key in @($table.alternateKeys)) {
+                [pscustomobject]@{
+                    SchemaName    = [string]$key.schemaName
+                    KeyAttributes = @($key.columns)
+                }
+            }
+            $responses[(Get-ConvergenceTableUnexpectedChildrenPath `
+                    -LogicalName $table.logicalName `
+                    -PublisherPrefix $publisherPrefix)] =
+                script:New-TableUnexpectedChildrenSnapshot `
+                    -LogicalName ([string]$table.logicalName) `
+                    -SchemaName ([string]$table.schemaName) `
+                    -PrimaryIdAttribute ("$($table.logicalName)id") `
+                    -Attributes @($inventoryAttributes) `
+                    -ManyToOneRelationships @(script:New-RelationshipSnapshots -Table $table) `
+                    -Keys @($inventoryKeys)
 
             foreach ($column in @($table.columns)) {
                 $typedAttribute = script:New-TypedAttributeSnapshot `
@@ -638,8 +775,14 @@ BeforeAll {
                         -Label $ruleLabel)] = [pscustomobject]@{
                     value = @($savedQuery)
                 }
+                $responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $savedQuery.savedqueryid)] =
+                    $savedQuery
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+                [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
+                        objectid      = [string]$savedQuery.savedqueryid
+                        componenttype = 26
+                    })
                 script:Add-LocalizedFieldResponses `
                     -Responses $responses `
                     -EntityLogicalName 'savedquery' `
@@ -663,8 +806,14 @@ BeforeAll {
                         -Label $viewLabel)] = [pscustomobject]@{
                     value = @($savedQuery)
                 }
+                $responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $savedQuery.savedqueryid)] =
+                    $savedQuery
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $savedQuery.savedqueryid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+                [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
+                        objectid      = [string]$savedQuery.savedqueryid
+                        componenttype = 26
+                    })
                 script:Add-LocalizedFieldResponses `
                     -Responses $responses `
                     -EntityLogicalName 'savedquery' `
@@ -685,8 +834,14 @@ BeforeAll {
                         -Label $formLabel)] = [pscustomobject]@{
                     value = @($systemForm)
                 }
+                $responses[(Get-ConvergenceSystemFormByIdPath -FormId $systemForm.formid)] =
+                    $systemForm
                 $responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $systemForm.formid)] =
                     script:New-SolutionMembershipResponse -SolutionUniqueName ([string]$table.solution)
+                [void]$solutionInventory[[string]$table.solution].Add([pscustomobject]@{
+                        objectid      = [string]$systemForm.formid
+                        componenttype = 60
+                    })
                 script:Add-LocalizedFieldResponses `
                     -Responses $responses `
                     -EntityLogicalName 'systemform' `
@@ -730,12 +885,36 @@ BeforeAll {
                         script:Get-ActualRolePrivileges -Role $role -Contract $Contract
                     )
                 }
+            $responses[(Get-ConvergenceRoleByIdPath -RoleId $roleId)] = [pscustomobject]@{
+                roleid = $roleId
+                name   = $roleName
+                _parentrootroleid_value = $null
+            }
+            [void]$rootRoles.Add([pscustomobject]@{
+                    roleid = $roleId
+                    name = $roleName
+                    _parentrootroleid_value = $null
+                })
         }
+
+        foreach ($solutionUniqueName in @($solutionInventory.Keys)) {
+            $responses[(Get-ConvergenceSolutionInventoryPath `
+                    -SolutionId $solutionIds[$solutionUniqueName] `
+                    -ComponentType (Get-ConvergenceReverseInventoryComponentTypes))] =
+                [pscustomobject]@{
+                    value = @($solutionInventory[$solutionUniqueName])
+                }
+        }
+        $responses[(Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance ')] =
+            [pscustomobject]@{
+                value = @($rootRoles)
+            }
 
         return [pscustomobject]@{
             Responses       = $responses
             IdMap           = $idMap
             ObjectTypeCodes = $objectTypeCodes
+            SolutionIds     = $solutionIds
         }
     }
 
@@ -846,6 +1025,12 @@ if ($env:TEST_INSURANCE_CONVERGENCE_SCENARIO -eq 'TransportFailure') {
     exit 1
 }
 
+if ($env:TEST_INSURANCE_CONVERGENCE_SCENARIO -eq 'RetrieveLocLabelsUnsupported' -and
+    $path -like '/RetrieveLocLabels*') {
+    Write-Error "The requested resource does not support HTTP method 'GET'."
+    exit 1
+}
+
 $map = Get-Content -LiteralPath '__MAP__' -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
 $property = $map.PSObject.Properties[$path]
 if ($null -eq $property) {
@@ -874,11 +1059,11 @@ Write-Json $property.Value
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict', 'TransportFailure')]
+            [ValidateSet('Ready', 'MissingLanguage', 'RoleNameCaseConflict', 'TransportFailure', 'RetrieveLocLabelsUnsupported')]
             [string]$Scenario
         )
 
-        $fixtureScenario = if ($Scenario -eq 'TransportFailure') {
+        $fixtureScenario = if ($Scenario -in @('TransportFailure', 'RetrieveLocLabelsUnsupported')) {
             'Ready'
         }
         else {
@@ -1096,6 +1281,43 @@ Describe 'Convergence path builders' {
                 "@p1=$expectedEntityMoniker&" +
                 "@p2='description'&" +
                 '@p3=true'
+            )
+    }
+
+    It 'builds bounded reverse-inventory paths for reviewed solutions and object IDs' {
+        Get-ConvergenceSolutionInventoryPath `
+            -SolutionId '{11111111-1111-1111-1111-111111111111}' `
+            -ComponentType @(60, 1, 9, 26, 1) | Should -Be (
+                "/solutioncomponents?`$select=objectid,componenttype&" +
+                "`$filter=_solutionid_value eq 11111111-1111-1111-1111-111111111111 and (componenttype eq 1 or componenttype eq 9 or componenttype eq 26 or componenttype eq 60)"
+            )
+
+        Get-ConvergenceEntityByMetadataIdPath `
+            -MetadataId '{33333333-3333-3333-3333-333333333333}' |
+            Should -Be "/EntityDefinitions(33333333-3333-3333-3333-333333333333)?`$select=MetadataId,LogicalName,SchemaName"
+
+        Get-ConvergenceGlobalChoiceByMetadataIdPath `
+            -MetadataId '{44444444-4444-4444-4444-444444444444}' | Should -Be (
+                "/GlobalOptionSetDefinitions(44444444-4444-4444-4444-444444444444)/" +
+                "Microsoft.Dynamics.CRM.OptionSetMetadata?`$select=MetadataId,Name,IsGlobal,OptionSetType"
+            )
+
+        Get-ConvergenceSavedQueryByIdPath `
+            -SavedQueryId '{55555555-5555-5555-5555-555555555555}' | Should -Be (
+                "/savedqueries(55555555-5555-5555-5555-555555555555)?" +
+                "`$select=savedqueryid,name,description,returnedtypecode,fetchxml,layoutxml"
+            )
+
+        Get-ConvergenceSystemFormByIdPath `
+            -FormId '{66666666-6666-6666-6666-666666666666}' | Should -Be (
+                "/systemforms(66666666-6666-6666-6666-666666666666)?" +
+                "`$select=formid,name,description,objecttypecode,type,formxml"
+            )
+
+        Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance ' |
+            Should -Be (
+                "/roles?`$select=roleid,name,_parentrootroleid_value&" +
+                "`$filter=_parentrootroleid_value eq null and startswith(name,'CRM Showcase Insurance ')"
             )
     }
 }
@@ -1586,6 +1808,434 @@ Describe 'Component-level convergence checks' {
     }
 }
 
+Describe 'Table classification propagation' {
+    It 'preserves the first blocking child classification when direct checks are exact' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $table = script:Clone-Object -InputObject $script:contract.tables[0]
+        $tableSnapshot = @(
+            $fixture.Responses[(Get-ConvergenceTableMetadataPath `
+                    -LogicalName $table.logicalName `
+                    -RequestedAttributeLogicalNames @($table.columns.logicalName))].value
+        )[0]
+
+        Mock Get-TableMetadataSnapshot { $tableSnapshot }
+        Mock Assert-ConvergenceSolutionOwnership {}
+        Mock Test-LocalizedMetadataChanged { $false }
+        Mock Test-InsuranceFoundationTableColumn {
+            param($Table, $Column, $Snapshot)
+
+            New-ConvergenceResult `
+                -Component "$($Table.logicalName)/column/$($Column.logicalName)" `
+                -State 'Ready'
+        }
+        Mock Test-InsuranceFoundationOrdinaryRelationship {
+            param($Table, $Relationship, $Snapshot)
+
+            $state = if ([string]$Relationship.schemaName -eq
+                [string]$table.relationships[1].schemaName) {
+                'UnsupportedInTenant'
+            }
+            else {
+                'Ready'
+            }
+
+            New-ConvergenceResult `
+                -Component "$($Table.logicalName)/relationship/$($Relationship.schemaName)" `
+                -State $state `
+                -Details @(
+                    if ($state -eq 'UnsupportedInTenant') {
+                        'Synthetic unsupported relationship child.'
+                    }
+                )
+        }
+        Mock Test-InsuranceFoundationCustomerRelationship {
+            param($Table, $Column, $Snapshot)
+
+            New-ConvergenceResult `
+                -Component "$($Table.logicalName)/relationship/$($Column.logicalName)" `
+                -State 'Ready'
+        }
+        Mock Test-InsuranceFoundationAlternateKey {
+            param($EnvironmentUrl, $Table, $Key)
+
+            New-ConvergenceResult `
+                -Component "$($Table.logicalName)/key/$($Key.schemaName)" `
+                -State 'ContractConflict' `
+                -Details @('Synthetic later key conflict.')
+        }
+        Mock Test-InsuranceFoundationView {
+            param($EnvironmentUrl, $Table, $View, $ObjectTypeCode)
+
+            New-ConvergenceResult `
+                -Component "$($Table.logicalName)/view/$($View.name)" `
+                -State 'Ready'
+        }
+        Mock Test-InsuranceFoundationForm {
+            param($EnvironmentUrl, $Table, $Form)
+
+            New-ConvergenceResult `
+                -Component "$($Table.logicalName)/form/$($Form.name)" `
+                -State 'Ready'
+        }
+
+        $result = Test-InsuranceFoundationTable `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Table $table
+
+        $result.State | Should -Be 'UnsupportedInTenant'
+        @($result.Children | Where-Object {
+                $_.State -ne 'Ready'
+            } | ForEach-Object {
+                [string]$_.Component
+            }) | Should -Be @(
+                "$($table.logicalName)/relationship/$([string]$table.relationships[1].schemaName)",
+                "$($table.logicalName)/key/$([string]$table.alternateKeys[0].schemaName)"
+            )
+    }
+}
+
+Describe 'Unexpected metadata reverse inventory' {
+    It 'classifies an unexpected Foundation global choice as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $choiceId = script:New-FakeGuid -Index 9701
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_Foundation'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            [pscustomobject]@{
+                objectid      = $choiceId
+                componenttype = 9
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceGlobalChoiceByMetadataIdPath -MetadataId $choiceId)] =
+            [pscustomobject]@{
+                MetadataId   = $choiceId
+                Name         = 'crmshow_unexpectedchoice'
+                IsGlobal     = $true
+                OptionSetType = 'Picklist'
+            }
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_Foundation/choice/crmshow_unexpectedchoice'
+    }
+
+    It 'classifies an unexpected DataModel table as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $tableId = script:New-FakeGuid -Index 9702
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            [pscustomobject]@{
+                objectid      = $tableId
+                componenttype = 1
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceEntityByMetadataIdPath -MetadataId $tableId)] =
+            (script:New-EntityInventorySnapshot `
+                -MetadataId $tableId `
+                -LogicalName 'crmshow_unexpectedtable' `
+                -SchemaName 'crmshow_UnexpectedTable')
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/table/crmshow_unexpectedtable'
+    }
+
+    It 'classifies an unexpected custom column as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $table = $script:contract.tables[1]
+        $path = Get-ConvergenceTableUnexpectedChildrenPath `
+            -LogicalName $table.logicalName `
+            -PublisherPrefix (Get-ConvergencePublisherLogicalPrefix -Manifest $script:manifest)
+        $fixture.Responses[$path].Attributes = @(
+            $fixture.Responses[$path].Attributes +
+            [pscustomobject]@{
+                LogicalName  = 'crmshow_unexpectedcolumn'
+                SchemaName   = 'crmshow_UnexpectedColumn'
+                AttributeType = 'String'
+                AttributeOf  = $null
+            }
+        )
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain "$($table.logicalName)/column/crmshow_unexpectedcolumn"
+    }
+
+    It 'classifies an unexpected custom relationship as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $table = $script:contract.tables[2]
+        $path = Get-ConvergenceTableUnexpectedChildrenPath `
+            -LogicalName $table.logicalName `
+            -PublisherPrefix (Get-ConvergencePublisherLogicalPrefix -Manifest $script:manifest)
+        $fixture.Responses[$path].ManyToOneRelationships = @(
+            $fixture.Responses[$path].ManyToOneRelationships +
+            [pscustomobject]@{
+                SchemaName           = 'crmshow_UnexpectedRelationship'
+                ReferencedEntity     = 'account'
+                ReferencingEntity    = [string]$table.logicalName
+                ReferencingAttribute = 'crmshow_unexpectedrelationshipid'
+            }
+        )
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain "$($table.logicalName)/relationship/crmshow_UnexpectedRelationship"
+    }
+
+    It 'classifies an unexpected custom alternate key as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $table = $script:contract.tables[0]
+        $path = Get-ConvergenceTableUnexpectedChildrenPath `
+            -LogicalName $table.logicalName `
+            -PublisherPrefix (Get-ConvergencePublisherLogicalPrefix -Manifest $script:manifest)
+        $fixture.Responses[$path].Keys = @(
+            $fixture.Responses[$path].Keys +
+            [pscustomobject]@{
+                SchemaName    = 'crmshow_UnexpectedKey'
+                KeyAttributes = @('crmshow_name')
+            }
+        )
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain "$($table.logicalName)/key/crmshow_UnexpectedKey"
+    }
+
+    It 'classifies an unexpected solution-owned view as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $viewId = script:New-FakeGuid -Index 9703
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            [pscustomobject]@{
+                objectid      = $viewId
+                componenttype = 26
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
+            [pscustomobject]@{
+                savedqueryid     = $viewId
+                name             = 'Unexpected Policy Projection View'
+                description      = 'Unexpected custom view.'
+                returnedtypecode = 'crmshow_policyprojection'
+                fetchxml         = '<fetch version="1.0"><entity name="crmshow_policyprojection"><attribute name="crmshow_name" /></entity></fetch>'
+                layoutxml        = '<grid name="resultset" object="10428"><row name="crmshow_policyprojection" id="crmshow_policyprojectionid"><cell name="crmshow_name" width="150" /></row></grid>'
+            }
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/view/crmshow_policyprojection/Unexpected Policy Projection View'
+    }
+
+    It 'classifies an unexpected solution-owned form as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $formId = script:New-FakeGuid -Index 9704
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            [pscustomobject]@{
+                objectid      = $formId
+                componenttype = 60
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceSystemFormByIdPath -FormId $formId)] =
+            [pscustomobject]@{
+                formid         = $formId
+                name           = 'Unexpected Policy Projection Form'
+                description    = 'Unexpected custom form.'
+                objecttypecode = 'crmshow_policyprojection'
+                type           = 2
+                formxml        = '<form><tabs><tab name="general"><columns><column width="100%"><sections><section name="general"><rows><row><cell><control id="crmshow_name" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="crmshow_name" /></cell></row></rows></section></sections></column></columns></tab></tabs></form>'
+            }
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_DataModel/form/crmshow_policyprojection/Unexpected Policy Projection Form'
+    }
+
+    It 'classifies an additional CRM Showcase Insurance root role as ContractConflict' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $roleId = script:New-FakeGuid -Index 9705
+        $rolesPath = Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance '
+        $fixture.Responses[$rolesPath].value = @(
+            $fixture.Responses[$rolesPath].value +
+            [pscustomobject]@{
+                roleid = $roleId
+                name = 'CRM Showcase Insurance Escalation'
+                _parentrootroleid_value = $null
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceRoleByIdPath -RoleId $roleId)] = [pscustomobject]@{
+            roleid = $roleId
+            name = 'CRM Showcase Insurance Escalation'
+            _parentrootroleid_value = $null
+        }
+        $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $roleId)] =
+            script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_Foundation'
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Contain 'crmshow_Foundation/role/CRM Showcase Insurance Escalation'
+    }
+
+    It 'ignores system-generated table children and unrelated platform roles or views' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $publisherPrefix = Get-ConvergencePublisherLogicalPrefix -Manifest $script:manifest
+        $table = $script:contract.tables[2]
+        $tablePath = Get-ConvergenceTableUnexpectedChildrenPath `
+            -LogicalName $table.logicalName `
+            -PublisherPrefix $publisherPrefix
+        $fixture.Responses[$tablePath].Attributes = @(
+            $fixture.Responses[$tablePath].Attributes +
+            [pscustomobject]@{
+                LogicalName  = "$($table.logicalName)id"
+                SchemaName   = "$($table.schemaName)Id"
+                AttributeType = 'Uniqueidentifier'
+                AttributeOf  = $null
+            } +
+            [pscustomobject]@{
+                LogicalName  = 'crmshow_partyidname'
+                SchemaName   = 'crmshow_PartyIdName'
+                AttributeType = 'String'
+                AttributeOf  = 'crmshow_partyid'
+            }
+        )
+
+        $rolesPath = Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance '
+        $fixture.Responses[$rolesPath].value = @(
+            $fixture.Responses[$rolesPath].value +
+            [pscustomobject]@{
+                roleid = script:New-FakeGuid -Index 9706
+                name = 'System Administrator'
+                _parentrootroleid_value = $null
+            }
+        )
+
+        $viewId = script:New-FakeGuid -Index 9707
+        $formId = script:New-FakeGuid -Index 9708
+        $inventoryPath = Get-ConvergenceSolutionInventoryPath `
+            -SolutionId $fixture.SolutionIds['crmshow_DataModel'] `
+            -ComponentType (Get-ConvergenceReverseInventoryComponentTypes)
+        $fixture.Responses[$inventoryPath].value = @(
+            $fixture.Responses[$inventoryPath].value +
+            [pscustomobject]@{
+                objectid      = $viewId
+                componenttype = 26
+            } +
+            [pscustomobject]@{
+                objectid      = $formId
+                componenttype = 60
+            }
+        )
+        $fixture.Responses[(Get-ConvergenceSavedQueryByIdPath -SavedQueryId $viewId)] =
+            [pscustomobject]@{
+                savedqueryid     = $viewId
+                name             = 'Active Cases'
+                description      = 'Platform case view.'
+                returnedtypecode = 'incident'
+                fetchxml         = '<fetch version="1.0"><entity name="incident"><attribute name="title" /></entity></fetch>'
+                layoutxml        = '<grid name="resultset" object="112"><row name="incident" id="incidentid"><cell name="title" width="150" /></row></grid>'
+            }
+        $fixture.Responses[(Get-ConvergenceSystemFormByIdPath -FormId $formId)] =
+            [pscustomobject]@{
+                formid         = $formId
+                name           = 'Case Main'
+                description    = 'Platform case form.'
+                objecttypecode = 'incident'
+                type           = 2
+                formxml        = '<form><tabs><tab name="general"><columns><column width="100%"><sections><section name="general"><rows><row><cell><control id="title" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}" datafieldname="title" /></cell></row></rows></section></sections></column></columns></tab></tabs></form>'
+            }
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Ready'
+        @($result.Unexpected) | Should -Be @()
+    }
+}
+
 Describe 'Invoke-InsuranceFoundationConvergence' {
     BeforeEach {
         Mock Invoke-PlannedRequest {}
@@ -1613,6 +2263,7 @@ Describe 'Invoke-InsuranceFoundationConvergence' {
         @($result.Results.Component) | Should -Contain 'account/crmshow_accounttype'
         @($result.Results.Component) | Should -Contain 'crmshow_policyprojection'
         @($result.Results.Component) | Should -Contain 'roles'
+        @($result.Results.Component) | Should -Contain 'unexpectedMetadata'
         @($result.Results.Component) | Should -Be (
             @('languages', 'solutions') +
             @($script:contract.choices | ForEach-Object {
@@ -1624,7 +2275,7 @@ Describe 'Invoke-InsuranceFoundationConvergence' {
             @($script:contract.tables | ForEach-Object {
                     [string]$_.logicalName
                 }) +
-            @('roles')
+            @('roles', 'unexpectedMetadata')
         )
 
         $policyProjection = @($result.Results | Where-Object {
@@ -1712,6 +2363,21 @@ Describe 'Convergence direct entry point' {
         $result.State | Should -Be 'ContractConflict'
         @($result.Results | Where-Object {
                 $_.Component -eq 'roles' -and $_.State -eq 'ContractConflict'
+            }).Count | Should -Be 1
+    }
+
+    It 'emits classified unsupported JSON and exits two when GET-only localization is unavailable' {
+        $invocation = script:Invoke-ConvergenceEntryScript -Scenario RetrieveLocLabelsUnsupported
+
+        $invocation.ExitCode | Should -Be 2
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'UnsupportedInTenant'
+        @($result.Results | Where-Object {
+                $_.Component -eq 'crmshow_accountcontactrole' -and
+                $_.State -eq 'UnsupportedInTenant'
             }).Count | Should -Be 1
     }
 

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -283,9 +283,15 @@ switch ($path) {
     "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
         $roles = @()
         if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -ne 'MissingRole') {
+            $resolvedRoleName = if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -eq 'LowerCaseRoleName') {
+                'crm showcase insurance data steward'
+            }
+            else {
+                'CRM Showcase Insurance Data Steward'
+            }
             $roles += [pscustomobject]@{
                 roleid = $stewardRoleId
-                name = 'CRM Showcase Insurance Data Steward'
+                name = $resolvedRoleName
             }
         }
         Write-Json ([pscustomobject]@{ value = @($roles) })
@@ -412,7 +418,7 @@ switch ($path) {
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [ValidateSet('Ready', 'MissingRole')]
+            [ValidateSet('Ready', 'MissingRole', 'LowerCaseRoleName')]
             [string]$Scenario
         )
 
@@ -758,6 +764,27 @@ Describe 'Test-InsuranceSecurityRole' {
         )
     }
 
+    It 'returns ContractConflict when the root-role query resolves only a case-insensitive name match' {
+        $resolvedRoleName = $script:role.name.ToLowerInvariant()
+        $script:rootRoleItems = @([pscustomobject]@{
+                roleid = $script:roleId
+                name = $resolvedRoleName
+            })
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Root security role query for contract name '$($script:role.name)' returned name '$resolvedRoleName'; exact case-sensitive identity match is required."
+        )
+        @($script:calls.Path) | Should -Be @(
+            Get-InsuranceSecurityRolePath -RoleName $script:role.name
+        )
+    }
+
     It 'returns ContractConflict when the role is not owned by its declared solution' {
         $script:solutionNames = @('crmshow_DataModel')
 
@@ -953,6 +980,27 @@ Describe 'Security-role verifier direct entry point' {
         $result.MutationOccurred | Should -BeFalse
         @($result.Results | Where-Object State -eq 'ManualPrerequisite').Count |
             Should -Be 1
+    }
+
+    It 'emits classified non-ready JSON and exits two when the root-role query returns lower-case name only' {
+        $invocation = script:Invoke-SecurityRolesEntryScript -Scenario LowerCaseRoleName
+
+        $invocation.ExitCode | Should -Be 2
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Results | Where-Object {
+                $_.Role -eq 'CRM Showcase Insurance Data Steward' -and
+                $_.State -eq 'ContractConflict'
+            }).Count | Should -Be 1
+        @($result.Results | Where-Object {
+                $_.Role -eq 'CRM Showcase Insurance Data Steward' -and
+                @($_.Details) -contains (
+                    "Root security role query for contract name 'CRM Showcase Insurance Data Steward' returned name 'crm showcase insurance data steward'; exact case-sensitive identity match is required."
+                )
+            }).Count | Should -Be 1
     }
 }
 

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -1,0 +1,969 @@
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:contractPath = Join-Path $script:repoRoot 'solution/schema/insurance-foundation.json'
+    $script:verifierPath = Join-Path $script:repoRoot 'scripts/solution/Test-InsuranceSecurityRoles.ps1'
+    $script:childPowerShellPath = if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+        (Get-Command pwsh -ErrorAction Stop).Source
+    }
+    else {
+        (Get-Command powershell -ErrorAction Stop).Source
+    }
+    . $script:verifierPath -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath $script:contractPath
+    $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+
+    function script:Clone-Object {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $InputObject
+        )
+
+        return $InputObject | ConvertTo-Json -Depth 100 | ConvertFrom-Json
+    }
+
+    function script:Get-SchemaMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $map = @{
+            account = 'Account'
+            contact = 'Contact'
+        }
+
+        foreach ($table in @($Contract.tables)) {
+            $map[[string]$table.logicalName] = [string]$table.schemaName
+        }
+
+        return $map
+    }
+
+    function script:Get-MetadataPrivilegeMap {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $schemaMap = script:Get-SchemaMap -Contract $Contract
+        $map = @{}
+
+        foreach ($role in @($Contract.roles)) {
+            foreach ($tablePrivilege in @($role.tablePrivileges)) {
+                $logicalName = [string]$tablePrivilege.table
+                if (-not $map.ContainsKey($logicalName)) {
+                    $map[$logicalName] = @()
+                }
+
+                $schemaName = [string]$schemaMap[$logicalName]
+                foreach ($verb in @($tablePrivilege.privileges)) {
+                    $map[$logicalName] += [pscustomobject]@{
+                        Name = "prv$verb$schemaName"
+                        PrivilegeId = "$logicalName-$verb"
+                    }
+                }
+            }
+        }
+
+        foreach ($logicalName in @($map.Keys)) {
+            $unique = @()
+            foreach ($privilege in @($map[$logicalName])) {
+                if (@($unique.Name | Where-Object { $_ -ceq $privilege.Name }).Count -gt 0) {
+                    continue
+                }
+
+                $unique += $privilege
+            }
+
+            $map[$logicalName] = @($unique)
+        }
+
+        return $map
+    }
+
+    function script:Get-ExpectedPrivilegesForRole {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Role,
+
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        $schemaMap = script:Get-SchemaMap -Contract $Contract
+        $expected = foreach ($tablePrivilege in @($Role.tablePrivileges)) {
+            $schemaName = [string]$schemaMap[[string]$tablePrivilege.table]
+            foreach ($verb in @($tablePrivilege.privileges)) {
+                [pscustomobject]@{
+                    Name = "prv$verb$schemaName"
+                    PrivilegeId = "$($tablePrivilege.table)-$verb"
+                    Depth = 'Global'
+                }
+            }
+        }
+
+        return @($expected)
+    }
+
+    function script:Get-ActualRolePrivileges {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            $Role,
+
+            [Parameter(Mandatory)]
+            $Contract
+        )
+
+        return @(
+            script:Get-ExpectedPrivilegesForRole -Role $Role -Contract $Contract |
+                ForEach-Object {
+                    [pscustomobject]@{
+                        PrivilegeName = $_.Name
+                        PrivilegeId = $_.PrivilegeId
+                        Depth = $_.Depth
+                    }
+                }
+        )
+    }
+
+    function script:New-SecurityRolesEntryContract {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath
+        )
+
+        $contract = [ordered]@{
+            tables = @(
+                [ordered]@{
+                    logicalName = 'crmshow_policyprojection'
+                    schemaName = 'crmshow_PolicyProjection'
+                }
+            )
+            roles = @(
+                [ordered]@{
+                    name = 'CRM Showcase Insurance Reader'
+                    solution = 'crmshow_Foundation'
+                    tablePrivileges = @(
+                        [ordered]@{
+                            table = 'account'
+                            depth = 'Organization'
+                            privileges = @('Read')
+                        },
+                        [ordered]@{
+                            table = 'crmshow_policyprojection'
+                            depth = 'Organization'
+                            privileges = @('Read')
+                        }
+                    )
+                    deniedPrivileges = @(
+                        'Delete', 'Assign', 'Share', 'Customize',
+                        'SecurityAdministration', 'BulkDelete',
+                        'AuditAdministration'
+                    )
+                },
+                [ordered]@{
+                    name = 'CRM Showcase Insurance Data Steward'
+                    solution = 'crmshow_Foundation'
+                    tablePrivileges = @(
+                        [ordered]@{
+                            table = 'account'
+                            depth = 'Organization'
+                            privileges = @('Read')
+                        },
+                        [ordered]@{
+                            table = 'crmshow_policyprojection'
+                            depth = 'Organization'
+                            privileges = @('Create', 'Read', 'Write')
+                        }
+                    )
+                    deniedPrivileges = @(
+                        'Delete', 'Assign', 'Share', 'Customize',
+                        'SecurityAdministration', 'BulkDelete',
+                        'AuditAdministration'
+                    )
+                }
+            )
+        }
+
+        $path = Join-Path $RootPath 'insurance-security-roles-entry-contract.json'
+        Set-Content -LiteralPath $path `
+            -Value ($contract | ConvertTo-Json -Depth 20) `
+            -Encoding UTF8
+        return $path
+    }
+
+    function script:New-SecurityRolesAzShim {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$RootPath
+        )
+
+        $shimScriptPath = Join-Path $RootPath 'az.ps1'
+        $shimCommandPath = Join-Path $RootPath 'az'
+
+        $shimScript = @'
+#!/usr/bin/env pwsh
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ArgumentValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$InputArguments,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $index = [Array]::IndexOf($InputArguments, $Name)
+    if ($index -lt 0 -or $index -ge ($InputArguments.Count - 1)) {
+        throw "Missing required argument: $Name"
+    }
+
+    return $InputArguments[$index + 1]
+}
+
+function Write-Json {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Value
+    )
+
+    $Value | ConvertTo-Json -Compress -Depth 20
+}
+
+$method = Get-ArgumentValue -InputArguments $Arguments -Name '--method'
+if ($method -cne 'get') {
+    Write-Error "Unexpected method: $method"
+    exit 1
+}
+
+$resource = Get-ArgumentValue -InputArguments $Arguments -Name '--resource'
+if ($resource -cne 'https://unit.crm.dynamics.com/') {
+    Write-Error "Unexpected resource URL: $resource"
+    exit 1
+}
+
+$url = Get-ArgumentValue -InputArguments $Arguments -Name '--url'
+$prefix = '/api/data/v9.2'
+$prefixIndex = $url.IndexOf($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+if ($prefixIndex -ge 0) {
+    $path = $url.Substring($prefixIndex + $prefix.Length)
+}
+else {
+    $path = $url
+}
+
+$readerRoleId = '11111111-1111-1111-1111-111111111111'
+$stewardRoleId = '22222222-2222-2222-2222-222222222222'
+
+switch ($path) {
+    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Reader'" {
+        Write-Json ([pscustomobject]@{
+                value = @([pscustomobject]@{
+                        roleid = $readerRoleId
+                        name = 'CRM Showcase Insurance Reader'
+                    })
+            })
+        exit 0
+    }
+    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
+        $roles = @()
+        if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -ne 'MissingRole') {
+            $roles += [pscustomobject]@{
+                roleid = $stewardRoleId
+                name = 'CRM Showcase Insurance Data Steward'
+            }
+        }
+        Write-Json ([pscustomobject]@{ value = @($roles) })
+        exit 0
+    }
+    "/solutioncomponents?`$select=solutioncomponentid&`$filter=objectid eq $readerRoleId&`$expand=solutionid(`$select=uniquename)" {
+        Write-Json ([pscustomobject]@{
+                value = @([pscustomobject]@{
+                        solutionid = [pscustomobject]@{
+                            uniquename = 'crmshow_Foundation'
+                        }
+                    })
+            })
+        exit 0
+    }
+    "/solutioncomponents?`$select=solutioncomponentid&`$filter=objectid eq $stewardRoleId&`$expand=solutionid(`$select=uniquename)" {
+        Write-Json ([pscustomobject]@{
+                value = @([pscustomobject]@{
+                        solutionid = [pscustomobject]@{
+                            uniquename = 'crmshow_Foundation'
+                        }
+                    })
+            })
+        exit 0
+    }
+    "/EntityDefinitions(LogicalName='account')?`$select=LogicalName,SchemaName,Privileges" {
+        Write-Json ([pscustomobject]@{
+                LogicalName = 'account'
+                SchemaName = 'Account'
+                Privileges = @([pscustomobject]@{
+                        Name = 'prvReadAccount'
+                        PrivilegeId = 'account-read'
+                    })
+            })
+        exit 0
+    }
+    "/EntityDefinitions(LogicalName='crmshow_policyprojection')?`$select=LogicalName,SchemaName,Privileges" {
+        Write-Json ([pscustomobject]@{
+                LogicalName = 'crmshow_policyprojection'
+                SchemaName = 'crmshow_PolicyProjection'
+                Privileges = @(
+                    [pscustomobject]@{
+                        Name = 'prvCreatecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-create'
+                    },
+                    [pscustomobject]@{
+                        Name = 'prvReadcrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-read'
+                    },
+                    [pscustomobject]@{
+                        Name = 'prvWritecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-write'
+                    }
+                )
+            })
+        exit 0
+    }
+    "/RetrieveRolePrivilegesRole(RoleId=$readerRoleId)" {
+        Write-Json ([pscustomobject]@{
+                RolePrivileges = @(
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadAccount'
+                        PrivilegeId = 'account-read'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadcrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-read'
+                        Depth = 'Global'
+                    }
+                )
+            })
+        exit 0
+    }
+    "/RetrieveRolePrivilegesRole(RoleId=$stewardRoleId)" {
+        Write-Json ([pscustomobject]@{
+                RolePrivileges = @(
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadAccount'
+                        PrivilegeId = 'account-read'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvCreatecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-create'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvReadcrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-read'
+                        Depth = 'Global'
+                    },
+                    [pscustomobject]@{
+                        PrivilegeName = 'prvWritecrmshow_PolicyProjection'
+                        PrivilegeId = 'policy-write'
+                        Depth = 'Global'
+                    }
+                )
+            })
+        exit 0
+    }
+    default {
+        Write-Error "Unexpected az rest URL: $url"
+        exit 1
+    }
+}
+'@
+
+        $shimScript = $shimScript -replace "`r`n", "`n"
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+        [System.IO.File]::WriteAllText($shimScriptPath, $shimScript, $utf8NoBom)
+        [System.IO.File]::WriteAllText($shimCommandPath, $shimScript, $utf8NoBom)
+
+        if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
+            & chmod +x -- $shimCommandPath
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to make az shim executable: $shimCommandPath"
+            }
+        }
+    }
+
+    function script:Invoke-SecurityRolesEntryScript {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [ValidateSet('Ready', 'MissingRole')]
+            [string]$Scenario
+        )
+
+        $testRoot = Join-Path (Get-PSDrive -Name TestDrive).Root ([guid]::NewGuid().Guid)
+        $null = New-Item -ItemType Directory -Path $testRoot -Force
+
+        $contractPath = script:New-SecurityRolesEntryContract -RootPath $testRoot
+        script:New-SecurityRolesAzShim -RootPath $testRoot
+
+        $previousPath = $env:PATH
+        $previousScenario = [Environment]::GetEnvironmentVariable(
+            'TEST_INSURANCE_SECURITY_ROLES_SCENARIO',
+            'Process'
+        )
+
+        try {
+            $pathSeparator = [System.IO.Path]::PathSeparator
+            $env:PATH = if ([string]::IsNullOrEmpty($previousPath)) {
+                $testRoot
+            }
+            else {
+                "$testRoot$pathSeparator$previousPath"
+            }
+            $env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO = $Scenario
+
+            $output = & $script:childPowerShellPath `
+                -NoLogo `
+                -NoProfile `
+                -NonInteractive `
+                -File $script:verifierPath `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -ContractPath $contractPath 2>&1
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            $env:PATH = $previousPath
+            if ($null -eq $previousScenario) {
+                Remove-Item Env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO `
+                    -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO = $previousScenario
+            }
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output = (@($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine).Trim()
+        }
+    }
+}
+
+Describe 'Invoke-InsuranceSecurityRoleDataverseRequest' {
+    AfterEach {
+        Remove-Item Function:\az -ErrorAction SilentlyContinue
+    }
+
+    It 'rejects non-GET methods' {
+        {
+            Invoke-InsuranceSecurityRoleDataverseRequest `
+                -Method POST `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -Path '/roles'
+        } | Should -Throw
+    }
+
+    It 'uses az rest GET against Dataverse v9.2 and parses JSON' {
+        $script:azArguments = @()
+        function global:az {
+            $script:azArguments = @($args)
+            $global:LASTEXITCODE = 0
+            '{"value":[{"roleid":"11111111-1111-1111-1111-111111111111","name":"Reader"}]}'
+        }
+
+        $result = Invoke-InsuranceSecurityRoleDataverseRequest `
+            -Method GET `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Path '/roles'
+
+        $result.value[0].roleid | Should -Be '11111111-1111-1111-1111-111111111111'
+        $script:azArguments | Should -Be @(
+            'rest',
+            '--method', 'get',
+            '--url', 'https://unit.crm.dynamics.com/api/data/v9.2/roles',
+            '--resource', 'https://unit.crm.dynamics.com/',
+            '--only-show-errors'
+        )
+    }
+
+    It 'throws a transport error with the GET path and az output on nonzero exit' {
+        function global:az {
+            $global:LASTEXITCODE = 9
+            'Permission denied'
+        }
+
+        {
+            Invoke-InsuranceSecurityRoleDataverseRequest `
+                -Method GET `
+                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                -Path '/roles'
+        } | Should -Throw '*GET /roles*Permission denied*'
+    }
+}
+
+Describe 'Compare-InsuranceRolePrivileges' {
+    It 'reports Ready when exact privileges and depth match' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                }) `
+            -Actual @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                })
+
+        $result.State | Should -Be 'Ready'
+        @($result.Missing) | Should -Be @()
+        @($result.Unexpected) | Should -Be @()
+        @($result.WrongDepth) | Should -Be @()
+    }
+
+    It 'reports missing expected privileges' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @(
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvReadContact'; Depth = 'Global' }
+            ) `
+            -Actual @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                })
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Missing) | Should -Be @('prvReadContact')
+    }
+
+    It 'fails closed for an unexpected privilege' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                }) `
+            -Actual @(
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvDeleteAccount'; Depth = 'Global' }
+            )
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Unexpected) | Should -Be @('prvDeleteAccount')
+    }
+
+    It 'reports wrong depth per privilege entry' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                }) `
+            -Actual @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Local'
+                })
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.WrongDepth).Count | Should -Be 1
+        $result.WrongDepth[0].Name | Should -Be 'prvReadAccount'
+        $result.WrongDepth[0].ExpectedDepth | Should -Be 'Global'
+        $result.WrongDepth[0].ActualDepth | Should -Be 'Local'
+    }
+
+    It 'treats duplicate actual privilege names as a conflict' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                }) `
+            -Actual @(
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' }
+            )
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.DuplicateActual) | Should -Be @('prvReadAccount')
+    }
+
+    It 'treats duplicate expected privilege names as a conflict' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @(
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' }
+            ) `
+            -Actual @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                })
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.DuplicateExpected) | Should -Be @('prvReadAccount')
+    }
+}
+
+Describe 'OData query helpers' {
+    It 'escapes root role names and enforces the root-role predicate' {
+        Get-InsuranceSecurityRolePath -RoleName "Reader's Role" |
+            Should -Be (
+                "/roles?`$select=roleid,name&" +
+                "`$filter=_parentrootroleid_value eq null and name eq 'Reader''s Role'"
+            )
+    }
+
+    It 'escapes logical names for entity privilege metadata lookup' {
+        Get-InsuranceRoleEntityPrivilegesPath -LogicalName "crmshow_o'reilly" |
+            Should -Be (
+                "/EntityDefinitions(LogicalName='crmshow_o''reilly')?" +
+                "`$select=LogicalName,SchemaName,Privileges"
+            )
+    }
+}
+
+Describe 'Test-InsuranceSecurityRole' {
+    BeforeEach {
+        $script:calls = [System.Collections.Generic.List[object]]::new()
+        $script:role = script:Clone-Object -InputObject $script:contract.roles[1]
+        $script:roleId = '22222222-2222-2222-2222-222222222222'
+        $script:schemaMap = script:Get-SchemaMap -Contract $script:contract
+        $script:metadataPrivileges = script:Get-MetadataPrivilegeMap -Contract $script:contract
+        $script:actualPrivileges = script:Get-ActualRolePrivileges `
+            -Role $script:role `
+            -Contract $script:contract
+        $script:rootRoleItems = @([pscustomobject]@{
+                roleid = $script:roleId
+                name = $script:role.name
+            })
+        $script:solutionNames = @($script:role.solution)
+
+        Mock Invoke-InsuranceSecurityRoleDataverseRequest {
+            param($EnvironmentUrl, $Method, $Path)
+
+            [void]$script:calls.Add([pscustomobject]@{
+                    EnvironmentUrl = $EnvironmentUrl
+                    Method = $Method
+                    Path = $Path
+                })
+
+            if ($Method -eq 'GET' -and $Path -like '/roles?*') {
+                return [pscustomobject]@{ value = @($script:rootRoleItems) }
+            }
+            if ($Method -eq 'GET' -and $Path -like '/solutioncomponents?*') {
+                return [pscustomobject]@{
+                    value = @($script:solutionNames | ForEach-Object {
+                            [pscustomobject]@{
+                                solutionid = [pscustomobject]@{
+                                    uniquename = $_
+                                }
+                            }
+                        })
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path.StartsWith("/EntityDefinitions(LogicalName='", [System.StringComparison]::Ordinal)) {
+                $logicalName = [regex]::Match(
+                    $Path,
+                    "^/EntityDefinitions\(LogicalName='((?:[^']|'')*)'\)"
+                ).Groups[1].Value.Replace("''", "'")
+                return [pscustomobject]@{
+                    LogicalName = $logicalName
+                    SchemaName = [string]$script:schemaMap[$logicalName]
+                    Privileges = @($script:metadataPrivileges[$logicalName])
+                }
+            }
+            if ($Method -eq 'GET' -and
+                $Path -eq "/RetrieveRolePrivilegesRole(RoleId=$($script:roleId))") {
+                return [pscustomobject]@{
+                    RolePrivileges = @($script:actualPrivileges)
+                }
+            }
+
+            throw "Unexpected mocked verifier path: $Path"
+        }
+    }
+
+    It 'returns Ready for exact ownership and privilege matches with GET-only transport' {
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.Role | Should -Be $script:role.name
+        $result.State | Should -Be 'Ready'
+        @($result.Missing) | Should -Be @()
+        @($result.Unexpected) | Should -Be @()
+        @($result.WrongDepth) | Should -Be @()
+        @($result.DuplicateExpected) | Should -Be @()
+        @($result.DuplicateActual) | Should -Be @()
+
+        $expectedGetCalls = @($script:role.tablePrivileges).Count + 3
+        Should -Invoke Invoke-InsuranceSecurityRoleDataverseRequest -Times $expectedGetCalls -Exactly `
+            -ParameterFilter { $Method -eq 'GET' }
+        Should -Invoke Invoke-InsuranceSecurityRoleDataverseRequest -Times 0 -Exactly `
+            -ParameterFilter { $Method -ne 'GET' }
+        @($script:calls.Path | Where-Object {
+                $_ -match '(?i)(SetLocLabels|AddPrivilegesRole|ReplacePrivilegesRole|/roles$)'
+            }) | Should -BeNullOrEmpty
+    }
+
+    It 'returns ManualPrerequisite when the root role is missing' {
+        $script:rootRoleItems = @()
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ManualPrerequisite'
+        @($result.Details) | Should -Contain (
+            "Root security role '$($script:role.name)' was not found."
+        )
+        @($script:calls.Path) | Should -Be @(
+            Get-InsuranceSecurityRolePath -RoleName $script:role.name
+        )
+    }
+
+    It 'returns ContractConflict when multiple root roles match the same name' {
+        $script:rootRoleItems = @(
+            [pscustomobject]@{ roleid = '1'; name = $script:role.name },
+            [pscustomobject]@{ roleid = '2'; name = $script:role.name }
+        )
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Expected exactly one root security role named '$($script:role.name)', found 2."
+        )
+    }
+
+    It 'returns ContractConflict when the role is not owned by its declared solution' {
+        $script:solutionNames = @('crmshow_DataModel')
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Role '$($script:role.name)' is not a member of solution '$($script:role.solution)'."
+        )
+    }
+
+    It 'resolves exact privilege metadata with case-sensitive schema names' {
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
+        Should -Invoke Invoke-InsuranceSecurityRoleDataverseRequest -Times 1 -Exactly -ParameterFilter {
+            $Path -eq (
+                "/EntityDefinitions(LogicalName='crmshow_policyprojection')?" +
+                "`$select=LogicalName,SchemaName,Privileges"
+            )
+        }
+    }
+
+    It 'fails closed when Dataverse returns a schema name with different casing' {
+        $script:schemaMap['crmshow_policyprojection'] = 'crmshow_policyprojection'
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Dataverse metadata for table 'crmshow_policyprojection' did not return contract schema name 'crmshow_PolicyProjection'."
+        )
+    }
+
+    It 'fails closed when the contract requests an unsupported depth' {
+        $role = script:Clone-Object -InputObject $script:role
+        $role.tablePrivileges[0].depth = 'BusinessUnit'
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Unsupported contract privilege depth 'BusinessUnit' for role '$($role.name)' table 'account'."
+        )
+    }
+
+    It 'fails closed when deniedPrivileges overlap requested verbs before transport' {
+        $role = script:Clone-Object -InputObject $script:role
+        $role.deniedPrivileges = @('Read')
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Role '$($role.name)' deniedPrivileges overlap requested privilege verbs: Read."
+        )
+        Should -Invoke Invoke-InsuranceSecurityRoleDataverseRequest -Times 0 -Exactly
+    }
+}
+
+Describe 'Invoke-InsuranceSecurityRoleVerification' {
+    It 'returns one result per contract role, overall Ready, and MutationOccurred false' {
+        Mock Test-InsuranceSecurityRole {
+            param($EnvironmentUrl, $Role, $Contract)
+
+            [pscustomobject]@{
+                Role = [string]$Role.name
+                State = 'Ready'
+                Missing = @()
+                Unexpected = @()
+                WrongDepth = @()
+                DuplicateExpected = @()
+                DuplicateActual = @()
+                Details = @()
+            }
+        }
+
+        $result = Invoke-InsuranceSecurityRoleVerification `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
+        $result.MutationOccurred | Should -BeFalse
+        @($result.Results.Role) | Should -Be @($script:contract.roles.name)
+        Should -Invoke Test-InsuranceSecurityRole -Times @($script:contract.roles).Count -Exactly
+    }
+
+    It 'prefers ManualPrerequisite overall when any contract role is missing' {
+        Mock Test-InsuranceSecurityRole {
+            param($EnvironmentUrl, $Role, $Contract)
+
+            if ($Role.name -eq 'CRM Showcase Insurance Reader') {
+                return [pscustomobject]@{
+                    Role = [string]$Role.name
+                    State = 'Ready'
+                    Missing = @()
+                    Unexpected = @()
+                    WrongDepth = @()
+                    DuplicateExpected = @()
+                    DuplicateActual = @()
+                    Details = @()
+                }
+            }
+
+            return [pscustomobject]@{
+                Role = [string]$Role.name
+                State = 'ManualPrerequisite'
+                Missing = @()
+                Unexpected = @()
+                WrongDepth = @()
+                DuplicateExpected = @()
+                DuplicateActual = @()
+                Details = @('missing')
+            }
+        }
+
+        $result = Invoke-InsuranceSecurityRoleVerification `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ManualPrerequisite'
+    }
+
+    It 'returns ContractConflict overall when no role is missing but one conflicts' {
+        Mock Test-InsuranceSecurityRole {
+            param($EnvironmentUrl, $Role, $Contract)
+
+            $state = if ($Role.name -eq 'CRM Showcase Insurance Reader') {
+                'ContractConflict'
+            }
+            else {
+                'Ready'
+            }
+
+            return [pscustomobject]@{
+                Role = [string]$Role.name
+                State = $state
+                Missing = @()
+                Unexpected = @()
+                WrongDepth = @()
+                DuplicateExpected = @()
+                DuplicateActual = @()
+                Details = @()
+            }
+        }
+
+        $result = Invoke-InsuranceSecurityRoleVerification `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+    }
+}
+
+Describe 'Security-role verifier direct entry point' {
+    It 'emits ready JSON and exits zero when verification is Ready' {
+        $invocation = script:Invoke-SecurityRolesEntryScript -Scenario Ready
+
+        $invocation.ExitCode | Should -Be 0
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'Ready'
+        $result.MutationOccurred | Should -BeFalse
+        @($result.Results).Count | Should -Be 2
+    }
+
+    It 'emits classified non-ready JSON and exits two when a root role is missing' {
+        $invocation = script:Invoke-SecurityRolesEntryScript -Scenario MissingRole
+
+        $invocation.ExitCode | Should -Be 2
+        { $invocation.Output | ConvertFrom-Json -ErrorAction Stop } |
+            Should -Not -Throw
+
+        $result = $invocation.Output | ConvertFrom-Json -ErrorAction Stop
+        $result.State | Should -Be 'ManualPrerequisite'
+        $result.MutationOccurred | Should -BeFalse
+        @($result.Results | Where-Object State -eq 'ManualPrerequisite').Count |
+            Should -Be 1
+    }
+}
+
+Describe 'Security-role verifier entry point safety' {
+    It 'does not invoke az when dot-sourced with unit arguments' {
+        $text = @'
+function az { throw 'az was called' }
+. '__SCRIPT__' -EnvironmentUrl 'https://unit.crm.dynamics.com' -ContractPath '__CONTRACT__'
+'@.Replace('__SCRIPT__', $script:verifierPath.Replace("'", "''")).
+            Replace('__CONTRACT__', $script:contractPath.Replace("'", "''"))
+
+        & ([scriptblock]::Create($text))
+    }
+}

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -153,6 +153,7 @@ BeforeAll {
         )
 
         $contract = [ordered]@{
+            solutions = @('crmshow_Foundation', 'crmshow_DataModel')
             tables = @(
                 [ordered]@{
                     logicalName = 'crmshow_policyprojection'
@@ -837,7 +838,7 @@ Describe 'Test-InsuranceSecurityRole' {
         )
     }
 
-    It 'returns ContractConflict when the role is not owned by its declared solution' {
+    It 'returns ContractConflict when the expected reviewed solution membership is missing' {
         $script:solutionNames = @('crmshow_DataModel')
 
         $result = Test-InsuranceSecurityRole `
@@ -847,7 +848,21 @@ Describe 'Test-InsuranceSecurityRole' {
 
         $result.State | Should -Be 'ContractConflict'
         @($result.Details) | Should -Contain (
-            "Role '$($script:role.name)' is not a member of solution '$($script:role.solution)'."
+            "Role '$($script:role.name)' reviewed-solution membership expected '$($script:role.solution)'; actual reviewed membership was 'crmshow_DataModel'."
+        )
+    }
+
+    It 'returns ContractConflict when the role is in an extra reviewed solution' {
+        $script:solutionNames = @('crmshow_Foundation', 'crmshow_DataModel')
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'ContractConflict'
+        @($result.Details) | Should -Contain (
+            "Role '$($script:role.name)' reviewed-solution membership expected '$($script:role.solution)'; actual reviewed membership was 'crmshow_Foundation, crmshow_DataModel'."
         )
     }
 

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -12,6 +12,20 @@ BeforeAll {
     $script:contract = Get-Content -LiteralPath $script:contractPath -Raw -Encoding UTF8 |
         ConvertFrom-Json
 
+    function script:Assert-SafeDiagnosticLine {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string]$Text,
+
+            [int]$MaxLength = 600
+        )
+
+        $Text | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
+        $Text | Should -Not -Match '(^|[\r\n])::'
+        $Text.Length | Should -BeLessThan ($MaxLength + 1)
+    }
+
     function script:Clone-Object {
         [CmdletBinding()]
         param(
@@ -267,6 +281,15 @@ else {
     $path = $url
 }
 
+$escape = [char]27
+if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -eq 'TransportFailure') {
+    Write-Error (
+        "::warning::security roles transport`r`nPermission denied`t" +
+        "$escape[31mblocked$escape[0m"
+    ) -ErrorAction Continue
+    exit 9
+}
+
 $readerRoleId = '11111111-1111-1111-1111-111111111111'
 $stewardRoleId = '22222222-2222-2222-2222-222222222222'
 
@@ -418,7 +441,7 @@ switch ($path) {
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [ValidateSet('Ready', 'MissingRole', 'LowerCaseRoleName')]
+            [ValidateSet('Ready', 'MissingRole', 'LowerCaseRoleName', 'TransportFailure')]
             [string]$Scenario
         )
 
@@ -444,14 +467,21 @@ switch ($path) {
             }
             $env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO = $Scenario
 
-            $output = & $script:childPowerShellPath `
-                -NoLogo `
-                -NoProfile `
-                -NonInteractive `
-                -File $script:verifierPath `
-                -EnvironmentUrl 'https://unit.crm.dynamics.com' `
-                -ContractPath $contractPath 2>&1
-            $exitCode = $LASTEXITCODE
+            $previousErrorActionPreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            try {
+                $output = & $script:childPowerShellPath `
+                    -NoLogo `
+                    -NoProfile `
+                    -NonInteractive `
+                    -File $script:verifierPath `
+                    -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+                    -ContractPath $contractPath 2>&1
+                $exitCode = $LASTEXITCODE
+            }
+            finally {
+                $ErrorActionPreference = $previousErrorActionPreference
+            }
         }
         finally {
             $env:PATH = $previousPath
@@ -508,18 +538,40 @@ Describe 'Invoke-InsuranceSecurityRoleDataverseRequest' {
         )
     }
 
-    It 'throws a transport error with the GET path and az output on nonzero exit' {
+    It 'sanitizes hostile az output on nonzero exit' {
+        $escape = [char]27
         function global:az {
+            Write-Error (
+                "::warning::security roles transport`r`nPermission denied`t" +
+                "$escape[31mblocked$escape[0m"
+            ) -ErrorAction Continue
             $global:LASTEXITCODE = 9
-            'Permission denied'
         }
 
-        {
+        $message = $null
+        try {
             Invoke-InsuranceSecurityRoleDataverseRequest `
                 -Method GET `
                 -EnvironmentUrl 'https://unit.crm.dynamics.com' `
                 -Path '/roles'
-        } | Should -Throw '*GET /roles*Permission denied*'
+            throw 'Expected transport failure.'
+        }
+        catch {
+            $message = $_.Exception.Message
+        }
+
+        script:Assert-SafeDiagnosticLine -Text $message -MaxLength 400
+        $message | Should -Match (
+            [regex]::Escape(
+                "Dataverse security-role verification failed (GET /roles); az rest exited with code 9."
+            )
+        )
+        $message | Should -Match (
+            [regex]::Escape(
+                "Output: '::warning::security roles transport Permission denied blocked"
+            )
+        )
+        $message | Should -Not -Match 'At line:|--method|--url|--resource'
     }
 }
 
@@ -1001,6 +1053,21 @@ Describe 'Security-role verifier direct entry point' {
                     "Root security role query for contract name 'CRM Showcase Insurance Data Steward' returned name 'crm showcase insurance data steward'; exact case-sensitive identity match is required."
                 )
             }).Count | Should -Be 1
+    }
+
+    It 'emits a single safe error line and exits one on hostile az transport failure' {
+        $invocation = script:Invoke-SecurityRolesEntryScript -Scenario TransportFailure
+
+        $invocation.ExitCode | Should -Be 1
+        script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
+        $invocation.Output | Should -Match 'Dataverse security-role verification failed'
+        $invocation.Output | Should -Match '/roles\?\$select=roleid,name'
+        $invocation.Output | Should -Match (
+            [regex]::Escape(
+                "'::warning::security roles transport Permission denied blocked"
+            )
+        )
+        $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'
     }
 }
 

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -567,9 +567,10 @@ Describe 'Invoke-InsuranceSecurityRoleDataverseRequest' {
                 "Dataverse security-role verification failed (GET /roles); az rest exited with code 9."
             )
         )
+        $message | Should -Match 'Output:'
         $message | Should -Match (
             [regex]::Escape(
-                "Output: '::warning::security roles transport Permission denied blocked"
+                '::warning::security roles transport Permission denied blocked'
             )
         )
         $message | Should -Not -Match 'At line:|--method|--url|--resource'
@@ -1077,9 +1078,10 @@ Describe 'Security-role verifier direct entry point' {
         script:Assert-SafeDiagnosticLine -Text $invocation.Output -MaxLength 450
         $invocation.Output | Should -Match 'Dataverse security-role verification failed'
         $invocation.Output | Should -Match '/roles\?\$select=roleid,name'
+        $invocation.Output | Should -Match 'Output:'
         $invocation.Output | Should -Match (
             [regex]::Escape(
-                "'::warning::security roles transport Permission denied blocked"
+                '::warning::security roles transport Permission denied blocked'
             )
         )
         $invocation.Output | Should -Not -Match 'At line:|--method|--url|--resource'


### PR DESCRIPTION
Implements US-702, US-707, and US-708 under ADR-0023.

- separates administrator-only security-role bootstrap from steady-state CI
- adds GET-only preflight, role verification, and full convergence gates
- converges Dataverse metadata in one bounded run
- exports exactly four managed/unmanaged packages atomically
- hardens the DEV workflow with OIDC privilege separation and reviewed-ref controls

Relates to #8 and #40.

Evidence:
- 354 offline Pester tests pass
- Terraform configuration validates
- live `dev` environment is restricted to `main`
- live `main` requires PR + strict `gate1`