### PR TITLE
chore(ci): align CD/CI workflow naming (ADR-0025) + Proof #2 TEST evidence

### DIFF
--- a/.github/workflows/cd-infra.yml
+++ b/.github/workflows/cd-infra.yml
@@ -1,4 +1,4 @@
-name: Terraform
+name: CD — Infra (Terraform)
 
 # Purpose: validate infra/terraform/ on every PR, and prove OIDC federation to the
 # demo tenant works end-to-end on merges to main / manual dispatch.
@@ -17,12 +17,12 @@ on:
   pull_request:
     paths:
       - 'infra/terraform/**'
-      - '.github/workflows/terraform.yml'
+      - '.github/workflows/cd-infra.yml'
   push:
     branches: [main]
     paths:
       - 'infra/terraform/**'
-      - '.github/workflows/terraform.yml'
+      - '.github/workflows/cd-infra.yml'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/cd-solution-dev.yml
+++ b/.github/workflows/cd-solution-dev.yml
@@ -1,4 +1,4 @@
-name: Author insurance foundation in DEV
+name: CD — Solution to DEV
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/cd-solution-test.yml
+++ b/.github/workflows/cd-solution-test.yml
@@ -1,4 +1,4 @@
-name: Promote insurance foundation to TEST
+name: CD — Solution to TEST
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci-solution.yml
+++ b/.github/workflows/ci-solution.yml
@@ -1,4 +1,4 @@
-name: Solution CI
+name: CI — Solution
 
 on:
   pull_request: {}
@@ -12,7 +12,8 @@ on:
     paths:
       - 'solution/**'
       - 'scripts/solution/**'
-      - '.github/workflows/solution-*.yml'
+      - '.github/workflows/ci-solution.yml'
+      - '.github/workflows/cd-solution-*.yml'
   # Manual dispatch for on-demand runs (e.g., re-validating a branch after an
   # intake sync from make.powerapps.com).
   workflow_dispatch: {}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ README.md   AGENTS.md   SUPERPOWERS_CONTRACT.md   CONTRIBUTING.md
    chatmodes/*.chatmode.md     matching chatmodes
    instructions/               path-scoped rules
    prompts/                    reusable prompts
-   workflows/                  CI: Terraform + eventual solution build
+   workflows/                  ci-solution · cd-infra · cd-solution-dev/test
    ISSUE_TEMPLATE/             governance escalation etc.
    pull_request_template.md
 docs/

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -51,7 +51,7 @@ household relocates across a jurisdiction boundary. See
 | US-401 | Every licensing flag resolved ([LICENSING.md](./LICENSING.md)) | `[TBD]` |
 | US-402 | Every AI maturity verified ([AI.md](./AI.md)) | `[TBD]` |
 | US-403 | Regression suite green on the eight curveballs ([TEST.md](./TEST.md)) | `[TBD]` |
-| US-404 | `.github/workflows/terraform.yml` extended with `plan` on real remote state | `[TBD]` |
+| US-404 | `.github/workflows/cd-infra.yml` extended with `plan` on real remote state | `[TBD]` |
 
 ## Epic 5 — Solution containers (Sprint 1)
 
@@ -64,9 +64,9 @@ Traces to spec [`docs/superpowers/specs/2026-08-06-solution-containers-design.md
 | US-503 | solution/manifest.json + schema + parser | `[TBD]` |
 | US-504 | Scaffold six empty solutions in DEV, export, unpack, commit | `[TBD]` |
 | US-505 | scripts/solution/*.ps1 (export, unpack, pack, import, bump-version) | `[TBD]` |
-| US-506 | .github/workflows/solution-ci.yml (Gate 1) | `[TBD]` |
-| US-507 | .github/workflows/solution-deploy-dev.yml | `[TBD]` |
-| US-508 | GitHub Environment test reviewers + solution-deploy-test.yml | `[TBD]` |
+| US-506 | .github/workflows/ci-solution.yml (Gate 1) | `[TBD]` |
+| US-507 | .github/workflows/cd-solution-dev.yml | `[TBD]` |
+| US-508 | GitHub Environment test reviewers + cd-solution-test.yml | `[TBD]` |
 | US-509 | solution-intake-on-demand.yml + solution-intake-drift.yml | `[TBD]` |
 | US-510 | ADR-0019 solution versioning strategy | `[TBD]` |
 | US-511 | Extend .github/CODEOWNERS with folder-scoped rules | `[TBD]` |

--- a/docs/MICROSOFT-FRAMEWORKS.md
+++ b/docs/MICROSOFT-FRAMEWORKS.md
@@ -45,7 +45,7 @@ WAF drives architectural excellence across five pillars.
 | **Reliability** | [docs/OPERATIONS.md](./OPERATIONS.md) — env topology. [docs/TEST.md](./TEST.md) — layered testing, golden-thread regression. `[TBD]` for RPO/RTO on the demo tenant. |
 | **Security** | [docs/SECURITY.md](./SECURITY.md), [ADR-0002](./adr/ADR-0002-oidc-federation-for-github-actions-to-entra.md), [ADR-0004](./adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md), [ADR-0005](./adr/ADR-0005-power-platform-application-users-for-ci.md). Zero Trust posture, no long-lived credentials, least-privilege CI apps. |
 | **Cost Optimization** | Terraform lets us right-size and tear down. `[TBD]` — no cost dashboard yet; demo runs on shared MCAPS trial capacity. |
-| **Operational Excellence** | [ADR-0017](./adr/ADR-0017-alm-everything-through-the-pipeline.md) — nothing reaches an environment except through the pipeline. Rollback is a pipeline action, not a manual repair. GitHub Actions workflow at [.github/workflows/terraform.yml](../.github/workflows/terraform.yml) proves the auth loop end-to-end. |
+| **Operational Excellence** | [ADR-0017](./adr/ADR-0017-alm-everything-through-the-pipeline.md) — nothing reaches an environment except through the pipeline. Rollback is a pipeline action, not a manual repair. GitHub Actions workflow at [.github/workflows/cd-infra.yml](../.github/workflows/cd-infra.yml) proves the auth loop end-to-end. |
 | **Performance Efficiency** | Native platform pillar for now. `[TBD]` — load characteristics unmeasured. |
 
 **Honest gaps.** Cost Optimization and Performance Efficiency are the two

--- a/docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md
+++ b/docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md
@@ -81,7 +81,7 @@ independent approver once the repo is no longer single-maintainer.
 
 ### CI workflow
 
-[`.github/workflows/terraform.yml`](../../.github/workflows/terraform.yml).
+[`.github/workflows/cd-infra.yml`](../../.github/workflows/cd-infra.yml).
 
 - **PR trigger.** `terraform fmt -check`, `terraform init -backend=false`,
   `terraform validate`. Never touches the tenant.

--- a/docs/adr/ADR-0025-cicd-workflow-naming-convention.md
+++ b/docs/adr/ADR-0025-cicd-workflow-naming-convention.md
@@ -1,0 +1,66 @@
+# ADR-0025 — CI/CD workflow naming convention
+
+| Field | Value |
+| --- | --- |
+| **Status** | Accepted |
+| **Date** | 2026-08-11 |
+| **Decision mode** | Reversible organizational change |
+| **Confidence** | High |
+| **Deciders** | SecDevOps, Enterprise Architect, repo owner |
+| **Topic area** | A8 — lifecycle, deployment, rollback |
+| **Licence** | Own build — GitHub Actions workflows |
+| **Upgrade impact** | Low — file renames + `name:` fields; job names unchanged so branch-protection required checks are unaffected |
+| **CAF methodology** | Govern, Manage |
+| **WAF pillar(s)** | Operational Excellence |
+| **Zero Trust** | No change to auth posture |
+| **Responsible AI** | Not AI-relevant |
+
+## Context
+
+The workflow files under `.github/workflows/` had inconsistent, non-descriptive
+names (`terraform.yml`, `solution-ci.yml`, `solution-author-dev.yml`,
+`solution-promote-test.yml`) that mixed lifecycle stage (CI vs CD) and target
+environment without a clear convention. The original delivery plans also
+intended `solution-deploy-dev.yml` / `solution-deploy-test.yml`, which the built
+files never matched — so there was drift between plan and reality.
+
+## Decision
+
+Adopt a **lifecycle-first `ci-*` / `cd-*` naming convention**:
+`<stage>-<subject>[-<target>].yml`.
+
+| Old file | New file | `name:` |
+| --- | --- | --- |
+| `terraform.yml` | `cd-infra.yml` | CD — Infra (Terraform) |
+| `solution-ci.yml` | `ci-solution.yml` | CI — Solution |
+| `solution-author-dev.yml` | `cd-solution-dev.yml` | CD — Solution to DEV |
+| `solution-promote-test.yml` | `cd-solution-test.yml` | CD — Solution to TEST |
+
+- `ci-*` = validation only (PR gates, no environment writes).
+- `cd-*` = deployment (infra provisioning / solution deploy to an environment).
+- **Job names are unchanged** (`gate1`, `validate`) so the branch-protection
+  required status check `gate1` keeps matching.
+- `cd-infra.yml` retains its dual role (PR validate + OIDC smoke on merge);
+  splitting it into `ci-infra.yml` + `cd-infra.yml` is deferred (YAGNI).
+
+## Consequences
+
+- Path-trigger globs updated: `ci-solution.yml` now watches
+  `.github/workflows/ci-solution.yml` and `.github/workflows/cd-solution-*.yml`;
+  `cd-infra.yml` self-reference updated.
+- Test references updated: `ReviewedRefControls.Tests.ps1` →
+  `ci-solution.yml`; `Publish-InsuranceFoundation.Tests.ps1` →
+  `cd-solution-dev.yml`.
+- Current-state docs updated (README, ADR-0004, MICROSOFT-FRAMEWORKS, BACKLOG).
+- **Dated records left as-is:** `docs/superpowers/plans/*`, `specs/*` and the
+  sprint status boards keep their original workflow names as historical
+  evidence. This ADR is the old→new mapping for anyone following a stale
+  reference.
+- The `skip-solution-ci` label is unchanged (no bypass label exists in
+  `ci-solution.yml`; the label rename would be cosmetic churn).
+
+## Related
+
+- [ADR-0002 — OIDC federation](./ADR-0002-oidc-federation-for-github-actions-to-entra.md)
+- [ADR-0004 — CI-plane app registrations and GitHub environments](./ADR-0004-ci-plane-app-registrations-and-github-environments.md)
+- [ADR-0017 — ALM everything through the pipeline](./ADR-0017-alm-everything-through-the-pipeline.md)

--- a/docs/superpowers/sprints/sprint-002-insurance-foundation-promotion/STATUS.md
+++ b/docs/superpowers/sprints/sprint-002-insurance-foundation-promotion/STATUS.md
@@ -52,3 +52,28 @@ failure throws instead of reporting a false clean.
 `import-to-test` job then imports the managed slice under the `test`
 protected-environment approval (the human gate), and the smoke evaluator records
 the TEST result here.
+
+**Run 2 — [31487139644](https://github.com/urruegg/CRMShowcase/actions/runs/31487139644) (main, after fix #51). ✅ SUCCESS — Proof #2 complete end to end.**
+
+| Step | Result |
+| --- | --- |
+| `export-from-dev` (auth, offline tests, managed export) | ✅ |
+| Assert excluded components absent | ✅ **gate passed — package is clean** (no `businessRules`, no `OverlapReporting`/`InvalidDateReporting` views) |
+| `import-to-test` → Preflight languages | ✅ LCIDs **1033/1031/1036/1040 all Active** in TEST |
+| `import-to-test` → Import managed | ✅ `crmshow_Foundation_managed.zip` Imported, then `crmshow_DataModel_managed.zip` Imported (InstallOrUpdate) |
+| `import-to-test` → Smoke evidence | ⚠️ placeholder step (see follow-up) |
+
+**Outcome.** The managed Insurance Foundation slice (Foundation + DataModel,
+schema/metadata/localization only — **no plug-ins, no business rules, no
+effective-date views**) is deployed to **TEST (prod-equivalent)**, with all four
+languages active and the exclusion gate green. This is the delegated pattern
+proven from brainstorm → design → plan → delegated build → PR → merge →
+managed deployment to TEST.
+
+**Follow-ups (not blocking Proof #2 completion).**
+1. Wire the `import-to-test` "Smoke evidence" step to actually invoke
+   `Get-PromotionSmokeResult` against live TEST facts (currently a placeholder;
+   the evaluator exists and is unit-tested).
+2. Harden the workflow `env:` block so `AZURE_TENANT_ID` / `POWER_PLATFORM_ENV_URL`
+   are not echoed in plaintext in the Actions log (per ENVIRONMENTS.md, tenant
+   IDs are identifying).

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -4571,7 +4571,7 @@ Describe 'Insurance Foundation table metadata convergence' {
 Describe 'Publisher entry point safety' {
     BeforeAll {
         $script:authoringWorkflow = Get-Content (Join-Path $script:repoRoot `
-            '.github/workflows/solution-author-dev.yml') -Raw
+            '.github/workflows/cd-solution-dev.yml') -Raw
         $script:validateJobBlock = [regex]::Match(
             $script:authoringWorkflow,
             '(?ms)^  validate:\r?\n.*?(?=^  author:\r?\n)'

--- a/scripts/solution/tests/ReviewedRefControls.Tests.ps1
+++ b/scripts/solution/tests/ReviewedRefControls.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
     $script:adr0004 = Get-Content (Join-Path $script:repoRoot `
         'docs/adr/ADR-0004-ci-plane-app-registrations-and-github-environments.md') -Raw
     $script:solutionCiWorkflow = Get-Content (Join-Path $script:repoRoot `
-        '.github/workflows/solution-ci.yml') -Raw
+        '.github/workflows/ci-solution.yml') -Raw
 }
 
 Describe 'GitHub environment reviewed-ref policies' {


### PR DESCRIPTION
Aligns the GitHub Actions workflow naming to a lifecycle-first `ci-*` / `cd-*` convention (ADR-0025), and records the Proof #2 TEST deployment success.

**Renames** (job names `gate1`/`validate` unchanged, so the required check is safe):
- `terraform.yml` -> `cd-infra.yml`
- `solution-ci.yml` -> `ci-solution.yml`
- `solution-author-dev.yml` -> `cd-solution-dev.yml`
- `solution-promote-test.yml` -> `cd-solution-test.yml`

**Also:** path-trigger globs, two test path-refs, and current-state docs (README, ADR-0004, MICROSOFT-FRAMEWORKS, BACKLOG) updated. Dated plans/specs left as historical records; ADR-0025 is the old->new map. Full solution suite 352/352 green.

**Proof #2 evidence:** run 31487139644 succeeded end-to-end - managed Foundation + DataModel imported to TEST (InstallOrUpdate), all four LCIDs active, exclusion gate green.

ADR: docs/adr/ADR-0025-cicd-workflow-naming-convention.md