### PR TITLE
fix(ci): unpack managed package type in promotion exclusion gate

### DIFF
--- a/.github/workflows/solution-promote-test.yml
+++ b/.github/workflows/solution-promote-test.yml
@@ -69,8 +69,9 @@ jobs:
           $out = Join-Path $env:RUNNER_TEMP 'promote'
           $contract = Get-PromotionComponents -SchemaPath ./solution/schema/insurance-foundation.json
           $unpacked = Join-Path $env:RUNNER_TEMP 'unpacked'
-          & $pac solution unpack --zipfile (Join-Path $out 'crmshow_DataModel_managed.zip') --folder $unpacked --allowDelete
-          $names = (Get-ChildItem -Recurse -File $unpacked | Select-String -SimpleMatch -Pattern $contract.ExcludedComponents) 
+          & $pac solution unpack --zipfile (Join-Path $out 'crmshow_DataModel_managed.zip') --folder $unpacked --packagetype Managed --allowDelete
+          if ($LASTEXITCODE -ne 0) { throw "pac solution unpack failed (exit $LASTEXITCODE)." }
+          $names = (Get-ChildItem -Recurse -File $unpacked | Select-String -SimpleMatch -Pattern $contract.ExcludedComponents)
           if ($names) { throw "Excluded effective-date components present in package: $($names.Pattern -join ', ')" }
           Write-Host 'Package excludes all effective-date components.'
       - name: Upload managed artifacts

--- a/docs/superpowers/sprints/sprint-002-insurance-foundation-promotion/STATUS.md
+++ b/docs/superpowers/sprints/sprint-002-insurance-foundation-promotion/STATUS.md
@@ -23,3 +23,32 @@ See the [charter](./sprint.md) and the
   workflow on the default branch (confirmed HTTP 404 pre-merge). After PR #50
   merges, run `solution-promote-test.yml` and approve the `test` protected
   environment; link the run + version + smoke evidence here.
+
+## Live promotion evidence
+
+**Run 1 — [31485409186](https://github.com/urruegg/CRMShowcase/actions/runs/31485409186) (main, after PR #50 merge).**
+
+| Step | Result |
+| --- | --- |
+| Sign in with workload identity (DEV) | ✅ OIDC federation works; `dev` env wired |
+| Offline promotion contract tests | ✅ green in CI |
+| Authenticate Power Platform CLI (DEV) | ✅ |
+| Export managed solutions (Foundation + DataModel) | ✅ DEV is authored; managed export succeeds |
+| Assert excluded components absent | ❌ **defect found** |
+| Import to TEST | ⏭️ not reached |
+
+**Finding (defect caught by the live run).** The exclusion-gate step ran
+`pac solution unpack` **without `--packagetype`**, which defaults to *unmanaged*
+and cannot unpack the managed export: `Error: Solution package type did not
+match requested type`. This failed the step *and* would have masked a
+false-clean (nothing unpacked to scan). Auth, export and the offline contract
+were all healthy — only the assertion step was defective.
+
+**Fix (branch `fix/promote-unpack-managed`).** Unpack with
+`--packagetype Managed` and add an explicit `$LASTEXITCODE` guard so an unpack
+failure throws instead of reporting a false clean.
+
+**Next.** After the fix merges to `main`, re-run `solution-promote-test.yml`; the
+`import-to-test` job then imports the managed slice under the `test`
+protected-environment approval (the human gate), and the smoke evaluator records
+the TEST result here.


### PR DESCRIPTION
Fix found by the live Proof #2 promotion run 31485409186. The exclusion-gate step ran `pac solution unpack` without `--packagetype`, which defaults to unmanaged and cannot unpack the managed export (`Error: Solution package type did not match requested type`), failing the step and masking a false-clean. This adds `--packagetype Managed` and a `LASTEXITCODE` guard so an unpack failure throws. Evidence documented in the sprint-002 STATUS board. After merge, re-run `solution-promote-test.yml` to reach the `test` import under protected-environment approval.