### PR TITLE
fix(security-roles): detect self-referencing root roles (#40)

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -2338,6 +2338,18 @@ function Get-ContractTableSchemaName {
     return [string]$tables[0].schemaName
 }
 
+function Test-InsuranceFoundationRoleIsRoot {
+    # Root roles may be represented with a null parent root role or as a
+    # self-reference (parentrootroleid == roleid). Treat both as root.
+    param(
+        [AllowNull()] $Role
+    )
+    if ($null -eq $Role) { return $false }
+    $parentRootRoleId = ([string]$Role._parentrootroleid_value).Trim('{}')
+    if ([string]::IsNullOrWhiteSpace($parentRootRoleId)) { return $true }
+    return ($parentRootRoleId -ieq ([string]$Role.roleid).Trim('{}'))
+}
+
 function Invoke-RoleReconciliation {
     param(
         [Parameter(Mandatory)] $Role,
@@ -2349,7 +2361,17 @@ function Invoke-RoleReconciliation {
         }
     }
     $escapedName = $Role.name.Replace("'", "''")
-    $existing = Get-One "/roles?`$select=roleid,name,description,_businessunitid_value&`$filter=name eq '$escapedName' and _parentrootroleid_value eq null"
+    $roleResponse = Invoke-DataverseRequest -Method GET -Path "/roles?`$select=roleid,name,description,_businessunitid_value,_parentrootroleid_value&`$filter=name eq '$escapedName'"
+    $rootRoles = @()
+    if ($null -ne $roleResponse) {
+        $rootRoles = @($roleResponse.value | Where-Object {
+            Test-InsuranceFoundationRoleIsRoot -Role $_
+        })
+    }
+    if ($rootRoles.Count -gt 1) {
+        throw "Metadata resolution was ambiguous for root security role '$($Role.name)'."
+    }
+    $existing = if ($rootRoles.Count -eq 1) { $rootRoles[0] } else { $null }
     if ($null -eq $existing) {
         $businessUnit = Get-One "/businessunits?`$select=businessunitid&`$filter=parentbusinessunitid eq null"
         if ($null -eq $businessUnit -or -not $businessUnit.businessunitid) {

--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -873,8 +873,30 @@ function Get-ConvergenceRootInsuranceRolesPath {
     $escapedRolePrefix = ConvertTo-ODataKeyString $RolePrefix
     return (
         "/roles?`$select=roleid,name,_parentrootroleid_value&" +
-        "`$filter=_parentrootroleid_value eq null and startswith(name,'$escapedRolePrefix')"
+        "`$filter=startswith(name,'$escapedRolePrefix')"
     )
+}
+
+function Test-ConvergenceRoleIsRoot {
+    # A root role has no parent root role. Some organisations represent the
+    # root as a self-reference (parentrootroleid == roleid) instead of null,
+    # so treat both shapes as root.
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Role
+    )
+
+    if ($null -eq $Role) {
+        return $false
+    }
+
+    $parentRootRoleId = ([string]$Role._parentrootroleid_value).Trim('{}')
+    if ([string]::IsNullOrWhiteSpace($parentRootRoleId)) {
+        return $true
+    }
+
+    return ($parentRootRoleId -ieq ([string]$Role.roleid).Trim('{}'))
 }
 
 function Get-ConvergenceRoleByIdPath {
@@ -3318,6 +3340,10 @@ function Test-InsuranceFoundationUnexpectedMetadata {
         if (-not (Test-ConvergenceStartsWithPrefix `
                     -Value $roleName `
                     -Prefix $rolePrefix)) {
+            continue
+        }
+
+        if (-not (Test-ConvergenceRoleIsRoot -Role $role)) {
             continue
         }
 

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -61,9 +61,31 @@ function Get-InsuranceSecurityRolePath {
 
     $escapedName = ConvertTo-ODataStringLiteral -Value $RoleName
     return (
-        "/roles?`$select=roleid,name&" +
-        "`$filter=_parentrootroleid_value eq null and name eq '$escapedName'"
+        "/roles?`$select=roleid,name,_parentrootroleid_value&" +
+        "`$filter=name eq '$escapedName'"
     )
+}
+
+function Test-InsuranceSecurityRoleIsRoot {
+    # A root security role has no parent root role. Some organisations
+    # materialise the root as a self-reference (parentrootroleid == roleid)
+    # rather than null, so treat both shapes as root.
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Role
+    )
+
+    if ($null -eq $Role) {
+        return $false
+    }
+
+    $parentRootRoleId = ([string]$Role._parentrootroleid_value).Trim('{}')
+    if ([string]::IsNullOrWhiteSpace($parentRootRoleId)) {
+        return $true
+    }
+
+    return ($parentRootRoleId -ieq ([string]$Role.roleid).Trim('{}'))
 }
 
 function Get-InsuranceSecurityRoleSolutionMembershipPath {
@@ -621,7 +643,9 @@ function Test-InsuranceSecurityRole {
         -Path (Get-InsuranceSecurityRolePath -RoleName $roleName)
     $matches = @()
     if ($null -ne $roleResponse) {
-        $matches = @($roleResponse.value)
+        $matches = @($roleResponse.value | Where-Object {
+                Test-InsuranceSecurityRoleIsRoot -Role $_
+            })
     }
 
     if ($matches.Count -eq 0) {

--- a/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceAuthoringPreflight.Tests.ps1
@@ -300,21 +300,24 @@ switch ($path) {
             })
         exit 0
     }
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Reader'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Reader'" {
+        # Self-referencing root shape (parentrootroleid == roleid).
         Write-Json ([pscustomobject]@{
                 value = @([pscustomobject]@{
                         roleid = $readerRoleId
                         name = 'CRM Showcase Insurance Reader'
+                        _parentrootroleid_value = $readerRoleId
                     })
             })
         exit 0
     }
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Data Steward'" {
         $roles = @()
         if ($env:TEST_INSURANCE_PREFLIGHT_SCENARIO -ne 'MissingRoles') {
             $roles += [pscustomobject]@{
                 roleid = $stewardRoleId
                 name = 'CRM Showcase Insurance Data Steward'
+                _parentrootroleid_value = $null
             }
         }
         Write-Json ([pscustomobject]@{ value = @($roles) })

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -1430,7 +1430,7 @@ Describe 'Convergence path builders' {
         Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance ' |
             Should -Be (
                 "/roles?`$select=roleid,name,_parentrootroleid_value&" +
-                "`$filter=_parentrootroleid_value eq null and startswith(name,'CRM Showcase Insurance ')"
+                "`$filter=startswith(name,'CRM Showcase Insurance ')"
             )
     }
 }
@@ -2498,6 +2498,35 @@ Describe 'Unexpected metadata reverse inventory' {
 
         $result.State | Should -Be 'ContractConflict'
         @($result.Unexpected) | Should -Contain 'crmshow_DataModel/role/CRM Showcase Insurance DataModel Reviewer'
+    }
+
+    It 'ignores inherited business-unit role copies that are not the root role' {
+        $fixture = script:New-ReadyConvergenceResponseMap `
+            -Contract $script:contract `
+            -Manifest $script:manifest `
+            -Scenario Ready
+        $inheritedRoleId = script:New-FakeGuid -Index 9720
+        $rootPointerId = script:New-FakeGuid -Index 9721
+        $rolesPath = Get-ConvergenceRootInsuranceRolesPath -RolePrefix 'CRM Showcase Insurance '
+        $fixture.Responses[$rolesPath].value = @(
+            $fixture.Responses[$rolesPath].value +
+            [pscustomobject]@{
+                roleid = $inheritedRoleId
+                name = 'CRM Showcase Insurance Reader'
+                _parentrootroleid_value = $rootPointerId
+            }
+        )
+        # No membership or by-id response is registered for the inherited copy:
+        # it must be skipped before any further lookup.
+        script:Register-ConvergenceTransportMock -Responses $fixture.Responses
+
+        $result = Test-InsuranceFoundationUnexpectedMetadata `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Contract $script:contract `
+            -Manifest $script:manifest
+
+        $result.State | Should -Be 'Ready'
+        @($result.Unexpected) | Should -Not -Contain 'crmshow_Foundation/role/CRM Showcase Insurance Reader'
     }
 
     It 'ignores system-generated table children and unrelated roles or views outside reviewed solutions' {

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -295,16 +295,19 @@ $readerRoleId = '11111111-1111-1111-1111-111111111111'
 $stewardRoleId = '22222222-2222-2222-2222-222222222222'
 
 switch ($path) {
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Reader'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Reader'" {
+        # Self-referencing root shape (parentrootroleid == roleid), which the
+        # previous `eq null` predicate failed to detect.
         Write-Json ([pscustomobject]@{
                 value = @([pscustomobject]@{
                         roleid = $readerRoleId
                         name = 'CRM Showcase Insurance Reader'
+                        _parentrootroleid_value = $readerRoleId
                     })
             })
         exit 0
     }
-    "/roles?`$select=roleid,name&`$filter=_parentrootroleid_value eq null and name eq 'CRM Showcase Insurance Data Steward'" {
+    "/roles?`$select=roleid,name,_parentrootroleid_value&`$filter=name eq 'CRM Showcase Insurance Data Steward'" {
         $roles = @()
         if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -ne 'MissingRole') {
             $resolvedRoleName = if ($env:TEST_INSURANCE_SECURITY_ROLES_SCENARIO -eq 'LowerCaseRoleName') {
@@ -316,6 +319,7 @@ switch ($path) {
             $roles += [pscustomobject]@{
                 roleid = $stewardRoleId
                 name = $resolvedRoleName
+                _parentrootroleid_value = $null
             }
         }
         Write-Json ([pscustomobject]@{ value = @($roles) })
@@ -681,11 +685,11 @@ Describe 'Compare-InsuranceRolePrivileges' {
 }
 
 Describe 'OData query helpers' {
-    It 'escapes root role names and enforces the root-role predicate' {
+    It 'escapes root role names and queries by name for client-side root selection' {
         Get-InsuranceSecurityRolePath -RoleName "Reader's Role" |
             Should -Be (
-                "/roles?`$select=roleid,name&" +
-                "`$filter=_parentrootroleid_value eq null and name eq 'Reader''s Role'"
+                "/roles?`$select=roleid,name,_parentrootroleid_value&" +
+                "`$filter=name eq 'Reader''s Role'"
             )
     }
 
@@ -816,6 +820,43 @@ Describe 'Test-InsuranceSecurityRole' {
         @($result.Details) | Should -Contain (
             "Expected exactly one root security role named '$($script:role.name)', found 2."
         )
+    }
+
+    It 'detects a self-referencing root role (parentrootroleid == roleid)' {
+        $script:rootRoleItems = @([pscustomobject]@{
+                roleid = $script:roleId
+                name = $script:role.name
+                _parentrootroleid_value = $script:roleId
+            })
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
+    }
+
+    It 'ignores inherited business-unit role copies and resolves the root' {
+        $script:rootRoleItems = @(
+            [pscustomobject]@{
+                roleid = '88888888-8888-8888-8888-888888888888'
+                name = $script:role.name
+                _parentrootroleid_value = $script:roleId
+            },
+            [pscustomobject]@{
+                roleid = $script:roleId
+                name = $script:role.name
+                _parentrootroleid_value = $null
+            }
+        )
+
+        $result = Test-InsuranceSecurityRole `
+            -EnvironmentUrl 'https://unit.crm.dynamics.com' `
+            -Role $script:role `
+            -Contract $script:contract
+
+        $result.State | Should -Be 'Ready'
     }
 
     It 'returns ContractConflict when the root-role query resolves only a case-insensitive name match' {


### PR DESCRIPTION
## What & why

Fixes the #40 DEV security-role bootstrap deadlock. Root-cause is a tooling bug, not a bad role or wrong solution.

Root-role detection filtered on `_parentrootroleid_value eq null`. In this org (and any org where the platform stores root roles as a **self-reference**, `parentrootroleid == roleid`) that predicate **never matches**, so:

- the verifier reported the existing `CRM Showcase Insurance Reader` root as *not found*;
- the publisher then tried to **create** it -> name collision on the BU/solution -> deadlock;
- `CRM Showcase Insurance Data Steward` was therefore never provisioned.

Confirmed read-only against DEV: `System Administrator`, `System Customizer` **and** the existing Reader all have `_parentrootroleid_value == roleid` (self-referencing), never null.

## The fix

Query roles by **name / prefix only**, then select the root **client-side** (parentrootroleid is null **OR** == roleid):

- `Test-InsuranceSecurityRoles.ps1` — `Get-InsuranceSecurityRolePath` + verifier root filter
- `Publish-InsuranceFoundation.ps1` — `Invoke-RoleReconciliation` (replaces the `Get-One ... eq null`)
- `Test-InsuranceFoundationConvergence.ps1` — reverse-inventory role loop

Reconciliation stays **create/update only — no role deletion**.

## Tests / evidence

- Updated mocked role queries to the new URLs + root shapes.
- New regression tests: self-referencing root is detected; inherited business-unit copies are skipped.
- All four affected suites green locally: **215 passed / 0 failed** (Pester v6).

## After merge (follow-up, not in this PR)

1. Re-run `Publish -Scope SecurityRoles` in DEV -> reconciles Reader + creates Data Steward.
2. Verifier -> State = Ready.
3. Re-dispatch `cd-solution-dev.yml` (DEV evidence) then `cd-solution-test.yml` (TEST evidence).

## Governance

Design-sensitive (CI security-role bootstrap logic). Human review + merge required per SUPERPOWERS_CONTRACT (never self-merge). No ADR change — detection-logic bug fix, no boundary/model change.

Closes #40