### PR TITLE
Sprint 3 Phase 4: measure-snapshot consumption contract (S3-04)

### DIFF
--- a/api/advisor-cockpit/measure-snapshot.sample.json
+++ b/api/advisor-cockpit/measure-snapshot.sample.json
@@ -1,0 +1,5 @@
+[
+  { "subject": "GA-Bern-Mittelland", "subjectType": "ga", "metric": "GoalAttainment", "region": "Mittelland", "productLine": null, "asOfDate": "2026-06-30", "value": 96, "unit": "percent", "externalSystem": "databricks-mock" },
+  { "subject": "GA-Bern-Mittelland", "subjectType": "ga", "metric": "GrowthYoY", "region": "Mittelland", "productLine": null, "asOfDate": "2026-06-30", "value": 7.2, "unit": "percent", "externalSystem": "databricks-mock" },
+  { "subject": "Motorfahrzeug", "subjectType": "product", "metric": "Forecast", "region": "Mittelland", "productLine": "MotorVehicle", "asOfDate": "2026-06-30", "value": 148, "unit": "chf_thousands", "externalSystem": "databricks-mock" }
+]

--- a/api/advisor-cockpit/measure-snapshot.schema.json
+++ b/api/advisor-cockpit/measure-snapshot.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crmshowcase/api/advisor-cockpit/measure-snapshot.schema.json",
+  "title": "Advisor Cockpit — Measure Snapshot projection",
+  "description": "Versioned consumption contract for the data-platform analytics projection surfaced by the Advisor Cockpit and Sales Leader Dashboard. Producer: the enterprise data platform (Databricks), mocked in the demo by the CD pipeline seed. Consumer: the crmshow_measuresnapshot Dataverse table and the two PCF controls. Swapping the producer does not change this contract. See ADR-0026.",
+  "type": "array",
+  "items": { "$ref": "#/$defs/measureRow" },
+  "$defs": {
+    "measureRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject", "subjectType", "metric", "asOfDate", "value", "unit", "externalSystem"],
+      "properties": {
+        "subject": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Business key of the thing being measured (GA name, product line, region, portfolio id, or a CRM record key)."
+        },
+        "subjectType": {
+          "enum": ["lead", "account", "contact", "ga", "region", "product", "portfolio"],
+          "description": "What kind of subject the measure is about."
+        },
+        "metric": {
+          "enum": ["GoalAttainment", "GrowthYoY", "NPS", "Automation", "Forecast", "Conversion", "Efficiency", "Satisfaction", "Quality"],
+          "description": "Metric code; mirrors the crmshow_metrictype choice."
+        },
+        "region": {
+          "type": ["string", "null"],
+          "enum": ["Mittelland", "Zurich", "Romandie", "Ticino", null],
+          "description": "Optional region dimension; mirrors the crmshow_region choice."
+        },
+        "productLine": {
+          "type": ["string", "null"],
+          "enum": ["MotorVehicle", "HouseholdContents", "CommercialProperty", "Pension3a", "LegalProtection", null],
+          "description": "Optional product-line dimension; mirrors the crmshow_productline choice."
+        },
+        "asOfDate": {
+          "type": "string",
+          "format": "date",
+          "description": "Effective date of the measure value (YYYY-MM-DD); every projected row is effective-dated."
+        },
+        "value": {
+          "type": "number",
+          "description": "The numeric measure value; unit gives the interpretation."
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unit of the value, e.g. percent, nps, chf_thousands, count."
+        },
+        "externalSystem": {
+          "const": "databricks-mock",
+          "description": "Identifies the producing system contract. In the demo this is the mock; production would carry the real system identifier."
+        }
+      }
+    }
+  }
+}

--- a/scripts/solution/tests/MeasureSnapshotContract.Tests.ps1
+++ b/scripts/solution/tests/MeasureSnapshotContract.Tests.ps1
@@ -1,0 +1,65 @@
+# Pester tests for the Advisor Cockpit measure-snapshot consumption contract (ADR-0026).
+# Runs under Windows PowerShell 5.1 (structural checks) and validates against the
+# JSON Schema when a validator is available (Test-Json -SchemaFile on PowerShell 7).
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:schemaPath = Join-Path $script:repoRoot 'api/advisor-cockpit/measure-snapshot.schema.json'
+    $script:samplePath = Join-Path $script:repoRoot 'api/advisor-cockpit/measure-snapshot.sample.json'
+
+    $script:subjectTypes = @('lead', 'account', 'contact', 'ga', 'region', 'product', 'portfolio')
+    $script:metrics = @('GoalAttainment', 'GrowthYoY', 'NPS', 'Automation', 'Forecast', 'Conversion', 'Efficiency', 'Satisfaction', 'Quality')
+    $script:regions = @('Mittelland', 'Zurich', 'Romandie', 'Ticino')
+    $script:productLines = @('MotorVehicle', 'HouseholdContents', 'CommercialProperty', 'Pension3a', 'LegalProtection')
+
+    function Get-Sample {
+        Get-Content -LiteralPath $script:samplePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
+
+    # Returns $true/$false when a schema validator is available, else $null (skip).
+    function Test-SampleAgainstSchema {
+        $cmd = Get-Command Test-Json -ErrorAction SilentlyContinue
+        if ($null -eq $cmd -or -not $cmd.Parameters.ContainsKey('SchemaFile')) { return $null }
+        $json = Get-Content -LiteralPath $script:samplePath -Raw -Encoding UTF8
+        try {
+            return [bool](Test-Json -Json $json -SchemaFile $script:schemaPath -ErrorAction Stop)
+        } catch {
+            return $false
+        }
+    }
+}
+
+Describe 'measure-snapshot contract' {
+    It 'schema and sample files exist and parse as JSON' {
+        Test-Path -LiteralPath $script:schemaPath | Should -BeTrue
+        Test-Path -LiteralPath $script:samplePath | Should -BeTrue
+        { Get-Content -LiteralPath $script:schemaPath -Raw -Encoding UTF8 | ConvertFrom-Json } | Should -Not -Throw
+        { Get-Sample } | Should -Not -Throw
+    }
+
+    It 'every sample row satisfies the contract rules' {
+        $rows = [object[]]((Get-Content -LiteralPath $script:samplePath -Raw -Encoding UTF8) | ConvertFrom-Json)
+        $rows.Count | Should -BeGreaterThan 0
+        foreach ($r in $rows) {
+            [string]$r.subject | Should -Not -BeNullOrEmpty
+            [string]$r.subjectType | Should -BeIn $script:subjectTypes
+            [string]$r.metric | Should -BeIn $script:metrics
+            if ($null -ne $r.region) { [string]$r.region | Should -BeIn $script:regions }
+            if ($null -ne $r.productLine) { [string]$r.productLine | Should -BeIn $script:productLines }
+            [string]$r.asOfDate | Should -Match '^\d{4}-\d{2}-\d{2}$'
+            { [double]$r.value } | Should -Not -Throw -Because 'value must be numeric'
+            [string]$r.unit | Should -Not -BeNullOrEmpty
+            [string]$r.externalSystem | Should -Be 'databricks-mock'
+        }
+    }
+
+    It 'sample validates against the JSON Schema when a validator is available' {
+        $result = Test-SampleAgainstSchema
+        if ($null -eq $result) {
+            Set-ItResult -Skipped -Because 'Test-Json -SchemaFile is unavailable in this runtime (Windows PowerShell 5.1)'
+        }
+        else {
+            $result | Should -BeTrue
+        }
+    }
+}


### PR DESCRIPTION
## Sprint 3 — Phase 4: measure-snapshot consumption contract (S3-04)

Closes #59

### What
Adds the versioned **consumption contract** for the data-platform analytics projection that feeds the Advisor Cockpit and Sales Leader Dashboard (per [ADR-0026](../blob/main/docs/adr/ADR-0026-inbound-analytics-projection-pattern.md), materialized-projection pattern).

| File | Purpose |
| --- | --- |
| `api/advisor-cockpit/measure-snapshot.schema.json` | JSON Schema (draft 2020-12), array of `measureRow` |
| `api/advisor-cockpit/measure-snapshot.sample.json` | 3 representative rows (GA goal attainment, YoY growth, product forecast) |
| `scripts/solution/tests/MeasureSnapshotContract.Tests.ps1` | Pester test: structural rules (always) + schema validation (when `Test-Json -SchemaFile` available) |

### Contract shape
`measureRow` required fields: `subject`, `subjectType`, `metric`, `asOfDate`, `value`, `unit`, `externalSystem`.
- `subjectType` ∈ lead/account/contact/ga/region/product/portfolio
- `metric` ∈ GoalAttainment/GrowthYoY/NPS/Automation/Forecast/Conversion/Efficiency/Satisfaction/Quality (mirrors the planned `crmshow_metrictype` choice)
- `region` / `productLine` optional dimensions (mirror `crmshow_region` / `crmshow_productline`)
- `externalSystem` const `databricks-mock` — the demo mock; swapping the producer does not change this contract.

### Evidence
Local run (Windows PowerShell 5.1, Pester 6.0.1):

```
[+] schema and sample files exist and parse as JSON
[+] every sample row satisfies the contract rules
[!] sample validates against the JSON Schema ... skipped (Test-Json -SchemaFile unavailable on 5.1)
Tests Passed: 2, Failed: 0, Skipped: 1
```

The schema-validation assertion runs (does not skip) under the CI runner's PowerShell 7.

### Scope note
This PR delivers the **contract + fixtures + test** only. Task 4.2 (the `crmshow_measuresnapshot` Dataverse table in `crmshow_Integration`) is DEV-gated — authored in DEV via make.powerapps.com, then exported/unpacked/committed — and lands in a follow-up once the Foundation choices (Phase 1) exist.

### Traceability
US: S3-04 (#59) · Epic #55 · Milestone _Sprint 3 - Advisor Cockpit_ · ADR-0026.
