### PR TITLE
fix(dataverse): align role bootstrap with live metadata

### DIFF
--- a/docs/runbooks/insurance-foundation-security-role-bootstrap.md
+++ b/docs/runbooks/insurance-foundation-security-role-bootstrap.md
@@ -33,12 +33,18 @@ This bootstrap may change only:
 
 - `CRM Showcase Insurance Reader`;
 - `CRM Showcase Insurance Data Steward`;
-- localized English (`1033`), German (`1031`), French (`1036`), and Italian
-  (`1040`) role labels and descriptions;
+- the canonical English role names and descriptions;
 - only the privileges declared by the reviewed contract.
 
 If the local confirmation text or resulting structural verifier output implies
 any other change, stop and escalate under administrator review.
+
+> **Platform limitation confirmed in DEV (2026-08-10).** Dataverse root roles
+> identify themselves through `_parentrootroleid_value`; it is not `null`.
+> The role `name` attribute rejects `SetLocLabels` with `0x80044198` because it
+> does not support localized labels. The contract retains DE/FR/IT role text as
+> target-state terminology, but this bootstrap must not claim or attempt native
+> multilingual role names or descriptions.
 
 ## Procedure
 
@@ -92,14 +98,12 @@ any other change, stop and escalate under administrator review.
    - exact declared privileges and Dataverse depth;
    - no mutation during verification.
 
-7. For localized English (`1033`), German (`1031`), French (`1036`), and
-   Italian (`1040`) role labels/descriptions, capture the reviewed
-   `ShouldProcess`/publisher output from step 3 and inspect the role
-   translations in Power Platform before attaching evidence. This is a manual
-   evidence item because the current GET-only verifier does not retrieve
-   localized role labels/descriptions.
+7. Confirm Power Platform displays the canonical English role names and
+   descriptions. Native role-label translation is not a delivered demo
+   capability because the Dataverse role `name` attribute does not support
+   `SetLocLabels`.
 
-8. Attach the verifier JSON output and the manual localization evidence to
+8. Attach the verifier JSON output and the platform-limitation evidence to
    issue #40, then trigger **Author insurance foundation in DEV**.
 
 ## Failure and rollback
@@ -107,8 +111,6 @@ any other change, stop and escalate under administrator review.
 - Stop immediately if verification reports an exact-name mismatch, unexpected
   privileges, wrong solution ownership, duplicate root roles, unsupported
   depth, or any other `ContractConflict`.
-- Stop immediately if the manual Power Platform review shows incorrect
-  EN/DE/FR/IT role labels or descriptions.
 - Do **not** delete either role.
 - Do **not** elevate normal GitHub CI beyond the approved `System Customizer`
   role.
@@ -120,10 +122,8 @@ any other change, stop and escalate under administrator review.
 ## Evidence and sign-out
 
 - Keep the local terminal transcript, reviewed `ShouldProcess`/publisher
-  output, Power Platform translation review screenshots/notes, and pasted
-  verifier JSON as administrator evidence for issue #40.
-- Localized label/description evidence remains manual because the current
-  GET-only verifier does not retrieve localized role labels/descriptions.
+  output, canonical English role review, the `0x80044198` platform-limitation
+  evidence, and pasted verifier JSON as administrator evidence for issue #40.
 - After the verified DEV bootstrap is complete, sign out locally:
 
   ```powershell

--- a/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
+++ b/docs/superpowers/plans/2026-08-09-demo-feasible-dataverse-authoring.md
@@ -959,8 +959,13 @@ security-role administration.
 3. Review each `ShouldProcess` confirmation. The run may change only:
    - `CRM Showcase Insurance Reader`;
    - `CRM Showcase Insurance Data Steward`;
-   - their localized labels/descriptions;
+   - their canonical English names/descriptions;
    - privileges declared by the reviewed contract.
+
+   DEV evidence later confirmed that root roles self-reference
+   `_parentrootroleid_value` and that role `name` rejects `SetLocLabels` with
+   `0x80044198`. DE/FR/IT role wording remains target-state terminology rather
+   than a delivered native role-label capability.
 4. Run read-only verification:
 
    ```powershell

--- a/docs/superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md
+++ b/docs/superpowers/specs/2026-08-09-demo-feasible-dataverse-authoring-design.md
@@ -177,6 +177,12 @@ dedicated automated bootstrap identity as the target-state hypothesis.
 | TEST promotion | Deferred to the solution-versioning sprint | Managed install/update/upgrade with approvals and rollback |
 | Fixtures and persona security smoke tests | Deferred until custom roles exist and are exported | Automated after managed deployment |
 
+**DEV evidence amendment (2026-08-10).** Dataverse root-role records use a
+self-reference in `_parentrootroleid_value`, not `null`. Security-role
+`name` rejects `SetLocLabels` with `0x80044198`; therefore the demo delivers
+canonical English role names/descriptions and records DE/FR/IT role wording as
+target-state terminology rather than claiming unsupported native localization.
+
 ## 6. Workflow architecture
 
 ### 6.1 Read-only preflight

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -2349,7 +2349,18 @@ function Invoke-RoleReconciliation {
         }
     }
     $escapedName = $Role.name.Replace("'", "''")
-    $existing = Get-One "/roles?`$select=roleid,name,description,_businessunitid_value&`$filter=name eq '$escapedName' and _parentrootroleid_value eq null"
+    $roleResponse = Invoke-DataverseRequest -Method GET -Path (
+        "/roles?`$select=roleid,name,description,_businessunitid_value," +
+        "_parentrootroleid_value&`$filter=name eq '$escapedName'"
+    )
+    $rootRoles = @($roleResponse.value | Where-Object {
+            -not [string]::IsNullOrWhiteSpace([string]$_.roleid) -and
+            [string]$_.roleid -eq [string]$_._parentrootroleid_value
+        })
+    if ($rootRoles.Count -gt 1) {
+        throw "Metadata resolution was ambiguous for root role '$($Role.name)'."
+    }
+    $existing = if ($rootRoles.Count -eq 1) { $rootRoles[0] } else { $null }
     if ($null -eq $existing) {
         $businessUnit = Get-One "/businessunits?`$select=businessunitid&`$filter=parentbusinessunitid eq null"
         if ($null -eq $businessUnit -or -not $businessUnit.businessunitid) {
@@ -2358,11 +2369,6 @@ function Invoke-RoleReconciliation {
         $businessUnitId = $businessUnit.businessunitid
         $request = [pscustomobject]@{
             Method = 'POST'; Path = '/roles'; Solution = $Role.solution
-            EntityLogicalName = 'role'; IdProperty = 'roleid'
-            LocalizedFields = @{
-                name = $Role.metadata.label
-                description = $Role.metadata.description
-            }
             Body = @{
                 name = $Role.name
                 description = [string]$Role.metadata.description.'1033'
@@ -2370,7 +2376,6 @@ function Invoke-RoleReconciliation {
             }
         }
         $existing = Invoke-PlannedRequest $request
-        Set-RecordLocalizedFields -Request $request -CreatedRecord $existing
         if ($null -eq $existing -or -not $existing.roleid) {
             throw "Created role '$($Role.name)' did not return its role ID."
         }
@@ -2379,17 +2384,8 @@ function Invoke-RoleReconciliation {
         Assert-SolutionOwnership $existing $Role.solution $Role.name
         $request = [pscustomobject]@{
             Solution = $Role.solution
-            EntityLogicalName = 'role'
-            IdProperty = 'roleid'
-            LocalizedFields = @{
-                name = $Role.metadata.label
-                description = $Role.metadata.description
-            }
         }
-        # Role localized labels are not exposed as a complete language set by
-        # the record query. Idempotently repair every language on each run.
-        Set-RecordLocalizedFields -Request $request -CreatedRecord $existing
-        Write-Output "$($Role.name): Updated"
+        Write-Output "$($Role.name): Unchanged"
     }
 
     $wanted = foreach ($tablePrivilege in $Role.tablePrivileges) {

--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -2382,10 +2382,24 @@ function Invoke-RoleReconciliation {
         Write-Output "$($Role.name): Created"
     } else {
         Assert-SolutionOwnership $existing $Role.solution $Role.name
-        $request = [pscustomobject]@{
-            Solution = $Role.solution
+        $canonicalDescription = [string]$Role.metadata.description.'1033'
+        if ([string]$existing.name -cne [string]$Role.name -or
+            [string]$existing.description -cne $canonicalDescription) {
+            $request = [pscustomobject]@{
+                Method = 'PATCH'
+                Path = "/roles($($existing.roleid))"
+                Solution = $Role.solution
+                Body = @{
+                    name = [string]$Role.name
+                    description = $canonicalDescription
+                }
+            }
+            Invoke-PlannedRequest $request | Out-Null
+            Write-Output "$($Role.name): Updated"
         }
-        Write-Output "$($Role.name): Unchanged"
+        else {
+            Write-Output "$($Role.name): Unchanged"
+        }
     }
 
     $wanted = foreach ($tablePrivilege in $Role.tablePrivileges) {

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -873,7 +873,7 @@ function Get-ConvergenceRootInsuranceRolesPath {
     $escapedRolePrefix = ConvertTo-ODataKeyString $RolePrefix
     return (
         "/roles?`$select=roleid,name,_parentrootroleid_value&" +
-        "`$filter=_parentrootroleid_value eq null and startswith(name,'$escapedRolePrefix')"
+        "`$filter=startswith(name,'$escapedRolePrefix')"
     )
 }
 
@@ -3313,7 +3313,10 @@ function Test-InsuranceFoundationUnexpectedMetadata {
             -Details @($_.Exception.Message)
     }
 
-    foreach ($role in @($rootRoles.value | Sort-Object name, roleid)) {
+    foreach ($role in @($rootRoles.value | Where-Object {
+                -not [string]::IsNullOrWhiteSpace([string]$_.roleid) -and
+                [string]$_.roleid -eq [string]$_._parentrootroleid_value
+            } | Sort-Object name, roleid)) {
         $roleName = [string]$role.name
         if (-not (Test-ConvergenceStartsWithPrefix `
                     -Value $roleName `

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -61,8 +61,8 @@ function Get-InsuranceSecurityRolePath {
 
     $escapedName = ConvertTo-ODataStringLiteral -Value $RoleName
     return (
-        "/roles?`$select=roleid,name&" +
-        "`$filter=_parentrootroleid_value eq null and name eq '$escapedName'"
+        "/roles?`$select=roleid,name,_parentrootroleid_value&" +
+        "`$filter=name eq '$escapedName'"
     )
 }
 
@@ -621,7 +621,10 @@ function Test-InsuranceSecurityRole {
         -Path (Get-InsuranceSecurityRolePath -RoleName $roleName)
     $matches = @()
     if ($null -ne $roleResponse) {
-        $matches = @($roleResponse.value)
+        $matches = @($roleResponse.value | Where-Object {
+                -not [string]::IsNullOrWhiteSpace([string]$_.roleid) -and
+                [string]$_.roleid -eq [string]$_._parentrootroleid_value
+            })
     }
 
     if ($matches.Count -eq 0) {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1635,9 +1635,9 @@ Describe 'Insurance Foundation reconciliation' {
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/systemforms','/SetLocLabels','/SetLocLabels',
-            '/roles','/SetLocLabels','/SetLocLabels',
+            '/roles',
             '/roles(new-role)/Microsoft.Dynamics.CRM.AddPrivilegesRole',
-            '/roles','/SetLocLabels','/SetLocLabels',
+            '/roles',
             '/roles(new-role)/Microsoft.Dynamics.CRM.AddPrivilegesRole',
             '/PublishAllXml'
         )
@@ -2395,6 +2395,7 @@ Describe 'Insurance Foundation reconciliation' {
             if ($Method -eq 'GET' -and $Path -like '/roles?*') {
                 return [pscustomobject]@{ value = @([pscustomobject]@{
                     roleid=$roleId; name=$role.name
+                    _parentrootroleid_value=$roleId
                     description=[string]$role.metadata.description.'1033'
                 }) }
             }
@@ -2442,13 +2443,8 @@ Describe 'Insurance Foundation reconciliation' {
         }) | Should -BeNullOrEmpty
         @($script:calls | Where-Object Path -like '/roleprivileges*') |
             Should -BeNullOrEmpty
-        $localizationRepairs = @($script:calls |
-            Where-Object Path -eq '/SetLocLabels')
-        $localizationRepairs.Count | Should -Be 2
-        foreach ($repair in $localizationRepairs) {
-            @($repair.Body.Labels.LanguageCode) |
-                Should -Be @(1033, 1031, 1036, 1040)
-        }
+        @($script:calls | Where-Object Path -eq '/SetLocLabels') |
+            Should -BeNullOrEmpty
         $wantedNames | Should -Contain 'prvReadcrmshow_PolicyProjection'
         ($wantedNames -ccontains 'prvReadcrmshow_policyprojection') |
             Should -BeFalse
@@ -2471,6 +2467,7 @@ Describe 'Insurance Foundation reconciliation' {
             if ($Method -eq 'GET' -and $Path -like '/roles?*') {
                 return [pscustomobject]@{ value = @([pscustomobject]@{
                     roleid=$roleId; name=$role.name
+                    _parentrootroleid_value=$roleId
                     description=[string]$role.metadata.description.'1033'
                 }) }
             }

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -2373,7 +2373,7 @@ Describe 'Insurance Foundation reconciliation' {
         }
     }
 
-    It 'retrieves and parses role privileges through the documented function' {
+    It 'converges canonical role fields before parsing privileges through the documented function' {
         $role = $script:contract.roles[0]
         $roleId = '11111111-1111-1111-1111-111111111111'
         $expectedPath = "/RetrieveRolePrivilegesRole(RoleId=$roleId)"
@@ -2396,7 +2396,7 @@ Describe 'Insurance Foundation reconciliation' {
                 return [pscustomobject]@{ value = @([pscustomobject]@{
                     roleid=$roleId; name=$role.name
                     _parentrootroleid_value=$roleId
-                    description=[string]$role.metadata.description.'1033'
+                    description='Stale role description'
                 }) }
             }
             if ($Method -eq 'GET' -and $Path -like '/solutioncomponents?*') {
@@ -2438,6 +2438,13 @@ Describe 'Insurance Foundation reconciliation' {
         @($script:calls | Where-Object {
             $_.Method -eq 'GET' -and $_.Path -eq $expectedPath
         }).Count | Should -Be 1
+        $roleUpdate = @($script:calls | Where-Object {
+                $_.Method -eq 'PATCH' -and $_.Path -eq "/roles($roleId)"
+            })
+        $roleUpdate.Count | Should -Be 1
+        $roleUpdate[0].Body.name | Should -Be $role.name
+        $roleUpdate[0].Body.description |
+            Should -Be ([string]$role.metadata.description.'1033')
         @($script:calls | Where-Object {
             $_.Path -match '(?:Add|Replace)PrivilegesRole$'
         }) | Should -BeNullOrEmpty

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -300,21 +300,23 @@ switch ($path) {
             })
         exit 0
     }
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Reader'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Reader'" {
         Write-Json ([pscustomobject]@{
                 value = @([pscustomobject]@{
                         roleid = $readerRoleId
                         name = 'CRM Showcase Insurance Reader'
+                        _parentrootroleid_value = $readerRoleId
                     })
             })
         exit 0
     }
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Data Steward'" {
         $roles = @()
         if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ne 'MissingRoles') {
             $roles += [pscustomobject]@{
                 roleid = $stewardRoleId
                 name = 'CRM Showcase Insurance Data Steward'
+                _parentrootroleid_value = $stewardRoleId
             }
         }
         Write-Json ([pscustomobject]@{ value = @($roles) })

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -939,6 +939,7 @@ BeforeAll {
                     value = @([pscustomobject]@{
                             roleid = $roleId
                             name   = $roleName
+                            _parentrootroleid_value = $roleId
                         })
                 }
             $responses[(Get-InsuranceSecurityRoleSolutionMembershipPath -RoleId $roleId)] =
@@ -952,12 +953,12 @@ BeforeAll {
             $responses[(Get-ConvergenceRoleByIdPath -RoleId $roleId)] = [pscustomobject]@{
                 roleid = $roleId
                 name   = $roleName
-                _parentrootroleid_value = $null
+                _parentrootroleid_value = $roleId
             }
             [void]$rootRoles.Add([pscustomobject]@{
                     roleid = $roleId
                     name = $roleName
-                    _parentrootroleid_value = $null
+                    _parentrootroleid_value = $roleId
                 })
         }
 
@@ -1430,7 +1431,7 @@ Describe 'Convergence path builders' {
         Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance ' |
             Should -Be (
                 "/roles?`$select=roleid,name,_parentrootroleid_value&" +
-                "`$filter=_parentrootroleid_value eq null and startswith(name,'CRM Showcase Insurance ')"
+                "`$filter=startswith(name,'CRM Showcase Insurance ')"
             )
     }
 }
@@ -2446,13 +2447,13 @@ Describe 'Unexpected metadata reverse inventory' {
             [pscustomobject]@{
                 roleid = $roleId
                 name = 'CRM Showcase Insurance Escalation'
-                _parentrootroleid_value = $null
+                _parentrootroleid_value = $roleId
             }
         )
         $fixture.Responses[(Get-ConvergenceRoleByIdPath -RoleId $roleId)] = [pscustomobject]@{
             roleid = $roleId
             name = 'CRM Showcase Insurance Escalation'
-            _parentrootroleid_value = $null
+            _parentrootroleid_value = $roleId
         }
         $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $roleId)] =
             script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_Foundation'
@@ -2479,13 +2480,13 @@ Describe 'Unexpected metadata reverse inventory' {
             [pscustomobject]@{
                 roleid = $roleId
                 name = 'CRM Showcase Insurance DataModel Reviewer'
-                _parentrootroleid_value = $null
+                _parentrootroleid_value = $roleId
             }
         )
         $fixture.Responses[(Get-ConvergenceRoleByIdPath -RoleId $roleId)] = [pscustomobject]@{
             roleid = $roleId
             name = 'CRM Showcase Insurance DataModel Reviewer'
-            _parentrootroleid_value = $null
+            _parentrootroleid_value = $roleId
         }
         $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId $roleId)] =
             script:New-SolutionMembershipResponse -SolutionUniqueName 'crmshow_DataModel'
@@ -2532,12 +2533,12 @@ Describe 'Unexpected metadata reverse inventory' {
             [pscustomobject]@{
                 roleid = script:New-FakeGuid -Index 9706
                 name = 'System Administrator'
-                _parentrootroleid_value = $null
+                _parentrootroleid_value = script:New-FakeGuid -Index 9706
             } +
             [pscustomobject]@{
                 roleid = script:New-FakeGuid -Index 9714
                 name = 'CRM Showcase Insurance Archive'
-                _parentrootroleid_value = $null
+                _parentrootroleid_value = script:New-FakeGuid -Index 9714
             }
         )
         $fixture.Responses[(Get-ConvergenceSolutionMembershipPath -ComponentId (script:New-FakeGuid -Index 9714))] =

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -295,16 +295,17 @@ $readerRoleId = '11111111-1111-1111-1111-111111111111'
 $stewardRoleId = '22222222-2222-2222-2222-222222222222'
 
 switch ($path) {
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Reader'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Reader'" {
         Write-Json ([pscustomobject]@{
                 value = @([pscustomobject]@{
                         roleid = $readerRoleId
                         name = 'CRM Showcase Insurance Reader'
+                        _parentrootroleid_value = $readerRoleId
                     })
             })
         exit 0
     }
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Data Steward'" {
         $roles = @()
         if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -ne 'MissingRole') {
             $resolvedRoleName = if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -eq 'LowerCaseRoleName') {
@@ -316,6 +317,7 @@ switch ($path) {
             $roles += [pscustomobject]@{
                 roleid = $stewardRoleId
                 name = $resolvedRoleName
+                _parentrootroleid_value = $stewardRoleId
             }
         }
         Write-Json ([pscustomobject]@{ value = @($roles) })
@@ -681,11 +683,11 @@ Describe 'Compare-InsuranceRolePrivileges' {
 }
 
 Describe 'OData query helpers' {
-    It 'escapes root role names and enforces the root-role predicate' {
+    It 'escapes role names and retrieves parent-root identity for client-side root filtering' {
         Get-InsuranceSecurityRolePath -RoleName "Reader's Role" |
             Should -Be (
-                "/roles?`$select=roleid,name&" +
-                "`$filter=_parentrootroleid_value eq null and name eq 'Reader''s Role'"
+                "/roles?`$select=roleid,name,_parentrootroleid_value&" +
+                "`$filter=name eq 'Reader''s Role'"
             )
     }
 
@@ -711,6 +713,7 @@ Describe 'Test-InsuranceSecurityRole' {
         $script:rootRoleItems = @([pscustomobject]@{
                 roleid = $script:roleId
                 name = $script:role.name
+                _parentrootroleid_value = $script:roleId
             })
         $script:solutionNames = @($script:role.solution)
 
@@ -784,6 +787,31 @@ Describe 'Test-InsuranceSecurityRole' {
             }) | Should -BeNullOrEmpty
     }
 
+    It 'ignores child business-unit copies and verifies the self-parented root role' {
+        $script:rootRoleItems = @(
+            [pscustomobject]@{
+                roleid = '33333333-3333-3333-3333-333333333333'
+                name = $script:role.name
+                _parentrootroleid_value = $script:roleId
+            },
+            [pscustomobject]@{
+                roleid = $script:roleId
+                name = $script:role.name
+                _parentrootroleid_value = $script:roleId
+            }
+        )
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
+        @($script:calls.Path) | Should -Contain (
+            "/RetrieveRolePrivilegesRole(RoleId=$($script:roleId))"
+        )
+    }
+
     It 'returns ManualPrerequisite when the root role is missing' {
         $script:rootRoleItems = @()
 
@@ -803,8 +831,14 @@ Describe 'Test-InsuranceSecurityRole' {
 
     It 'returns ContractConflict when multiple root roles match the same name' {
         $script:rootRoleItems = @(
-            [pscustomobject]@{ roleid = '1'; name = $script:role.name },
-            [pscustomobject]@{ roleid = '2'; name = $script:role.name }
+            [pscustomobject]@{
+                roleid = '1'; name = $script:role.name
+                _parentrootroleid_value = '1'
+            },
+            [pscustomobject]@{
+                roleid = '2'; name = $script:role.name
+                _parentrootroleid_value = '2'
+            }
         )
 
         $result = Test-InsuranceSecurityRole `
@@ -823,6 +857,7 @@ Describe 'Test-InsuranceSecurityRole' {
         $script:rootRoleItems = @([pscustomobject]@{
                 roleid = $script:roleId
                 name = $resolvedRoleName
+                _parentrootroleid_value = $script:roleId
             })
 
         $result = Test-InsuranceSecurityRole `


### PR DESCRIPTION
## Summary
- align Dataverse root-role detection with live self-parented `_parentrootroleid_value`
- stop unsupported `SetLocLabels` calls for security-role attributes
- converge canonical English role name/description before privilege mutation
- document the DEV platform limitation and update regression fixtures

## Live evidence
- workflow run 31346856267 failed safely with `ManualPrerequisite` before mutation
- authorized local bootstrap created the Reader root role, then Dataverse returned `0x80044198` for role `name` localization
- live metadata confirmed root roles self-reference their parent-root ID

## Validation
- complete offline suite: 355 passed, 0 failed after root-role/localization fix
- focused publisher suite after review fix: 103 passed, 0 failed

## Remaining before merge/deployment
- CI review and merge
- rerun administrator `SecurityRoles` bootstrap from merged main
- run GET-only role verifier
- rerun DEV authoring twice for export and idempotency evidence

Links #40
Links #8
ADR: ADR-0023
Story: US-702