### PR TITLE
docs(superpowers): anchor Sprint Operating Model as default + reconcile Sprint 3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,6 +161,13 @@ Treat as constraints:
 
 - [SUPERPOWERS_CONTRACT.md](../SUPERPOWERS_CONTRACT.md) — the binding
   operating contract.
+- [docs/superpowers/SPRINT-OPERATING-MODEL.md](../docs/superpowers/SPRINT-OPERATING-MODEL.md)
+  — **the default way to run any sprint or multi-stream build**: brainstorm and
+  design on the trunk → Sprint Charter issue + one handover packet per stream
+  (each with an autonomy class) → isolated `wt/` worktrees via
+  `scripts/orchestration/*` → PR intake (never self-merge) → human merge. Do
+  **not** improvise a milestone/epic/branch flow. Sprint index + live status:
+  [docs/superpowers/sprints/](../docs/superpowers/sprints/).
 - [AGENTS.md](../AGENTS.md) — 6 runtime agents (`AG-F-##`) + 10 engineering
   agents (`AG-E-##`).
 - [.github/agents/](./agents/) — one Markdown file per custom agent Copilot

--- a/.github/instructions/superpowers.instructions.md
+++ b/.github/instructions/superpowers.instructions.md
@@ -14,6 +14,7 @@ Apply these rules to all edits in this repository.
 6. Human approval is required before agents send external communication, change pricing/quotes, or close cases — unless a story's acceptance criteria explicitly scopes autonomy.
 7. Architecture-impacting changes update or add an ADR under [docs/adr/](../../docs/adr/).
 8. Models, prompts, and agent tool schemas are versioned in Git, PR-reviewed, and changelogged.
+9. Run every sprint or multi-stream build through [docs/superpowers/SPRINT-OPERATING-MODEL.md](../../docs/superpowers/SPRINT-OPERATING-MODEL.md): brainstorm/design on the trunk → Sprint Charter issue + one handover packet per stream (with an autonomy class) → isolated `wt/` worktrees via `scripts/orchestration/*` → PR intake (never self-merge) → human merge. Do not improvise a milestone/epic/branch flow.
 
 See [SUPERPOWERS_CONTRACT.md](../../SUPERPOWERS_CONTRACT.md) and
 [copilot-instructions.md](../copilot-instructions.md) for the full policy.

--- a/docs/superpowers/sprints/README.md
+++ b/docs/superpowers/sprints/README.md
@@ -1,0 +1,24 @@
+# Sprints — index
+
+Canonical list of sprints run through the
+[Sprint Operating Model](../SPRINT-OPERATING-MODEL.md). Each sprint has a
+**charter issue** (`#S`), one **stream issue** (`#N`) per delegated stream, and a
+`sprint.md` + `STATUS.md` here. If an issue is not linked below, it is **not**
+part of an active sprint (it is a standalone feature/blocker/idea in the backlog).
+
+| Sprint | Folder | Charter | Streams | Proof / theme | State |
+| --- | --- | --- | --- | --- | --- |
+| sprint-001 | [sprint-001/](./sprint-001/) | #43 | #44 | Proof #1 — the delegated operating model | merged |
+| sprint-002 | [sprint-002-insurance-foundation-promotion/](./sprint-002-insurance-foundation-promotion/) | #46 | #47 · #48 · #49 | Proof #2 — Insurance Foundation DEV→TEST | merged |
+| sprint-003 | [sprint-003-advisor-cockpit/](./sprint-003-advisor-cockpit/) | #55 | #56–#65 (see charter) | Advisor Cockpit + Sales Leader Dashboard | in progress |
+
+## Backlog issues not tied to a sprint
+
+These are standalone items; triage into a future sprint charter when picked up.
+
+| Issue | Kind | Note |
+| --- | --- | --- |
+| #61 | Deferred | Copilot Studio NBA agent — needs a use-case description before it re-enters a sprint |
+| #40 | Blocker | Bootstrap DEV CI security-role authoring privilege — verify against sprint-002 outcome |
+| #9 | Enhancement | Enforce effective-date integrity — decision recorded in ADR-0024; enforcement still open |
+| #5 | Idea | Power Platform → Git integration (Preview) — standing tooling idea |

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -1,0 +1,31 @@
+# Sprint-003 — status board
+
+Live status for the Advisor Cockpit (charter **#55**). See the
+[charter](./sprint.md) and the
+[Sprint Operating Model](../../SPRINT-OPERATING-MODEL.md).
+
+| Stream | Issue | Class | Branch | PR | State | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| governance | #55 | DESIGN-SENSITIVE | feat/s3-phase0-adrs | #66 | ✅ merged | ADR-0026 (projection pattern, closes ADR-0018 TBD) + ADR-0027 (page-level PCF + polish loop) + pattern doc |
+| measure-contract | #59 | EXECUTION-ONLY | feat/s3-phase4-measure-contract | #67 | ✅ merged | `api/advisor-cockpit/measure-snapshot.schema.json` + sample + Pester; suite green |
+| seed-fixtures + loader | #60 | EXECUTION-ONLY | feat/s3-phase5-seed-fixtures | #68 | ✅ merged | 7 synthetic fixtures (exact mockup labels/KPIs) + `seed-advisor-cockpit.ps1` + tests; full suite 367 passed / 2 skipped |
+| advisorcockpit-pcf | #62 | DESIGN-SENSITIVE | feat/sprint-003-advisorcockpit-pcf | — | ▶ next | packet: [streams/advisorcockpit-pcf.md](./streams/advisorcockpit-pcf.md) |
+| salesleaderdashboard-pcf | #63 | DESIGN-SENSITIVE | feat/sprint-003-salesleaderdashboard-pcf | — | ▶ next | packet: [streams/salesleaderdashboard-pcf.md](./streams/salesleaderdashboard-pcf.md) |
+| foundation-choices | #56 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | needs live DEV (make.powerapps.com authoring) |
+| foundational-tables | #57 | DESIGN-SENSITIVE | — | — | ⏳ DEV-gated | slices 1–5 (mobiliar-data-model-extension) |
+| cockpit-tables | #58 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | crmshow_nextbestaction + provenance |
+| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | — | — | ⏳ DEV-gated | task 5.3; needs the tables to exist for smoke |
+| mda-app | #64 | DESIGN-SENSITIVE | — | — | ⏳ DEV-gated | app + two custom pages |
+| e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
+| nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
+
+## Run log
+
+- Reconciled onto the operating model after Phases 0/4/5 had already merged
+  under an ad-hoc milestone+epic+phase flow. Charter **#55**; streams mapped
+  above; the model is now the default for the remaining streams.
+- Next: streams **#62** and **#63** (the two PCF surfaces) run **attended**
+  (DESIGN-SENSITIVE — pixel-perfect UI), each in its own `wt/` worktree off
+  `main`, via the PCF local-first polish loop (ADR-0027) against the local HTML
+  web-resource ground truth.
+- DEV-gated streams (#56/#57/#58/#64/#65 + 5.3) wait on live Power Platform DEV.

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
@@ -1,0 +1,62 @@
+# Sprint-003 — Advisor Cockpit
+
+Charter for the third sprint: rebuild the BA's HTML **Sales Advisory Cockpit** +
+**Sales Leader Dashboard** as a pixel-faithful Model-Driven App on the
+six-solution architecture, with a Dataverse-mocked data platform and an advisory
+Copilot NBA agent, deployed DEV→TEST.
+
+**Design spec:** [../../specs/2026-08-11-advisor-cockpit-design.md](../../specs/2026-08-11-advisor-cockpit-design.md)
+**Plan:** [../../plans/2026-08-11-advisor-cockpit.md](../../plans/2026-08-11-advisor-cockpit.md)
+**ADRs:** [ADR-0026](../../../adr/ADR-0026-inbound-analytics-projection-pattern.md) · [ADR-0027](../../../adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md)
+**Pattern:** [pcf-local-first-polish-loop](../../patterns/pcf-local-first-polish-loop.md)
+**Operating model:** [../../SPRINT-OPERATING-MODEL.md](../../SPRINT-OPERATING-MODEL.md)
+**Charter issue:** #55 · **Milestone:** Sprint 3 - Advisor Cockpit
+
+> **Note on convention.** Sprint-003 began under an ad-hoc milestone + epic + phase
+> flow (#55–#65) before it was reconciled onto the operating model. This charter is
+> the reconciliation: the phases below are the streams, each with an autonomy class.
+> Phases 0/4/5 already merged; the remaining streams follow the model going forward.
+
+## Outcome
+
+Two page-level React + Fluent UI v9 PCF surfaces (Recharts) on MDA custom pages,
+reading a Dataverse **measure-snapshot** projection (materialized-projection
+pattern, ADR-0026) plus native Lead/Opportunity/Activity/Case and thin
+policy/claim projections. Analytics are mocked by pipeline-seeded synthetic
+fixtures standing in for Databricks. Agents are advisory only (ADR-0014).
+
+## Streams
+
+Autonomy class per the [Handover Contract](../../contracts/HANDOVER-CONTRACT.md).
+DESIGN-SENSITIVE streams run **attended**; EXECUTION-ONLY may run headless.
+
+| Stream | Phase | Issue | Class | State |
+| --- | --- | --- | --- | --- |
+| governance (ADRs 0026/0027 + pattern) | 0 | #55 | DESIGN-SENSITIVE | ✅ merged (PR #66) |
+| measure-contract | 4 | #59 | EXECUTION-ONLY | ✅ merged (PR #67) |
+| seed-fixtures + loader | 5.1/5.2 | #60 | EXECUTION-ONLY | ✅ merged (PR #68) |
+| advisorcockpit-pcf | 7 | #62 | DESIGN-SENSITIVE | ▶ next (attended, local-first polish loop) |
+| salesleaderdashboard-pcf | 8 | #63 | DESIGN-SENSITIVE | ▶ next (attended, local-first polish loop) |
+| foundation-choices | 1 | #56 | EXECUTION-ONLY | ⏳ DEV-gated |
+| foundational-tables (slices 1–5) | 2 | #57 | DESIGN-SENSITIVE | ⏳ DEV-gated |
+| cockpit-tables (nba + provenance) | 3 | #58 | EXECUTION-ONLY | ⏳ DEV-gated |
+| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ DEV-gated (needs tables) |
+| mda-app + custom pages | 9 | #64 | DESIGN-SENSITIVE | ⏳ DEV-gated |
+| e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated |
+| nba-agent (Copilot Studio) | 6 | #61 | DESIGN-SENSITIVE | ⏸ deferred (out of sprint) |
+
+The two **next** streams (7, 8) are independent and parallelizable — run them as
+two worktrees off `main` once the PCF prerequisites (contract + fixtures) are on
+the trunk (they are, via #67/#68).
+
+## Definition of done
+
+- [x] Governance: ADR-0026/0027 + polish-loop pattern recorded (#66).
+- [x] Measure-snapshot consumption contract + tests (#67).
+- [x] Synthetic seed fixtures + idempotent loader + tests (#68).
+- [ ] `AdvisorCockpit` PCF pixel-faithful to the mockup, local-first polished (#62).
+- [ ] `SalesLeaderDashboard` PCF pixel-faithful to the mockup (#63).
+- [ ] Foundation choices + foundational/cockpit tables authored in DEV (#56/#57/#58).
+- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3).
+- [ ] MDA app "Advisor Cockpit" + custom pages (#64).
+- [ ] E2E DEV→TEST evidence (#65).

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/streams/advisorcockpit-pcf.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/streams/advisorcockpit-pcf.md
@@ -1,0 +1,54 @@
+# Handover Packet — advisorcockpit-pcf
+
+- **Sprint:** sprint-003
+- **Stream:** advisorcockpit-pcf
+- **GitHub issue:** #62
+- **Autonomy class:** DESIGN-SENSITIVE (pixel-perfect UI — run attended)
+- **Branch:** feat/sprint-003-advisorcockpit-pcf
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-003-advisorcockpit-pcf
+- **Approved design ref:** [ADR-0027](../../../../adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md) · [spec](../../../specs/2026-08-11-advisor-cockpit-design.md) · [pcf-local-first-polish-loop](../../../patterns/pcf-local-first-polish-loop.md)
+
+## Goal / Definition of Done
+
+Build the `AdvisorCockpit` page-level PCF (React 18 + Fluent UI v9 + Recharts),
+pixel-faithful to the local HTML ground truth
+`intake/mobiliar/source/WebResources/cr7e8_sharedpage01advisorcockpit`
+(git-ignored, local-only), reading the Phase-5 fixtures for local development.
+
+Done when: the control renders the cockpit (greeting/KPIs, lead queue + Brunner
+cluster, NBA copilot cards, Termine/Aufgaben, Anliegen & Schäden) from
+`data/scenarios/advisor-cockpit/*.json`; the local Vite harness runs at
+`localhost:5173`; a screenshot diff against the web resource is within tolerance
+(ux-designer reviewed); Fluent v9 tokens are ported from the mockup CSS
+(`--brand #0078d4`, Segoe UI, neutral n0–n190); Jest + RTL tests pass; the PCF
+builds. Binding to Dataverse is a later DEV-gated step (not in this stream).
+
+## Allowed scope (paths)
+
+- `solution/apps/sales/Controls/AdvisorCockpit/**`
+- local harness + fixtures wiring only under that control folder
+- **read-only** reference: `data/scenarios/advisor-cockpit/**`, the local web resource
+
+Do not touch the six-solution manifests, other controls, or the seed loader.
+
+## Verification commands
+
+```
+npm ci
+npm run build        # PCF/tsc build is clean
+npm test             # Jest + React Testing Library green
+npm run start         # Vite harness on localhost:5173 for screenshot diff
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1 and the PCF instructions
+(`.github/instructions/pcf-alm.instructions.md`, `pcf-best-practices.instructions.md`).
+Synthetic data only. Headless streams additionally deny `shell(git push)`,
+`shell(rm)`, `shell(git reset)` — but this stream is DESIGN-SENSITIVE, so run it
+attended, not headless.
+
+## Escalation rule
+
+If a new design decision is needed → STOP, write `BLOCKED: needs design`, surface
+the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/streams/salesleaderdashboard-pcf.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/streams/salesleaderdashboard-pcf.md
@@ -1,0 +1,56 @@
+# Handover Packet — salesleaderdashboard-pcf
+
+- **Sprint:** sprint-003
+- **Stream:** salesleaderdashboard-pcf
+- **GitHub issue:** #63
+- **Autonomy class:** DESIGN-SENSITIVE (pixel-perfect UI — run attended)
+- **Branch:** feat/sprint-003-salesleaderdashboard-pcf
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-003-salesleaderdashboard-pcf
+- **Approved design ref:** [ADR-0027](../../../../adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md) · [spec](../../../specs/2026-08-11-advisor-cockpit-design.md) · [pcf-local-first-polish-loop](../../../patterns/pcf-local-first-polish-loop.md)
+
+## Goal / Definition of Done
+
+Build the `SalesLeaderDashboard` page-level PCF (React 18 + Fluent UI v9 +
+Recharts), pixel-faithful to the local HTML ground truth
+`intake/mobiliar/source/WebResources/cr7e8_sharedpage12v2salessteeringcockpit`
+(git-ignored, local-only), reading the Phase-5 `measures.json` projection for
+local development.
+
+Done when: the control renders the Führungsdashboard (scorecard gauges
+Zielerreichung 96 % / Wachstum YoY 7.2 % / NPS 42 / Automation 72 %, forecast
+confidence band 320→412 vs target 430, product-line + region drill, funnel,
+GA benchmark) from `data/scenarios/advisor-cockpit/measures.json`; the local Vite
+harness runs at `localhost:5173`; a screenshot diff against the web resource is
+within tolerance (ux-designer reviewed); Fluent v9 tokens ported from the mockup
+CSS; Jest + RTL tests pass; the PCF builds. Binding to Dataverse is a later
+DEV-gated step (not in this stream).
+
+## Allowed scope (paths)
+
+- `solution/apps/sales/Controls/SalesLeaderDashboard/**`
+- local harness + fixtures wiring only under that control folder
+- **read-only** reference: `data/scenarios/advisor-cockpit/measures.json`, the local web resource
+
+Do not touch the six-solution manifests, other controls, or the seed loader.
+
+## Verification commands
+
+```
+npm ci
+npm run build        # PCF/tsc build is clean
+npm test             # Jest + React Testing Library green
+npm run start         # Vite harness on localhost:5173 for screenshot diff
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1 and the PCF instructions
+(`.github/instructions/pcf-alm.instructions.md`, `pcf-best-practices.instructions.md`).
+Synthetic data only. Headless streams additionally deny `shell(git push)`,
+`shell(rm)`, `shell(git reset)` — but this stream is DESIGN-SENSITIVE, so run it
+attended, not headless.
+
+## Escalation rule
+
+If a new design decision is needed → STOP, write `BLOCKED: needs design`, surface
+the question to the control-plane chat. Never self-approve.


### PR DESCRIPTION
## Anchor the Sprint Operating Model + reconcile Sprint 3 onto it

Follow-up to the process gap we caught: Sprint 3 ran under an ad-hoc
milestone+epic+phase flow instead of [SPRINT-OPERATING-MODEL.md](../blob/main/docs/superpowers/SPRINT-OPERATING-MODEL.md)
(which sprint-001 and sprint-002 used properly). This PR makes the model the
**default** and reconciles Sprint 3 onto it — no code, docs/governance only.

### Anchor the model as default (so this can't drift again)
- `.github/instructions/superpowers.instructions.md` — new rule **9**: run every sprint/multi-stream build through the operating model (charter + stream packets + worktrees + intake); don't improvise a milestone/branch flow. (Path-scoped, auto-loaded.)
- `.github/copilot-instructions.md` §7 — added the operating model as *the default way to run any sprint*, linking the sprints index.

### Make issues legible ("which issues are relevant?")
- `docs/superpowers/sprints/README.md` — canonical **sprint index**: sprint-001 (charter #43), sprint-002 (#46), sprint-003 (#55), plus a **backlog** table for the standalone issues (#61 deferred, #40 blocker, #9 enhancement, #5 idea) that are *not* part of any sprint.

### Reconcile Sprint 3 (Option A)
- `docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md` — charter mapping every phase → a **stream** with an autonomy class; Phases 0/4/5 merged, 7/8 next (DESIGN-SENSITIVE), 1/2/3/5.3/9/10 DEV-gated, 6 deferred.
- `.../STATUS.md` — live status board (same format as sprint-002).
- `.../streams/advisorcockpit-pcf.md` + `.../streams/salesleaderdashboard-pcf.md` — handover packets for the two next PCF streams (#62/#63), attended, via the local-first polish loop.

### Issue audit summary (for the tracker cleanup)
12 open issues. Sprint 3 = milestone #1 (epic #55 + #56/#57/#58/#62/#63/#64/#65; #59/#60 closed by #67/#68). Standalone backlog: #61 (deferred), #40 (DEV CI security-role blocker — needs a relevance check), #9 (effective-date integrity — decision in ADR-0024, enforcement still open), #5 (Power Platform→Git idea). sprint-001/002 charter+stream issues are all closed.

**Open questions handled separately (not in this PR — shared-tracker mutations):** whether to add autonomy/`dev-gated` labels, retitle epic #55 as the charter, and dispose of #40/#9/#5. Also noted: ADR-0023 number is duplicated (two files) — worth renumbering.

### Traceability
Relates to the process question on SPRINT-OPERATING-MODEL.md · Sprint 3 charter #55.
