### PR TITLE
docs(sprint-3): Phase 0 - ADR-0026, ADR-0027 + PCF polish-loop pattern

### DIFF
--- a/.github/agents/ux-designer.agent.md
+++ b/.github/agents/ux-designer.agent.md
@@ -23,7 +23,9 @@ Marketing** surfaces across the showcase's solution design.
    [pcf-best-practices](../instructions/pcf-best-practices.instructions.md) and
    [pcf-alm](../instructions/pcf-alm.instructions.md); use Fluent v9 tokens and
    theming so the control matches the host MDA theme. Controls live under
-   `solution/**/Controls/**`.
+   `solution/**/Controls/**`. For pixel-faithful surfaces, build via the
+   **[PCF Local-First Polish Loop](../../docs/superpowers/patterns/pcf-local-first-polish-loop.md)**
+   ([ADR-0027](../../docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md)).
 3. **Copilot Studio agent UX** — extend the runtime agents (`AG-F-##`) via
    **adaptive cards** and rich, actionable interactions so a human accepts, edits
    or dismisses an agent proposal in-context.

--- a/docs/adr/ADR-0018-analytics-split-crm-vs-databricks.md
+++ b/docs/adr/ADR-0018-analytics-split-crm-vs-databricks.md
@@ -29,5 +29,7 @@ illustrated example, Databricks).
 - The split must be stated as a **principle the customer can apply themselves**,
   not a list — otherwise every new report becomes a debate.
 - KPI governance is a shared-responsibility topic (A9), not a tooling topic.
-- **Open with the customer:** the provisioning mechanism and latency expectation
-  toward the analytics platform. `[TBD]`
+- **Provisioning mechanism and latency** toward the analytics platform:
+  **resolved by [ADR-0026](./ADR-0026-inbound-analytics-projection-pattern.md)** —
+  inbound analytics use a *materialized projection* (with virtual-table and
+  embedded Power BI / Fabric as catalogued alternatives).

--- a/docs/adr/ADR-0026-inbound-analytics-projection-pattern.md
+++ b/docs/adr/ADR-0026-inbound-analytics-projection-pattern.md
@@ -1,0 +1,99 @@
+# ADR-0026 — Inbound analytics projection pattern (data platform → CRM)
+
+| Field | Value |
+| --- | --- |
+| **Status** | Accepted |
+| **Date** | 2026-08-11 |
+| **Decision mode** | Committed decision (for the cockpit); the catalogue is a reusable reference |
+| **Confidence** | High — grounded in Microsoft-documented integration patterns and ADR-0008/0018 |
+| **Deciders** | Enterprise Architect (AG-E-03) · Integration Engineer (AG-E-09) · Data Engineer & Scientist (AG-E-07) |
+| **Topic area** | A3 — Integration · A7 — Analytics |
+| **Use case** | UC-01 · Advisor Cockpit ([spec](../superpowers/specs/2026-08-11-advisor-cockpit-design.md)) |
+| **Licence** | 🧩 configuration / own build |
+| **Upgrade impact** | Low — the projection table + contract are additive; the producer can change without touching consumers |
+| **CAF methodology** | Adopt · Govern |
+| **WAF pillar(s)** | Primary: Operational Excellence · Reliability. Trade-off: Cost Optimization vs freshness (a copy must be refreshed). |
+| **Zero Trust** | Least privilege — project only the measures a named persona needs; read-only in CRM. |
+| **Responsible AI** | Transparency — surfaced numbers cite their source system and as-of date. |
+
+## Context
+
+[ADR-0018](./ADR-0018-analytics-split-crm-vs-databricks.md) sets the split
+between operational analytics in CRM and enterprise analytics on the data
+platform (Databricks), but left the **provisioning mechanism and latency toward
+the analytics platform** as an open `[TBD]`. The Advisor Cockpit forces the
+question: model-computed numbers (AI-Score, forecast, scorecard, product-line
+and region analytics, aggregate KPIs) must appear **in-context** inside the
+cockpit. This ADR records the reusable pattern catalogue for getting
+data-platform data **into** the app and selects one for the cockpit.
+
+The well-known Dataverse⇄lakehouse integrations (Azure Synapse Link for
+Dataverse, Link to Microsoft Fabric) are **outbound** (CRM → lake). This ADR is
+about the **inbound** direction.
+
+## Options
+
+### Option A — Materialized projection ("snapshot") ✅ preferred
+A scheduled job computes aggregates on the platform and **upserts them into a
+Dataverse table**, keyed by *subject · metric · as-of date*. Production producer:
+Databricks job → Azure Data Factory / Synapse pipeline / Power Platform dataflow.
+**Why:** the app reads a normal Dataverse table — fast, filterable, relatable to
+CRM rows, governed by security roles, and it composes pixel-precisely inside a
+PCF. Cost: it is a copy, so freshness is owned (daily/hourly is sufficient for
+KPIs/scores/forecasts).
+
+### Option B — Virtual table (live read-through)
+A Dataverse virtual table over an OData/SQL endpoint on the lake; no copy,
+always fresh. **Why not (here):** needs a stable low-latency endpoint, is
+read-only with query/relationship limits, and every page render hits the
+external system. Good when data is large, must be live, and read-only.
+
+### Option C — Embedded Power BI / Fabric
+Leave analytics in the lakehouse; surface an embedded visual on the page.
+**Why not (here):** separate security/latency model, and hard to interleave
+pixel-perfectly with a custom PCF layout. Good for rich historical charts and
+cross-domain blending; real cockpits often blend A (numbers) with C (heavy
+charts).
+
+## Decision or working hypothesis
+
+The Advisor Cockpit uses **Option A — a materialized projection**. Analytics land
+in a Dataverse table (`crmshow_measuresnapshot`, in `crmshow_Integration`) via a
+versioned, contract-first schema in `api/`. Because the demo tenant has no Azure
+subscription, the producer is **mimicked**: synthetic "gold" fixtures are seeded
+by the CD pipeline. Swapping the mock producer for a real Databricks→ADF feed
+changes the **producer only** — the consumer contract is unchanged. All three
+options remain valid reusable patterns for future scenarios.
+
+## Evidence and assumptions
+
+- **Known:** Dataverse tables are the most faithful in-context surface for a PCF;
+  the demo tenant has no Azure subscription (data platform must be mocked);
+  ADR-0008 keeps the platform authoritative and the CRM copy read-only.
+- **Inferred:** daily/hourly freshness is adequate for the surfaced measures.
+- **Evidence still required:** the real Mobiliar core-system/data-platform
+  integration (API/event/latency) — will select the production producer for
+  Option A (or move a measure to B/C).
+
+## Validation and review triggers
+
+Reopen when the real data-platform integration is designed, or when a measure
+needs sub-minute latency (→ Option B) or rich historical drill-down (→ Option C).
+Deciders: AG-E-03 + AG-E-09.
+
+## Consequences
+
+- **At the next release:** `crmshow_measuresnapshot` + its `api/` contract ship;
+  the seed step populates DEV/TEST.
+- **Operationally:** freshness/latency is a pipeline concern; the failure path is
+  re-seed / re-run.
+- **For the customer's teams:** the contract in `api/` is the hand-off point to
+  the data-platform team; they own the producer, CRM owns the consumer.
+- **Reversibility:** high — drop the table + contract; no system-of-record data
+  is lost (the platform stays authoritative).
+
+## Competitive note
+
+Forces the equivalent engagement to state *how* analytics reach the operative
+screen and *who owns freshness* — a contract-and-ownership answer, not a
+dashboard screenshot.

--- a/docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md
+++ b/docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md
@@ -1,0 +1,92 @@
+# ADR-0027 — Page-level PCF + the PCF Local-First Polish Loop
+
+| Field | Value |
+| --- | --- |
+| **Status** | Accepted |
+| **Date** | 2026-08-11 |
+| **Decision mode** | Committed decision |
+| **Confidence** | High — grounded in the pcf-best-practices / pcf-alm instructions and the pixel-fidelity requirement |
+| **Deciders** | UX Designer (AG-E-11) · Enterprise Architect (AG-E-03) · Developer (AG-E-02) |
+| **Topic area** | A4 — Extensibility · UX |
+| **Use case** | UC-01 · Advisor Cockpit ([spec](../superpowers/specs/2026-08-11-advisor-cockpit-design.md)) |
+| **Licence** | 🧩 configuration / own build (pro-code PCF) |
+| **Upgrade impact** | Medium — PCF controls carry an upgrade-impact declaration per pcf-alm; Fluent v9 + framework versions are pinned |
+| **CAF methodology** | Adopt |
+| **WAF pillar(s)** | Primary: Operational Excellence (tested, source-controlled UI) · Performance Efficiency. Trade-off: pro-code effort vs out-of-box config. |
+| **Zero Trust** | Controls read Dataverse under the user's context and security roles. |
+| **Responsible AI** | Transparency — AI-authored content (NBA cards) renders a visible provenance badge + "AI-assisted" disclosure. |
+
+## Context
+
+The Advisor Cockpit must reproduce two dense, full-bleed HTML cockpits **as
+close to pixel-perfect as possible** (ground truth: the unpacked Mobiliar HTML
+web resources, local-only). Two questions: (1) how is each surface rendered, and
+(2) how do we reliably reach pixel fidelity? This ADR settles both and anchors
+the build method as a reusable pattern.
+
+## Options
+
+### Option A — One page-level PCF per surface ✅ preferred
+Each surface is a single React + Fluent UI v9 control rendering the whole page.
+**Why:** full control of every pixel, 1:1 with the mockup, one focused build per
+surface, clean local harness. The mockup already uses the Fluent palette, so
+tokens port directly.
+
+### Option B — Many small PCF tiles on an MDA custom page
+Each region is its own PCF, arranged on the page. **Why not:** MDA page/section
+layout fights pixel-perfect spacing; the dense header/KPI band is hard to match;
+more controls to wire.
+
+### Option C — Hybrid
+Page-level PCF for the hero, native + small tiles elsewhere. **Why not:** mixes
+two layout models on one page; harder to keep visually consistent for a
+pixel-perfect target.
+
+## Decision or working hypothesis
+
+Use **Option A — one page-level PCF per surface** (`AdvisorCockpit`,
+`SalesLeaderDashboard`), and adopt the **PCF Local-First Polish Loop** as the
+build method for pixel-faithful PCF in this repo:
+
+1. Derive TypeScript types + mock fixtures from the data model.
+2. Build the component in a **Vite** harness with fixtures (hot reload, full
+   screen).
+3. Serve on localhost, **open as a shared browser page in VS Code**, screenshot
+   and diff against the ground-truth HTML web resource; **ux-designer** (AG-E-11)
+   polishes tokens/spacing to fidelity.
+4. Wrap as PCF, bind `context`/dataset to Dataverse (same component, swap the
+   data source).
+5. Pack into the app solution; CI (pcf-alm) → DEV → TEST.
+
+The loop is documented in
+[docs/superpowers/patterns/pcf-local-first-polish-loop.md](../superpowers/patterns/pcf-local-first-polish-loop.md)
+and referenced by the `ux-designer` agent.
+
+## Evidence and assumptions
+
+- **Known:** the mockups are full-bleed custom layouts using the Fluent palette;
+  pcf-best-practices mandates React + Fluent v9; pcf-alm governs packaging.
+- **Inferred:** page-level controls are more maintainable here than many tiles.
+- **Evidence still required:** none blocking; performance validated during build.
+
+## Validation and review triggers
+
+Reopen if a surface needs to be recomposed from independently-reusable tiles, or
+if MDA native config can meet the fidelity bar for a future, simpler surface
+(config → low-code → pro-code still applies).
+
+## Consequences
+
+- **At the next release:** two PCF controls + the pattern doc ship; the loop is
+  reusable for every future pixel-faithful surface.
+- **Operationally:** controls are Jest-tested and versioned; upgrade impact is
+  declared per control.
+- **For the customer's teams:** a repeatable, reviewable UX build method rather
+  than ad-hoc pixel-pushing.
+- **Reversibility:** medium — a control can be re-split into tiles later, but the
+  component code is reusable either way.
+
+## Competitive note
+
+Forces the equivalent engagement to show a **repeatable** path to a
+pixel-faithful, tested, source-controlled UI — not a one-off demo screen.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ Copy [ADR-TEMPLATE.md](./ADR-TEMPLATE.md) and edit — do not invent a new shape
 
 `ADR-####-kebab-case-title.md`, four-digit sequence, no gaps.
 
-`0023` is the latest allocated sequence; use `0024` for the next ADR.
+`0027` is the latest allocated sequence; use `0028` for the next ADR.
 
 ## Index
 
@@ -53,6 +53,10 @@ Copy [ADR-TEMPLATE.md](./ADR-TEMPLATE.md) and edit — do not invent a new shape
 | [0021](./ADR-0021-multilingual-semantic-dataverse-metadata.md) | Multilingual semantic Dataverse metadata | A2 · A4 · A6 · A8 | Accepted |
 | [0022](./ADR-0022-curated-external-copilot-capability-packs.md) | Curated external Copilot capability packs | A4 · A6 · A8 | Accepted |
 | [0023](./ADR-0023-demo-feasible-dataverse-bootstrap.md) | Demo-feasible Dataverse bootstrap and steady-state identities | A8 | Proposed hypothesis |
+| [0024](./ADR-0024-effective-date-integrity-options.md) | Effective-date integrity options | A8 | Accepted |
+| [0025](./ADR-0025-cicd-workflow-naming-convention.md) | CI/CD workflow naming convention | A8 | Accepted |
+| [0026](./ADR-0026-inbound-analytics-projection-pattern.md) | Inbound analytics projection pattern (data platform → CRM) | A3 · A7 | Accepted |
+| [0027](./ADR-0027-page-level-pcf-and-local-first-polish-loop.md) | Page-level PCF + the PCF Local-First Polish Loop | A4 | Accepted |
 
 ADRs 0011, 0012, 0013, 0017, 0018, 0019, 0020, and 0023 remain proposed until
 confirmed with customer architecture in the next review.

--- a/docs/superpowers/patterns/pcf-local-first-polish-loop.md
+++ b/docs/superpowers/patterns/pcf-local-first-polish-loop.md
@@ -1,0 +1,78 @@
+# Pattern — PCF Local-First Polish Loop
+
+> Anchored by [ADR-0027](../../adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md). Referenced by the `ux-designer` agent (AG-E-11).
+
+A repeatable method for building **pixel-faithful, tested, Dataverse-bound PCF
+controls** by developing locally against mock data first, polishing against a
+visual ground truth with an agent in the loop, and only then wiring to Dataverse.
+
+## When to use
+
+Any PCF surface that must match a visual ground truth (a mockup, an existing
+HTML web resource, a brand spec) closely. Prefer **configuration → low-code →
+pro-code**: only reach for this once out-of-box MDA config cannot meet the bar.
+
+## The loop
+
+### 1. Model-first types + fixtures
+Derive TypeScript interfaces from the Dataverse columns the control will bind to,
+and author **mock JSON fixtures** typed to them. Fixtures are the same shape the
+real `context` will provide, so the component never knows it's on mock data.
+
+```
+src/types.ts        // interfaces mirroring the data model
+src/fixtures.ts     // typed mock data (import repo JSON where seed exists)
+```
+
+### 2. Local Vite harness (hot reload, full screen)
+Render the component in a standalone Vite app with the fixtures — fast HMR, full
+viewport, no Power Platform round-trip.
+
+```
+harness/index.html
+harness/main.tsx    // renders <Control data={fixtures} />
+npm run dev         // http://localhost:5173
+```
+
+### 3. Agent-in-the-loop polish against the ground truth
+Serve locally, then **share the browser page with the VS Code agent** and compare
+to the ground truth:
+
+- `open_browser_page http://localhost:5173` (the PCF harness)
+- open the ground-truth artifact too (e.g. the local HTML web resource)
+- `screenshot_page` both, diff, and have the **ux-designer** agent (AG-E-11) tune
+  Fluent v9 theme tokens, spacing, and typography until it matches.
+- Port CSS variables from the ground truth into Fluent tokens where the palette
+  already aligns (Fluent-based mockups map almost 1:1).
+
+Iterate here until fidelity is reached — this is cheap because it's local.
+
+### 4. Wrap as PCF + bind Dataverse
+Keep the **same** component; swap the data source from fixtures to `context`
+(dataset / WebAPI). Jest tests use a mocked `context`.
+
+```
+ControlManifest.Input.xml
+index.ts            // maps context → the component's props
+```
+
+### 5. ALM
+Controls live under `solution/**/Controls/**` per
+[pcf-alm](../../../.github/instructions/pcf-alm.instructions.md); packed into the
+app solution; CI → DEV → TEST. Declare upgrade impact + licensing per control.
+
+## Guardrails
+
+- Tests first (Jest + React Testing Library) for each subcomponent.
+- WCAG 2.1 AA: keyboard nav, roles, contrast via Fluent tokens.
+- Multilingual strings (repo standard: EN/DE/FR/IT — 1033/1031/1036/1040).
+- AI-authored content renders a visible provenance badge + "AI-assisted"
+  disclosure (Responsible AI).
+- No real customer data in fixtures — synthetic only.
+
+## Why local-first
+
+The expensive part of pixel work is iteration. Doing it against a live MDA form
+is slow (publish + reload) and couples layout debugging to Dataverse. Local Vite
++ shared-browser review collapses the loop to seconds and lets an agent compare
+against the ground truth directly. Dataverse binding is the *last*, small step.


### PR DESCRIPTION
Sprint 3 Phase 0 (governance scaffolding for the Advisor Cockpit). Closes S3 Phase 0 of the plan; epic #55.

- **ADR-0026** inbound analytics projection pattern (catalogue of 3; materialized projection chosen) - closes the open TBD in ADR-0018.
- **ADR-0027** page-level PCF + the PCF Local-First Polish Loop.
- **Pattern doc** docs/superpowers/patterns/pcf-local-first-polish-loop.md (referenced by the ux-designer agent AG-E-11).
- ADR index updated (adds 0024-0027; bumps latest-allocated to 0027); ADR-0018 open item resolved.

Note: pre-existing duplicate ADR-0023 number (two files) left untouched - flagged for separate housekeeping. Milestone 'Sprint 3 - Advisor Cockpit' + phase issues #56-#65 created.