### PR TITLE
fix(deps): correct bogus vite ^8.2.1 bump in both PCF controls

### DIFF
--- a/solution/apps/sales/Controls/AdvisorCockpit/package-lock.json
+++ b/solution/apps/sales/Controls/AdvisorCockpit/package-lock.json
@@ -19,24 +19,20 @@
         "@testing-library/react": "^16.0.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "@vitejs/plugin-react": "^4.3.1",
+        "@vitejs/plugin-react": "^6.0.5",
         "jsdom": "^24.1.1",
         "typescript": "^5.5.4",
-        "vite": "^8.2.1",
+        "vite": "^8.2.0",
         "vitest": "^4.1.10"
       }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@adobe/css-tools/-/css-tools-4.5.0.tgz",
-      "integrity": "sha1-tbcaJaTRavokglkt36YvzMYLx9E=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha1-zEL1uFxZP3nx+k8l0rmzIeYdF5Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -47,17 +43,8 @@
         "lru-cache": "^10.4.3"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -69,286 +56,23 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.8.tgz",
-      "integrity": "sha1-SwuIeIVCJkMzngkCIUikxOuqSXk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.8",
-        "@babel/types": "^7.29.8",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha1-wKB2bxoTYX2KF0B9erj51IYiXqQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
-      "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.8"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha1-wkQkUnhYIgYk/Vmlseq0+kE8gDo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha1-XPJaNomQa1ji8KLys3R4nmYnsV8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha1-EgIkUMRaTabY2Ch7GKT/Ldsj92g=",
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.8.tgz",
-      "integrity": "sha1-QREBTNxxoPldlHGQdZC6oLimsoo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.8",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.8",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.8",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.8.tgz",
-      "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha1-EGxUyAjKv9GrTGAthQXuWEwplu8=",
       "dev": true,
       "funding": [
         {
@@ -367,8 +91,6 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha1-hHP2Pi/NbkWYON1BJAHVlI8iTGU=",
       "dev": true,
       "funding": [
         {
@@ -391,8 +113,6 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha1-Tjhq86md02xG/vATz+TBw0Hu1vA=",
       "dev": true,
       "funding": [
         {
@@ -419,8 +139,6 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha1-V1U3Cpopq67FUVtDyLPyz5wuMHY=",
       "dev": true,
       "funding": [
         {
@@ -433,6 +151,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -442,8 +161,6 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha1-Mz/tq8P9Go5dAQABNzHPGeaoxdM=",
       "dev": true,
       "funding": [
         {
@@ -456,14 +173,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "3.6.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-      "integrity": "sha1-tsdaVqGUfMkW6gWHctZmosiTLzE=",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -471,14 +187,10 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha1-/5IhufWLTf5h5hmneIc0vWP2iYs=",
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/core/-/core-1.8.0.tgz",
-      "integrity": "sha1-0BwLvqAuSlf2/X1d5vwsXH3KQOE=",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.12"
@@ -486,8 +198,6 @@
     },
     "node_modules/@floating-ui/devtools": {
       "version": "0.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/devtools/-/devtools-0.2.3.tgz",
-      "integrity": "sha1-Bx8Gnlol5vKmPtaFhKEf98kpiUc=",
       "license": "MIT",
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -495,9 +205,8 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha1-iiDm+sviRWr9vrbIuWinLfaJz2M=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
         "@floating-ui/utils": "^0.2.12"
@@ -505,14 +214,10 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha1-r+/nhZSfFqxM3R5pWTWjIVct1Wo=",
       "license": "MIT"
     },
     "node_modules/@fluentui/keyboard-keys": {
       "version": "9.0.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
-      "integrity": "sha1-gSuSPyDUKPPFzf+ZIqRHi1npB8U=",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -520,8 +225,6 @@
     },
     "node_modules/@fluentui/priority-overflow": {
       "version": "9.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/priority-overflow/-/priority-overflow-9.4.1.tgz",
-      "integrity": "sha1-hvGMZ/MtyThmEraSOuDVdfph5ng=",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -529,8 +232,6 @@
     },
     "node_modules/@fluentui/react-accordion": {
       "version": "9.12.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-accordion/-/react-accordion-9.12.1.tgz",
-      "integrity": "sha1-9S3K+uXm5FogpfHAewSHigsgbpc=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.13",
@@ -555,8 +256,6 @@
     },
     "node_modules/@fluentui/react-alert": {
       "version": "9.0.0-beta.143",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-alert/-/react-alert-9.0.0-beta.143.tgz",
-      "integrity": "sha1-96jOqc+iVRdOhCiuoBuxql2nENY=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-avatar": "^9.11.4",
@@ -578,8 +277,6 @@
     },
     "node_modules/@fluentui/react-aria": {
       "version": "9.17.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-aria/-/react-aria-9.17.13.tgz",
-      "integrity": "sha1-P2RrZNTfTzMuDBBZBF6jtBQqtAc=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -598,8 +295,6 @@
     },
     "node_modules/@fluentui/react-avatar": {
       "version": "9.11.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-avatar/-/react-avatar-9.11.4.tgz",
-      "integrity": "sha1-I3FhocGj5F1FecNTi21g7hL2YsQ=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-badge": "^9.5.4",
@@ -624,8 +319,6 @@
     },
     "node_modules/@fluentui/react-badge": {
       "version": "9.5.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-badge/-/react-badge-9.5.4.tgz",
-      "integrity": "sha1-z8bkvn4EjBDketbqHRJml2CqlAM=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -645,8 +338,6 @@
     },
     "node_modules/@fluentui/react-breadcrumb": {
       "version": "9.4.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.4.tgz",
-      "integrity": "sha1-DQlPr/xE5PSXB+6NlFkZ+xXhaLw=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.13",
@@ -670,8 +361,6 @@
     },
     "node_modules/@fluentui/react-button": {
       "version": "9.10.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-button/-/react-button-9.10.1.tgz",
-      "integrity": "sha1-/ZE4HDfmJ5qZKdzgJZYOvbec2W4=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -694,8 +383,6 @@
     },
     "node_modules/@fluentui/react-card": {
       "version": "9.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-card/-/react-card-9.7.1.tgz",
-      "integrity": "sha1-zq0vx7rRtC5fJf5rWi4wxCJicGo=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -717,8 +404,6 @@
     },
     "node_modules/@fluentui/react-carousel": {
       "version": "9.9.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-carousel/-/react-carousel-9.9.11.tgz",
-      "integrity": "sha1-Awl8B2HSvgwiEcONYDjuRVjbfVo=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.13",
@@ -746,8 +431,6 @@
     },
     "node_modules/@fluentui/react-checkbox": {
       "version": "9.6.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-checkbox/-/react-checkbox-9.6.3.tgz",
-      "integrity": "sha1-t/BHLtFVMcigYTtaAvQ0pDUMbVk=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -770,8 +453,6 @@
     },
     "node_modules/@fluentui/react-color-picker": {
       "version": "9.2.19",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-color-picker/-/react-color-picker-9.2.19.tgz",
-      "integrity": "sha1-YNUMOkGtQiJAHOE1mEq3mOOMPqU=",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.3.4",
@@ -793,8 +474,6 @@
     },
     "node_modules/@fluentui/react-combobox": {
       "version": "9.17.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-combobox/-/react-combobox-9.17.4.tgz",
-      "integrity": "sha1-YVmVjGOolBVvQnqt3/Cce1jmgTU=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -821,8 +500,6 @@
     },
     "node_modules/@fluentui/react-components": {
       "version": "9.74.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-components/-/react-components-9.74.5.tgz",
-      "integrity": "sha1-dett/EAUsc2pZK+mf/1Xdw38bgU=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-accordion": "^9.12.1",
@@ -897,8 +574,6 @@
     },
     "node_modules/@fluentui/react-context-selector": {
       "version": "9.2.18",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-context-selector/-/react-context-selector-9.2.18.tgz",
-      "integrity": "sha1-4w2WBfCBaTJQ7/0MiRWg4V4+MzQ=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-utilities": "^9.26.5",
@@ -914,8 +589,6 @@
     },
     "node_modules/@fluentui/react-dialog": {
       "version": "9.18.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-dialog/-/react-dialog-9.18.2.tgz",
-      "integrity": "sha1-rjnUnyrBoKcIG8wAvVIQZWg+f0k=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -942,8 +615,6 @@
     },
     "node_modules/@fluentui/react-divider": {
       "version": "9.7.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-divider/-/react-divider-9.7.3.tgz",
-      "integrity": "sha1-bTjfe4VHehtlkvANyiW/0QzWfLg=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.4",
@@ -962,8 +633,6 @@
     },
     "node_modules/@fluentui/react-drawer": {
       "version": "9.13.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-drawer/-/react-drawer-9.13.1.tgz",
-      "integrity": "sha1-rS0kGsQFDFtK7YsjnRIy1M0t2Ek=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-dialog": "^9.18.2",
@@ -987,8 +656,6 @@
     },
     "node_modules/@fluentui/react-field": {
       "version": "9.5.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-field/-/react-field-9.5.3.tgz",
-      "integrity": "sha1-8o9u5Ofr6rlHgByMXhFYPM0ERZw=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.18",
@@ -1010,7 +677,7 @@
     },
     "node_modules/@fluentui/react-icons": {
       "version": "2.0.334",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-icons/-/react-icons-2.0.334.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-icons/-/react-icons-2.0.334.tgz",
       "integrity": "sha1-HtqpKBqZe1qpblVlGwr2IMg0xaI=",
       "license": "MIT",
       "dependencies": {
@@ -1023,8 +690,6 @@
     },
     "node_modules/@fluentui/react-image": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-image/-/react-image-9.4.3.tgz",
-      "integrity": "sha1-Z2EAfqYaY11GCj0OcQnM7PjpAbY=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.4",
@@ -1043,8 +708,6 @@
     },
     "node_modules/@fluentui/react-infobutton": {
       "version": "9.0.0-beta.118",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.118.tgz",
-      "integrity": "sha1-uVnpcSRgCRAteytp5dF2mnQDgwY=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.237",
@@ -1066,8 +729,6 @@
     },
     "node_modules/@fluentui/react-infolabel": {
       "version": "9.4.23",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-infolabel/-/react-infolabel-9.4.23.tgz",
-      "integrity": "sha1-ThgZS25+bk1DXh0gbJBcDBH0/FQ=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -1090,8 +751,6 @@
     },
     "node_modules/@fluentui/react-input": {
       "version": "9.8.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-input/-/react-input-9.8.5.tgz",
-      "integrity": "sha1-W8dojWfScG6PTscg6CESz7WPrZw=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1111,8 +770,6 @@
     },
     "node_modules/@fluentui/react-jsx-runtime": {
       "version": "9.4.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.4.tgz",
-      "integrity": "sha1-1C9Z8VeWSqDmFaFnGRTArQiWPOA=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-utilities": "^9.26.5",
@@ -1125,8 +782,6 @@
     },
     "node_modules/@fluentui/react-label": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-label/-/react-label-9.4.3.tgz",
-      "integrity": "sha1-8mHWrSbQ9G5+osIL91c1+ZGdsvM=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.4",
@@ -1145,8 +800,6 @@
     },
     "node_modules/@fluentui/react-link": {
       "version": "9.8.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-link/-/react-link-9.8.3.tgz",
-      "integrity": "sha1-FWQOdibB0nDx5TyfZRC5BR3RGUQ=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1167,8 +820,6 @@
     },
     "node_modules/@fluentui/react-list": {
       "version": "9.6.16",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-list/-/react-list-9.6.16.tgz",
-      "integrity": "sha1-qo+KNropS6psCv1+AqsQ4mhpspw=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1191,8 +842,6 @@
     },
     "node_modules/@fluentui/react-menu": {
       "version": "9.25.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-menu/-/react-menu-9.25.2.tgz",
-      "integrity": "sha1-MmWrRh7siUyM8UtL8Hzo83uEmyY=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1220,8 +869,6 @@
     },
     "node_modules/@fluentui/react-message-bar": {
       "version": "9.7.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-message-bar/-/react-message-bar-9.7.4.tgz",
-      "integrity": "sha1-3NvGi1v+itwIQ1WqUSooUINDKQ4=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-button": "^9.10.1",
@@ -1245,8 +892,6 @@
     },
     "node_modules/@fluentui/react-motion": {
       "version": "9.16.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-motion/-/react-motion-9.16.1.tgz",
-      "integrity": "sha1-uiYSrPlRY/HaHiQ2cz/qS3kMFS8=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
@@ -1262,8 +907,6 @@
     },
     "node_modules/@fluentui/react-motion-components-preview": {
       "version": "0.15.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
-      "integrity": "sha1-0lg1U5l83ef9xF4qNbJ2mqfQ6fc=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-motion": "*",
@@ -1279,8 +922,6 @@
     },
     "node_modules/@fluentui/react-nav": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-nav/-/react-nav-9.4.3.tgz",
-      "integrity": "sha1-V9OOReFhSWJCk61HEmvqKBGlkzk=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.13",
@@ -1309,8 +950,6 @@
     },
     "node_modules/@fluentui/react-overflow": {
       "version": "9.9.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-overflow/-/react-overflow-9.9.1.tgz",
-      "integrity": "sha1-/JxqZzXI+U95QiSvesb309Cdo6U=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/priority-overflow": "^9.4.1",
@@ -1329,8 +968,6 @@
     },
     "node_modules/@fluentui/react-persona": {
       "version": "9.7.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-persona/-/react-persona-9.7.6.tgz",
-      "integrity": "sha1-u4I3VGfGHpn/dxchK4SYQvVXw4k=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-avatar": "^9.11.4",
@@ -1351,8 +988,6 @@
     },
     "node_modules/@fluentui/react-popover": {
       "version": "9.14.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-popover/-/react-popover-9.14.5.tgz",
-      "integrity": "sha1-u1tiR6dRamPHkdN/ztsSfLrZaKc=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1379,8 +1014,6 @@
     },
     "node_modules/@fluentui/react-portal": {
       "version": "9.8.14",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-portal/-/react-portal-9.8.14.tgz",
-      "integrity": "sha1-CxNSqzA7QwIyRXB98+7mikFC92M=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
@@ -1398,8 +1031,6 @@
     },
     "node_modules/@fluentui/react-positioning": {
       "version": "9.23.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-positioning/-/react-positioning-9.23.0.tgz",
-      "integrity": "sha1-qWwy18ZyUuFLOasu1W7rRRYuAOQ=",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/devtools": "^0.2.3",
@@ -1420,8 +1051,6 @@
     },
     "node_modules/@fluentui/react-progress": {
       "version": "9.5.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-progress/-/react-progress-9.5.3.tgz",
-      "integrity": "sha1-SGmwk+y+4hNrQy52RN/VrV+lnUY=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1442,8 +1071,6 @@
     },
     "node_modules/@fluentui/react-provider": {
       "version": "9.22.19",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-provider/-/react-provider-9.22.19.tgz",
-      "integrity": "sha1-U3+U3rDnaLhmnwqD3jHdvHUptxI=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -1465,8 +1092,6 @@
     },
     "node_modules/@fluentui/react-radio": {
       "version": "9.6.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-radio/-/react-radio-9.6.4.tgz",
-      "integrity": "sha1-WMCanew1z9u7CqCyKXcHgMqon/g=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1488,8 +1113,6 @@
     },
     "node_modules/@fluentui/react-rating": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-rating/-/react-rating-9.4.3.tgz",
-      "integrity": "sha1-bZN1GIiB7f+enrrcaa7Qh1L5r78=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -1510,8 +1133,6 @@
     },
     "node_modules/@fluentui/react-search": {
       "version": "9.4.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-search/-/react-search-9.4.5.tgz",
-      "integrity": "sha1-3xu3kK4YZPnCuZx6VuntjAI09tI=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -1532,8 +1153,6 @@
     },
     "node_modules/@fluentui/react-select": {
       "version": "9.5.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-select/-/react-select-9.5.4.tgz",
-      "integrity": "sha1-R753Z5q2vjB9hYCc9W0m6cuenOk=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1554,8 +1173,6 @@
     },
     "node_modules/@fluentui/react-shared-contexts": {
       "version": "9.26.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
-      "integrity": "sha1-A4ZM7kVinVc/X4Yxy569R4vLq/c=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-theme": "^9.2.1",
@@ -1568,8 +1185,6 @@
     },
     "node_modules/@fluentui/react-skeleton": {
       "version": "9.7.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-skeleton/-/react-skeleton-9.7.4.tgz",
-      "integrity": "sha1-kc1ER+I8AGRNlbjCny4W7PLUcO0=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1589,8 +1204,6 @@
     },
     "node_modules/@fluentui/react-slider": {
       "version": "9.6.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-slider/-/react-slider-9.6.4.tgz",
-      "integrity": "sha1-I10Exll7lmAcpCU7onY/W9NPTPE=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1611,8 +1224,6 @@
     },
     "node_modules/@fluentui/react-spinbutton": {
       "version": "9.6.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-spinbutton/-/react-spinbutton-9.6.4.tgz",
-      "integrity": "sha1-Anr6BG6trenZVojuaM7Wgvpa2Z0=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1634,8 +1245,6 @@
     },
     "node_modules/@fluentui/react-spinner": {
       "version": "9.8.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-spinner/-/react-spinner-9.8.4.tgz",
-      "integrity": "sha1-R0reupmYnVBv1+bo1a2q6w4KlBA=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.4",
@@ -1655,8 +1264,6 @@
     },
     "node_modules/@fluentui/react-swatch-picker": {
       "version": "9.5.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.4.tgz",
-      "integrity": "sha1-vZ6171RIjyve9UCMBmmQABClq6o=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.18",
@@ -1679,8 +1286,6 @@
     },
     "node_modules/@fluentui/react-switch": {
       "version": "9.7.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-switch/-/react-switch-9.7.4.tgz",
-      "integrity": "sha1-R2L+3jLAMhx8qWMfXqnSe3K/FIc=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1703,8 +1308,6 @@
     },
     "node_modules/@fluentui/react-table": {
       "version": "9.19.18",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-table/-/react-table-9.19.18.tgz",
-      "integrity": "sha1-uy3HCiR40XL86fq51Z/XAWSSdZM=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1731,8 +1334,6 @@
     },
     "node_modules/@fluentui/react-tabs": {
       "version": "9.12.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tabs/-/react-tabs-9.12.3.tgz",
-      "integrity": "sha1-2bsigoHcZeyRz8CDv1bYSIIPjww=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.18",
@@ -1753,8 +1354,6 @@
     },
     "node_modules/@fluentui/react-tabster": {
       "version": "9.26.16",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tabster/-/react-tabster-9.26.16.tgz",
-      "integrity": "sha1-W+25Rsa54NTNfNYD3z5+xTKTgdw=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
@@ -1774,8 +1373,6 @@
     },
     "node_modules/@fluentui/react-tag-picker": {
       "version": "9.10.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tag-picker/-/react-tag-picker-9.10.1.tgz",
-      "integrity": "sha1-RqSKg67av8zTCnm7t6B4G3npc7E=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1804,8 +1401,6 @@
     },
     "node_modules/@fluentui/react-tags": {
       "version": "9.9.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tags/-/react-tags-9.9.3.tgz",
-      "integrity": "sha1-l4KCXnZD1o7tMffBs+kUOyH6MYs=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1829,8 +1424,6 @@
     },
     "node_modules/@fluentui/react-teaching-popover": {
       "version": "9.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.3.tgz",
-      "integrity": "sha1-LYCg2Zm/44TB/5Wxrn58ZYy9Ebo=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.13",
@@ -1856,8 +1449,6 @@
     },
     "node_modules/@fluentui/react-text": {
       "version": "9.6.18",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-text/-/react-text-9.6.18.tgz",
-      "integrity": "sha1-cAPzAcfQDcyLD6nBPsPnzFhe0S8=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.4",
@@ -1876,8 +1467,6 @@
     },
     "node_modules/@fluentui/react-textarea": {
       "version": "9.7.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-textarea/-/react-textarea-9.7.5.tgz",
-      "integrity": "sha1-Cq94qkJo4NKt9l0rr9pSDDJcjX0=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.3",
@@ -1897,8 +1486,6 @@
     },
     "node_modules/@fluentui/react-theme": {
       "version": "9.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
-      "integrity": "sha1-136U7MjtoyJDe2HY36L9FnkcN9o=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/tokens": "1.0.0-alpha.23",
@@ -1907,8 +1494,6 @@
     },
     "node_modules/@fluentui/react-toast": {
       "version": "9.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-toast/-/react-toast-9.8.1.tgz",
-      "integrity": "sha1-VV7L0VRNiKyVlMfttNUvQfyfcNg=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1934,8 +1519,6 @@
     },
     "node_modules/@fluentui/react-toolbar": {
       "version": "9.8.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-toolbar/-/react-toolbar-9.8.3.tgz",
-      "integrity": "sha1-dIbqsEt/g17lK8+bVlW4zWJdBA0=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-button": "^9.10.1",
@@ -1959,8 +1542,6 @@
     },
     "node_modules/@fluentui/react-tooltip": {
       "version": "9.10.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tooltip/-/react-tooltip-9.10.4.tgz",
-      "integrity": "sha1-kCLgr65fUQnkZHvIZI2/pksGW7s=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1983,8 +1564,6 @@
     },
     "node_modules/@fluentui/react-tree": {
       "version": "9.16.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tree/-/react-tree-9.16.4.tgz",
-      "integrity": "sha1-TKzcRpevydyom6mkV2ionCqvhiM=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2014,8 +1593,6 @@
     },
     "node_modules/@fluentui/react-utilities": {
       "version": "9.26.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
-      "integrity": "sha1-I/Czh8/18uiormwR0UuhB8mIMgs=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2029,8 +1606,6 @@
     },
     "node_modules/@fluentui/react-virtualizer": {
       "version": "9.0.0-alpha.114",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.114.tgz",
-      "integrity": "sha1-J1d7PpDLCGs46tR5xxP/4PmAyDU=",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.4",
@@ -2048,8 +1623,6 @@
     },
     "node_modules/@fluentui/tokens": {
       "version": "1.0.0-alpha.23",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
-      "integrity": "sha1-T4RsHk/Ns8qA6zGALEo2bVWZsw4=",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -2057,8 +1630,6 @@
     },
     "node_modules/@griffel/core": {
       "version": "1.21.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/core/-/core-1.21.3.tgz",
-      "integrity": "sha1-fhN+aJYuYq2OwVVj/TBRzH4elX0=",
       "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
@@ -2071,8 +1642,6 @@
     },
     "node_modules/@griffel/react": {
       "version": "1.7.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/react/-/react-1.7.7.tgz",
-      "integrity": "sha1-iQiFJzS/aqAnZ2NDAxoHkTFm/QM=",
       "license": "MIT",
       "dependencies": {
         "@griffel/core": "^1.21.3",
@@ -2084,316 +1653,26 @@
     },
     "node_modules/@griffel/style-types": {
       "version": "1.4.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/style-types/-/style-types-1.4.2.tgz",
-      "integrity": "sha1-T2aXpznqvCzteNK/9POMN+SOkRU=",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.3"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "version": "0.142.0",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "version": "1.2.2",
       "cpu": [
         "x64"
       ],
@@ -2408,23 +1687,17 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha1-R9K/TO9tRwsi9YMbQg+JZOC/dV8=",
+      "version": "1.0.1",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha1-GSh9DYbZYrERN2A5pQx5KQLJqGo=",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -2432,8 +1705,6 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha1-1ET4qInppG6aO087iOD8s++2z5U=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2453,8 +1724,6 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha1-dhOgThRt0pdtJN3wGXMNV6idVsI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2473,15 +1742,11 @@
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha1-mT6SXMHXPyxmLn113VpURSWaj9g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/react/-/react-16.3.2.tgz",
-      "integrity": "sha1-ZyiDt6y453X8BJLZ6dJeBuiXhtA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2508,61 +1773,11 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha1-GjHD03iFDSd42rtjdNA23LpLpwg=",
       "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha1-tYGSlMUReZV6+uw0FEL5NB5BCKk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha1-B9cT1szg0mXJhJ2wy+YtP2Hzb3Q=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2572,26 +1787,18 @@
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha1-4CFRRk0C1KG0RkbQ/NuT+viP3ow=",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha1-NoyWGhjech2oIA6AvzlD+1MTavI=",
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha1-4o2xv7+mFwdvd3DdHZpI6qO2xRs=",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha1-QSuQ6EhwKF8v+KhGxutgNE8SpBw=",
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
@@ -2599,14 +1806,10 @@
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha1-9jKzgMOsoduo40qgSbzWpK8j34o=",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha1-V6L3ByQub+Hega17/Myq9gYXmvs=",
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
@@ -2614,8 +1817,6 @@
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha1-0VFsxQh1O+BoUs0GdY47tUoisOM=",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -2623,41 +1824,30 @@
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha1-hHL+7NY5aRRQ3YAA6zPt1EThMj8=",
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha1-cLvad9wjqnJ0E+IuIUr6Pw6FL3A=",
       "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha1-5uWobWAr6spxzlFj+t9fldcJMcc=",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha1-teleKP/M6rjZgvM/LrB24XZTwqQ=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2665,38 +1855,38 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha1-uJ3fLNg7T+r8xOLqQa/fuVoNGU8=",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha1-ZHr057t1rTrdV452KtmEuQ9KJLk=",
+      "version": "6.0.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2713,8 +1903,6 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2740,8 +1928,6 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2753,8 +1939,6 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2767,8 +1951,6 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2783,8 +1965,6 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2793,8 +1973,6 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2808,8 +1986,6 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2818,22 +1994,16 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2843,8 +2013,6 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha1-ZQxWnkGtkLUbPX315e7Rx1ScED4=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2853,8 +2021,6 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2863,62 +2029,11 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.11.12",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
-      "integrity": "sha1-QqxIdwv3PSkvYM6LpNxefrskLsM=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
-      "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.44",
-        "caniuse-lite": "^1.0.30001806",
-        "electron-to-chromium": "^1.5.393",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2929,31 +2044,8 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2962,8 +2054,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2971,8 +2061,6 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2984,22 +2072,16 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha1-6hgAcCTjFn9PEFMV8+wtmCv0jtk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3012,21 +2094,15 @@
     },
     "node_modules/cssstyle/node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha1-MCHRtDUvvzthSq7tC8DVc5q+C8I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha1-Ff7DOyN/l6xdfJhtx32ic6jtC7U=",
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
@@ -3037,8 +2113,6 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha1-OVsoM9+scVB/EqwvevI7+BneJOI=",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3046,8 +2120,6 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha1-llisOKIUDVnTRhYPH2ww/aC9EvQ=",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -3055,8 +2127,6 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha1-Af20a1i+sfVbELQq1wtuNE1esq4=",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3064,8 +2134,6 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha1-PEeqWzLFs9+1bvP9Q0IHimMrQA0=",
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -3076,8 +2144,6 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha1-It+TkDL7WnGuixgA1h3beFHEJSY=",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3085,8 +2151,6 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha1-grOOjo/3CAdk+Nzsd71L45Nok5Y=",
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -3101,8 +2165,6 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha1-oag5y9m6RfKGdMadf4Vbz5HfxqU=",
       "license": "ISC",
       "dependencies": {
         "d3-path": "^3.1.0"
@@ -3113,8 +2175,6 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha1-kxDbVumS48AXXh7zheVF5Iqbtcc=",
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -3125,8 +2185,6 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha1-erUlelBB0R7LT+cKXH0WoZW7QIo=",
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -3137,8 +2195,6 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha1-YoTSonCChbGrt+IB7aQ4CvNeY7A=",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3146,8 +2202,6 @@
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha1-L3aQa84YJEKf/stpIPRaCzDwDd4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3160,8 +2214,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3178,21 +2230,15 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha1-5kmkPjq5U6chkv9Zg4ZeUJ837Zo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha1-E0/TJQjxniCPT7L42sDSYmqGeTQ=",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3201,8 +2247,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3211,8 +2255,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3221,16 +2263,11 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha1-WnQp5gZus2ZNkR4z+w5F3o6whFM=",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha1-2UAFNrK/giWtmP4FLgKUUaxA6QI=",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -3239,8 +2276,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3252,23 +2287,13 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.400",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
-      "integrity": "sha1-qbD7BkoRDFmOwqElNfLID8GkXGQ=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel/-/embla-carousel-8.6.0.tgz",
-      "integrity": "sha1-q87f8r/zaZLqisJ80wCAyltqP1g=",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
-      "integrity": "sha1-vIbJfeANUuw0sFBYc271Cvbg0OQ=",
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"
@@ -3276,8 +2301,6 @@
     },
     "node_modules/embla-carousel-fade": {
       "version": "8.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
-      "integrity": "sha1-ktGezVREHrbzeRC/nhb9P1R+M3Q=",
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"
@@ -3285,8 +2308,6 @@
     },
     "node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3298,8 +2319,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3308,8 +2327,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3318,15 +2335,11 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3338,8 +2351,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3352,20 +2363,8 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3374,14 +2373,10 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
       "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expect-type/-/expect-type-1.4.0.tgz",
-      "integrity": "sha1-JO338MxppE0AhWe6RZSrlvPDo9Y=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3390,8 +2385,6 @@
     },
     "node_modules/fast-equals": {
       "version": "5.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-equals/-/fast-equals-5.4.1.tgz",
-      "integrity": "sha1-qRdLA+7OUwfb1nW+bW1C9/odAO0=",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3399,8 +2392,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3417,8 +2408,6 @@
     },
     "node_modules/form-data": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3432,45 +2421,16 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3494,8 +2454,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3508,8 +2466,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3521,8 +2477,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3534,8 +2488,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3550,8 +2502,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3563,8 +2513,6 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha1-aW31KafP2CRGNp3FGT5ZCjc1tEg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3576,8 +2524,6 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3590,8 +2536,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3604,8 +2548,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3617,8 +2559,6 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3627,8 +2567,6 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha1-ZoXyN1XkPFJOJR0py8lySOMGEAk=",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3636,23 +2574,18 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "24.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsdom/-/jsdom-24.1.3.tgz",
-      "integrity": "sha1-iOSgfLndIQZ1FKYZ6fF7CQo5Sp8=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -3688,42 +2621,12 @@
         }
       }
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/keyborg": {
       "version": "2.14.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/keyborg/-/keyborg-2.14.1.tgz",
-      "integrity": "sha1-BElZ/w5PldBi0eB+LToPvCrRHTA=",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -3750,10 +2653,29 @@
         "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
-    "node_modules/lightningcss-android-arm64": {
+    "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha1-mmhB+IrlD8g1ApA4krQa9BvCuQc=",
       "cpu": [
         "arm64"
       ],
@@ -3771,10 +2693,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-darwin-arm64": {
+    "node_modules/lightningcss/node_modules/lightningcss-darwin-arm64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha1-wPLDHAv9GfpN0/GOlXofGhUgl9Y=",
       "cpu": [
         "arm64"
       ],
@@ -3792,10 +2714,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-darwin-x64": {
+    "node_modules/lightningcss/node_modules/lightningcss-darwin-x64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha1-ywcFllrLU4xmg5Sc5pJfs833w2E=",
       "cpu": [
         "x64"
       ],
@@ -3813,10 +2735,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-freebsd-x64": {
+    "node_modules/lightningcss/node_modules/lightningcss-freebsd-x64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha1-djU4gosmurJoDa2vzITueLDrUCs=",
       "cpu": [
         "x64"
       ],
@@ -3834,10 +2756,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
+    "node_modules/lightningcss/node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha1-aGLjF2ozGu297B7TUrTX0N0HhN4=",
       "cpu": [
         "arm"
       ],
@@ -3855,106 +2777,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-linux-arm64-gnu": {
+    "node_modules/lightningcss/node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha1-xqOi7RUUHa9r3CYokw+OOb30c6o=",
       "cpu": [
         "arm64"
       ],
@@ -3962,7 +2788,7 @@
       "license": "MPL-2.0",
       "optional": true,
       "os": [
-        "win32"
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -3972,12 +2798,75 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-win32-x64-msvc": {
+    "node_modules/lightningcss/node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha1-f6EzSXH8goRfmCffbvigsgkUusY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha1-i5J4YuqMK7xoMaRlCSRLUNmTblU=",
       "cpu": [
         "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha1-DFJbsHff2UQEwFnP5C2teX6Wrq8=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha1-hQ7hED2smJz6tQ46wi0aaeOU5j0=",
+      "cpu": [
+        "arm64"
       ],
       "dev": true,
       "license": "MPL-2.0",
@@ -3995,14 +2884,10 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4012,30 +2897,20 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+      "version": "10.4.3",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
+      "license": "ISC"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha1-watQ93iHtxJiEgG6n9Tjpu0JmUE=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4044,8 +2919,6 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4054,8 +2927,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4064,8 +2935,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4077,8 +2946,6 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4087,15 +2954,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.17",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
       "dev": true,
       "funding": [
         {
@@ -4111,27 +2974,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.52",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.52.tgz",
-      "integrity": "sha1-2Cg7ol5Xek2XVtW0Xso1O6VQAwA=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.24",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nwsapi/-/nwsapi-2.2.24.tgz",
-      "integrity": "sha1-+JJwQ9TJtRar3r6ASjLI0flITR8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4139,8 +2988,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
-      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -4153,8 +3000,6 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha1-1+Ik+nI5nHoXUJn0X8KtAksF7AU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4166,24 +3011,19 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4193,8 +3033,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.25",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=",
       "dev": true,
       "funding": [
         {
@@ -4222,11 +3060,8 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha1-IYGHn96lGnpYUfs52SD6pj8B2I4=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4238,8 +3073,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4249,14 +3082,10 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
       "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha1-vazjGJbx2XzsannoIkiYzpPZdMY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4268,8 +3097,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4278,16 +3105,13 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react/-/react-18.3.1.tgz",
-      "integrity": "sha1-SauJIAnFOTNiW9FrJTP8dUyrKJE=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4297,9 +3121,8 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha1-wiZdeVEbV9R5s90/36UVNklMXLQ=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4310,8 +3133,6 @@
     },
     "node_modules/react-dom/node_modules/scheduler": {
       "version": "0.23.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha1-QUumSjsoKJLpRM8hCOzAeNEVzcM=",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -4319,26 +3140,11 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
       "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha1-t+V5w2V/I9BOzL5K0uWKjtUeflM=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha1-pYdfi7YZY8phuBnO3FadwkU4lLQ=",
       "license": "MIT",
       "dependencies": {
         "fast-equals": "^5.0.1",
@@ -4352,8 +3158,6 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha1-5T1OPzNE2oUhSJ+++PJYHUK+zdE=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -4368,9 +3172,6 @@
     },
     "node_modules/recharts": {
       "version": "2.15.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha1-DtPmbAhDvPLZ+aFyyvl7HQUSel8=",
-      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
@@ -4392,8 +3193,6 @@
     },
     "node_modules/recharts-scale": {
       "version": "0.4.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recharts-scale/-/recharts-scale-0.4.5.tgz",
-      "integrity": "sha1-CWknHxTnMuZC/MW9SrJw1uh90dk=",
       "license": "MIT",
       "dependencies": {
         "decimal.js-light": "^2.4.1"
@@ -4401,14 +3200,10 @@
     },
     "node_modules/recharts/node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
       "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4421,19 +3216,15 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "version": "1.2.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.143.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4443,40 +3234,250 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.3",
-        "@rolldown/binding-darwin-arm64": "1.2.3",
-        "@rolldown/binding-darwin-x64": "1.2.3",
-        "@rolldown/binding-freebsd-x64": "1.2.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-        "@rolldown/binding-linux-arm64-musl": "1.2.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-musl": "1.2.3",
-        "@rolldown/binding-openharmony-arm64": "1.2.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
       }
     },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+    "node_modules/rolldown/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha1-t9I11Fs4yE8miSrIBLtPF0OKu/4=",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha1-kCHbIkFV8VpBq2mDMu2zADEY/c0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha1-f521YY0M5GP5sLuu7qSNGzC7lpw=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha1-X7uSUp+43XP+bJITqaC54f2LiuE=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha1-qDaq36OOp3i9xVCO79UDb1u/gFI=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha1-x321wkOoHYJBteTvapmoLIrPmkA=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha1-BuzpiHLrPFsSln+qjgfvKwPgLQY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha1-tvVbzIOFIID4R47F2g6IsuP5ptE=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha1-f6QW0sN69lTyi0MuJOW+lIO4nxk=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha1-mu+mfnIkz9RGQ3OppPU4HNGcrjs=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha1-jNcWCutbS6wz/Orz1+DGegx4yh0=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha1-DDkaCKOaCXlK+XPuznghbIDhRPY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha1-aJUmXiRhZO0ugWLLqRwMP8K/NoQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha1-xzRRpIS4bdfPseCyiY30twMYPks=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rtl-css-js": {
       "version": "1.16.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
-      "integrity": "sha1-S0i0NUsP+RejBIjZUQD79yGaPoA=",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
@@ -4484,15 +3485,11 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha1-/ltKR2jfTxSiAbG6amXB89mYjMU=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4504,32 +3501,16 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha1-DE74LWfR5cHjWej8dtOofwRf5b0=",
       "license": "MIT",
       "peer": true
     },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha1-MudscLeXJOO7Vny51UPrhYzPrzA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4538,22 +3519,16 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
-      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4565,21 +3540,15 @@
     },
     "node_modules/stylis": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stylis/-/stylis-4.4.0.tgz",
-      "integrity": "sha1-xYRsk0X0v8Ub0MvXyjWgdE9IWl0=",
       "license": "MIT"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tabster": {
       "version": "8.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tabster/-/tabster-8.8.0.tgz",
-      "integrity": "sha1-cE7yrsD91vQss1DXgfJIh32hmWw=",
       "license": "MIT",
       "dependencies": {
         "keyborg": "^2.14.0",
@@ -4588,21 +3557,15 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha1-RmgLeoc6DV0QAFmV65CnDXTWASc=",
       "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha1-EDyfi6bXI3pHq23R3P93JRhjQms=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4611,8 +3574,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4628,8 +3589,6 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4638,8 +3597,6 @@
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha1-lF8UYbRbWox2ghwz6knDrBksGzY=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4654,8 +3611,6 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha1-lq6GfN24/bZKScwwWajUKLzyOMo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4667,14 +3622,10 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4687,49 +3638,14 @@
     },
     "node_modules/universalify": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha1-ZFF2BWb6hXU0dFqx3elS0bF2G+A=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha1-nTwvc2wddd070r5QfcwRHx4uqcE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4739,8 +3655,6 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha1-sXS/plyytSZzLZ8qwKQIAnh28y0=",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4748,8 +3662,6 @@
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha1-ZosCpEj6TqD3iNv0Iot+ZGaf+AE=",
       "license": "MIT AND ISC",
       "dependencies": {
         "@types/d3-array": "^3.0.3",
@@ -4769,16 +3681,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4846,10 +3757,22 @@
         }
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4938,8 +3861,6 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha1-+SW6JoVRWFlNkHMTzt0UdsWWf2w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4951,8 +3872,6 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha1-JWtOGIK+feu/AdBfCqIDl3jqCAo=",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4961,9 +3880,6 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha1-0PTvdpkF1CbhaI8+NDgambYLduU=",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4975,8 +3891,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha1-vBv5SphdxQOI1UqSWKxAXDyi/Ao=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4985,8 +3899,6 @@
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha1-TuAtXXJRVdrgBPaulcc+fvXZVmM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4999,8 +3911,6 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha1-o/aalxB/SUs83Dvd3Yg6fWXOvwQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5016,8 +3926,6 @@
     },
     "node_modules/ws": {
       "version": "8.21.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha1-5pds/pYWHUBCBoml8FE3jRGw8M4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5038,8 +3946,6 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha1-gr6blX96/az5YeWYDxvyJ8C/dnM=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5048,17 +3954,8 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/solution/apps/sales/Controls/AdvisorCockpit/package.json
+++ b/solution/apps/sales/Controls/AdvisorCockpit/package.json
@@ -22,10 +22,10 @@
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^24.1.1",
     "typescript": "^5.5.4",
-    "vite": "^8.2.1",
+    "vite": "^8.2.0",
     "vitest": "^4.1.10"
   }
 }

--- a/solution/apps/sales/Controls/SalesLeaderDashboard/package-lock.json
+++ b/solution/apps/sales/Controls/SalesLeaderDashboard/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "advisor-cockpit-pcf",
+  "name": "sales-leader-dashboard-pcf",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "advisor-cockpit-pcf",
+      "name": "sales-leader-dashboard-pcf",
       "version": "0.1.0",
       "dependencies": {
         "@fluentui/react-components": "^9.54.0",
@@ -19,16 +19,16 @@
         "@testing-library/react": "^16.0.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "@vitejs/plugin-react": "^4.3.1",
+        "@vitejs/plugin-react": "^6.0.5",
         "jsdom": "^24.1.1",
         "typescript": "^5.5.4",
-        "vite": "^8.2.1",
+        "vite": "^8.2.0",
         "vitest": "^4.1.10"
       }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha1-tbcaJaTRavokglkt36YvzMYLx9E=",
       "dev": true,
       "license": "MIT"
@@ -47,16 +47,9 @@
         "lru-cache": "^10.4.3"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -69,146 +62,9 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.8.tgz",
-      "integrity": "sha1-SwuIeIVCJkMzngkCIUikxOuqSXk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.8",
-        "@babel/types": "^7.29.8",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha1-wKB2bxoTYX2KF0B9erj51IYiXqQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -216,131 +72,11 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
-      "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.8"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha1-wkQkUnhYIgYk/Vmlseq0+kE8gDo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha1-XPJaNomQa1ji8KLys3R4nmYnsV8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha1-EgIkUMRaTabY2Ch7GKT/Ldsj92g=",
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.8.tgz",
-      "integrity": "sha1-QREBTNxxoPldlHGQdZC6oLimsoo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.8",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.8",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.8",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.8.tgz",
-      "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -367,7 +103,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha1-hHP2Pi/NbkWYON1BJAHVlI8iTGU=",
       "dev": true,
       "funding": [
@@ -419,7 +155,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha1-V1U3Cpopq67FUVtDyLPyz5wuMHY=",
       "dev": true,
       "funding": [
@@ -433,6 +169,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -456,13 +193,14 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "3.6.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
       "integrity": "sha1-tsdaVqGUfMkW6gWHctZmosiTLzE=",
       "license": "MIT",
       "engines": {
@@ -477,7 +215,7 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/core/-/core-1.8.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/core/-/core-1.8.0.tgz",
       "integrity": "sha1-0BwLvqAuSlf2/X1d5vwsXH3KQOE=",
       "license": "MIT",
       "dependencies": {
@@ -486,7 +224,7 @@
     },
     "node_modules/@floating-ui/devtools": {
       "version": "0.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/devtools/-/devtools-0.2.3.tgz",
       "integrity": "sha1-Bx8Gnlol5vKmPtaFhKEf98kpiUc=",
       "license": "MIT",
       "peerDependencies": {
@@ -495,9 +233,10 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/dom/-/dom-1.8.0.tgz",
       "integrity": "sha1-iiDm+sviRWr9vrbIuWinLfaJz2M=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
         "@floating-ui/utils": "^0.2.12"
@@ -505,13 +244,13 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha1-r+/nhZSfFqxM3R5pWTWjIVct1Wo=",
       "license": "MIT"
     },
     "node_modules/@fluentui/keyboard-keys": {
       "version": "9.0.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
       "integrity": "sha1-gSuSPyDUKPPFzf+ZIqRHi1npB8U=",
       "license": "MIT",
       "dependencies": {
@@ -529,7 +268,7 @@
     },
     "node_modules/@fluentui/react-accordion": {
       "version": "9.12.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-accordion/-/react-accordion-9.12.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-accordion/-/react-accordion-9.12.1.tgz",
       "integrity": "sha1-9S3K+uXm5FogpfHAewSHigsgbpc=",
       "license": "MIT",
       "dependencies": {
@@ -555,7 +294,7 @@
     },
     "node_modules/@fluentui/react-alert": {
       "version": "9.0.0-beta.143",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-alert/-/react-alert-9.0.0-beta.143.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-alert/-/react-alert-9.0.0-beta.143.tgz",
       "integrity": "sha1-96jOqc+iVRdOhCiuoBuxql2nENY=",
       "license": "MIT",
       "dependencies": {
@@ -578,7 +317,7 @@
     },
     "node_modules/@fluentui/react-aria": {
       "version": "9.17.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-aria/-/react-aria-9.17.13.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-aria/-/react-aria-9.17.13.tgz",
       "integrity": "sha1-P2RrZNTfTzMuDBBZBF6jtBQqtAc=",
       "license": "MIT",
       "dependencies": {
@@ -598,7 +337,7 @@
     },
     "node_modules/@fluentui/react-avatar": {
       "version": "9.11.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-avatar/-/react-avatar-9.11.4.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-avatar/-/react-avatar-9.11.4.tgz",
       "integrity": "sha1-I3FhocGj5F1FecNTi21g7hL2YsQ=",
       "license": "MIT",
       "dependencies": {
@@ -624,7 +363,7 @@
     },
     "node_modules/@fluentui/react-badge": {
       "version": "9.5.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-badge/-/react-badge-9.5.4.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-badge/-/react-badge-9.5.4.tgz",
       "integrity": "sha1-z8bkvn4EjBDketbqHRJml2CqlAM=",
       "license": "MIT",
       "dependencies": {
@@ -670,7 +409,7 @@
     },
     "node_modules/@fluentui/react-button": {
       "version": "9.10.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-button/-/react-button-9.10.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-button/-/react-button-9.10.1.tgz",
       "integrity": "sha1-/ZE4HDfmJ5qZKdzgJZYOvbec2W4=",
       "license": "MIT",
       "dependencies": {
@@ -694,7 +433,7 @@
     },
     "node_modules/@fluentui/react-card": {
       "version": "9.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-card/-/react-card-9.7.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-card/-/react-card-9.7.1.tgz",
       "integrity": "sha1-zq0vx7rRtC5fJf5rWi4wxCJicGo=",
       "license": "MIT",
       "dependencies": {
@@ -717,7 +456,7 @@
     },
     "node_modules/@fluentui/react-carousel": {
       "version": "9.9.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-carousel/-/react-carousel-9.9.11.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-carousel/-/react-carousel-9.9.11.tgz",
       "integrity": "sha1-Awl8B2HSvgwiEcONYDjuRVjbfVo=",
       "license": "MIT",
       "dependencies": {
@@ -746,7 +485,7 @@
     },
     "node_modules/@fluentui/react-checkbox": {
       "version": "9.6.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-checkbox/-/react-checkbox-9.6.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-checkbox/-/react-checkbox-9.6.3.tgz",
       "integrity": "sha1-t/BHLtFVMcigYTtaAvQ0pDUMbVk=",
       "license": "MIT",
       "dependencies": {
@@ -770,7 +509,7 @@
     },
     "node_modules/@fluentui/react-color-picker": {
       "version": "9.2.19",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-color-picker/-/react-color-picker-9.2.19.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-color-picker/-/react-color-picker-9.2.19.tgz",
       "integrity": "sha1-YNUMOkGtQiJAHOE1mEq3mOOMPqU=",
       "license": "MIT",
       "dependencies": {
@@ -793,7 +532,7 @@
     },
     "node_modules/@fluentui/react-combobox": {
       "version": "9.17.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-combobox/-/react-combobox-9.17.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-combobox/-/react-combobox-9.17.4.tgz",
       "integrity": "sha1-YVmVjGOolBVvQnqt3/Cce1jmgTU=",
       "license": "MIT",
       "dependencies": {
@@ -821,7 +560,7 @@
     },
     "node_modules/@fluentui/react-components": {
       "version": "9.74.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-components/-/react-components-9.74.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-components/-/react-components-9.74.5.tgz",
       "integrity": "sha1-dett/EAUsc2pZK+mf/1Xdw38bgU=",
       "license": "MIT",
       "dependencies": {
@@ -897,7 +636,7 @@
     },
     "node_modules/@fluentui/react-context-selector": {
       "version": "9.2.18",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-context-selector/-/react-context-selector-9.2.18.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-context-selector/-/react-context-selector-9.2.18.tgz",
       "integrity": "sha1-4w2WBfCBaTJQ7/0MiRWg4V4+MzQ=",
       "license": "MIT",
       "dependencies": {
@@ -914,7 +653,7 @@
     },
     "node_modules/@fluentui/react-dialog": {
       "version": "9.18.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-dialog/-/react-dialog-9.18.2.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-dialog/-/react-dialog-9.18.2.tgz",
       "integrity": "sha1-rjnUnyrBoKcIG8wAvVIQZWg+f0k=",
       "license": "MIT",
       "dependencies": {
@@ -942,7 +681,7 @@
     },
     "node_modules/@fluentui/react-divider": {
       "version": "9.7.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-divider/-/react-divider-9.7.3.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-divider/-/react-divider-9.7.3.tgz",
       "integrity": "sha1-bTjfe4VHehtlkvANyiW/0QzWfLg=",
       "license": "MIT",
       "dependencies": {
@@ -962,7 +701,7 @@
     },
     "node_modules/@fluentui/react-drawer": {
       "version": "9.13.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-drawer/-/react-drawer-9.13.1.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-drawer/-/react-drawer-9.13.1.tgz",
       "integrity": "sha1-rS0kGsQFDFtK7YsjnRIy1M0t2Ek=",
       "license": "MIT",
       "dependencies": {
@@ -987,7 +726,7 @@
     },
     "node_modules/@fluentui/react-field": {
       "version": "9.5.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-field/-/react-field-9.5.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-field/-/react-field-9.5.3.tgz",
       "integrity": "sha1-8o9u5Ofr6rlHgByMXhFYPM0ERZw=",
       "license": "MIT",
       "dependencies": {
@@ -1010,7 +749,7 @@
     },
     "node_modules/@fluentui/react-icons": {
       "version": "2.0.334",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-icons/-/react-icons-2.0.334.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-icons/-/react-icons-2.0.334.tgz",
       "integrity": "sha1-HtqpKBqZe1qpblVlGwr2IMg0xaI=",
       "license": "MIT",
       "dependencies": {
@@ -1023,7 +762,7 @@
     },
     "node_modules/@fluentui/react-image": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-image/-/react-image-9.4.3.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-image/-/react-image-9.4.3.tgz",
       "integrity": "sha1-Z2EAfqYaY11GCj0OcQnM7PjpAbY=",
       "license": "MIT",
       "dependencies": {
@@ -1043,7 +782,7 @@
     },
     "node_modules/@fluentui/react-infobutton": {
       "version": "9.0.0-beta.118",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.118.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.118.tgz",
       "integrity": "sha1-uVnpcSRgCRAteytp5dF2mnQDgwY=",
       "license": "MIT",
       "dependencies": {
@@ -1066,7 +805,7 @@
     },
     "node_modules/@fluentui/react-infolabel": {
       "version": "9.4.23",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-infolabel/-/react-infolabel-9.4.23.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-infolabel/-/react-infolabel-9.4.23.tgz",
       "integrity": "sha1-ThgZS25+bk1DXh0gbJBcDBH0/FQ=",
       "license": "MIT",
       "dependencies": {
@@ -1090,7 +829,7 @@
     },
     "node_modules/@fluentui/react-input": {
       "version": "9.8.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-input/-/react-input-9.8.5.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-input/-/react-input-9.8.5.tgz",
       "integrity": "sha1-W8dojWfScG6PTscg6CESz7WPrZw=",
       "license": "MIT",
       "dependencies": {
@@ -1111,7 +850,7 @@
     },
     "node_modules/@fluentui/react-jsx-runtime": {
       "version": "9.4.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.4.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.4.tgz",
       "integrity": "sha1-1C9Z8VeWSqDmFaFnGRTArQiWPOA=",
       "license": "MIT",
       "dependencies": {
@@ -1125,7 +864,7 @@
     },
     "node_modules/@fluentui/react-label": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-label/-/react-label-9.4.3.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-label/-/react-label-9.4.3.tgz",
       "integrity": "sha1-8mHWrSbQ9G5+osIL91c1+ZGdsvM=",
       "license": "MIT",
       "dependencies": {
@@ -1191,7 +930,7 @@
     },
     "node_modules/@fluentui/react-menu": {
       "version": "9.25.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-menu/-/react-menu-9.25.2.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-menu/-/react-menu-9.25.2.tgz",
       "integrity": "sha1-MmWrRh7siUyM8UtL8Hzo83uEmyY=",
       "license": "MIT",
       "dependencies": {
@@ -1220,7 +959,7 @@
     },
     "node_modules/@fluentui/react-message-bar": {
       "version": "9.7.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-message-bar/-/react-message-bar-9.7.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-message-bar/-/react-message-bar-9.7.4.tgz",
       "integrity": "sha1-3NvGi1v+itwIQ1WqUSooUINDKQ4=",
       "license": "MIT",
       "dependencies": {
@@ -1245,7 +984,7 @@
     },
     "node_modules/@fluentui/react-motion": {
       "version": "9.16.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-motion/-/react-motion-9.16.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-motion/-/react-motion-9.16.1.tgz",
       "integrity": "sha1-uiYSrPlRY/HaHiQ2cz/qS3kMFS8=",
       "license": "MIT",
       "dependencies": {
@@ -1262,7 +1001,7 @@
     },
     "node_modules/@fluentui/react-motion-components-preview": {
       "version": "0.15.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
       "integrity": "sha1-0lg1U5l83ef9xF4qNbJ2mqfQ6fc=",
       "license": "MIT",
       "dependencies": {
@@ -1279,7 +1018,7 @@
     },
     "node_modules/@fluentui/react-nav": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-nav/-/react-nav-9.4.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-nav/-/react-nav-9.4.3.tgz",
       "integrity": "sha1-V9OOReFhSWJCk61HEmvqKBGlkzk=",
       "license": "MIT",
       "dependencies": {
@@ -1309,7 +1048,7 @@
     },
     "node_modules/@fluentui/react-overflow": {
       "version": "9.9.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-overflow/-/react-overflow-9.9.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-overflow/-/react-overflow-9.9.1.tgz",
       "integrity": "sha1-/JxqZzXI+U95QiSvesb309Cdo6U=",
       "license": "MIT",
       "dependencies": {
@@ -1329,7 +1068,7 @@
     },
     "node_modules/@fluentui/react-persona": {
       "version": "9.7.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-persona/-/react-persona-9.7.6.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-persona/-/react-persona-9.7.6.tgz",
       "integrity": "sha1-u4I3VGfGHpn/dxchK4SYQvVXw4k=",
       "license": "MIT",
       "dependencies": {
@@ -1351,7 +1090,7 @@
     },
     "node_modules/@fluentui/react-popover": {
       "version": "9.14.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-popover/-/react-popover-9.14.5.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-popover/-/react-popover-9.14.5.tgz",
       "integrity": "sha1-u1tiR6dRamPHkdN/ztsSfLrZaKc=",
       "license": "MIT",
       "dependencies": {
@@ -1379,7 +1118,7 @@
     },
     "node_modules/@fluentui/react-portal": {
       "version": "9.8.14",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-portal/-/react-portal-9.8.14.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-portal/-/react-portal-9.8.14.tgz",
       "integrity": "sha1-CxNSqzA7QwIyRXB98+7mikFC92M=",
       "license": "MIT",
       "dependencies": {
@@ -1398,7 +1137,7 @@
     },
     "node_modules/@fluentui/react-positioning": {
       "version": "9.23.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-positioning/-/react-positioning-9.23.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-positioning/-/react-positioning-9.23.0.tgz",
       "integrity": "sha1-qWwy18ZyUuFLOasu1W7rRRYuAOQ=",
       "license": "MIT",
       "dependencies": {
@@ -1420,7 +1159,7 @@
     },
     "node_modules/@fluentui/react-progress": {
       "version": "9.5.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-progress/-/react-progress-9.5.3.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-progress/-/react-progress-9.5.3.tgz",
       "integrity": "sha1-SGmwk+y+4hNrQy52RN/VrV+lnUY=",
       "license": "MIT",
       "dependencies": {
@@ -1442,7 +1181,7 @@
     },
     "node_modules/@fluentui/react-provider": {
       "version": "9.22.19",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-provider/-/react-provider-9.22.19.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-provider/-/react-provider-9.22.19.tgz",
       "integrity": "sha1-U3+U3rDnaLhmnwqD3jHdvHUptxI=",
       "license": "MIT",
       "dependencies": {
@@ -1488,7 +1227,7 @@
     },
     "node_modules/@fluentui/react-rating": {
       "version": "9.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-rating/-/react-rating-9.4.3.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-rating/-/react-rating-9.4.3.tgz",
       "integrity": "sha1-bZN1GIiB7f+enrrcaa7Qh1L5r78=",
       "license": "MIT",
       "dependencies": {
@@ -1510,7 +1249,7 @@
     },
     "node_modules/@fluentui/react-search": {
       "version": "9.4.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-search/-/react-search-9.4.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-search/-/react-search-9.4.5.tgz",
       "integrity": "sha1-3xu3kK4YZPnCuZx6VuntjAI09tI=",
       "license": "MIT",
       "dependencies": {
@@ -1532,7 +1271,7 @@
     },
     "node_modules/@fluentui/react-select": {
       "version": "9.5.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-select/-/react-select-9.5.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-select/-/react-select-9.5.4.tgz",
       "integrity": "sha1-R753Z5q2vjB9hYCc9W0m6cuenOk=",
       "license": "MIT",
       "dependencies": {
@@ -1554,7 +1293,7 @@
     },
     "node_modules/@fluentui/react-shared-contexts": {
       "version": "9.26.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
       "integrity": "sha1-A4ZM7kVinVc/X4Yxy569R4vLq/c=",
       "license": "MIT",
       "dependencies": {
@@ -1568,7 +1307,7 @@
     },
     "node_modules/@fluentui/react-skeleton": {
       "version": "9.7.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-skeleton/-/react-skeleton-9.7.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-skeleton/-/react-skeleton-9.7.4.tgz",
       "integrity": "sha1-kc1ER+I8AGRNlbjCny4W7PLUcO0=",
       "license": "MIT",
       "dependencies": {
@@ -1589,7 +1328,7 @@
     },
     "node_modules/@fluentui/react-slider": {
       "version": "9.6.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-slider/-/react-slider-9.6.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-slider/-/react-slider-9.6.4.tgz",
       "integrity": "sha1-I10Exll7lmAcpCU7onY/W9NPTPE=",
       "license": "MIT",
       "dependencies": {
@@ -1611,7 +1350,7 @@
     },
     "node_modules/@fluentui/react-spinbutton": {
       "version": "9.6.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-spinbutton/-/react-spinbutton-9.6.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-spinbutton/-/react-spinbutton-9.6.4.tgz",
       "integrity": "sha1-Anr6BG6trenZVojuaM7Wgvpa2Z0=",
       "license": "MIT",
       "dependencies": {
@@ -1634,7 +1373,7 @@
     },
     "node_modules/@fluentui/react-spinner": {
       "version": "9.8.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-spinner/-/react-spinner-9.8.4.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-spinner/-/react-spinner-9.8.4.tgz",
       "integrity": "sha1-R0reupmYnVBv1+bo1a2q6w4KlBA=",
       "license": "MIT",
       "dependencies": {
@@ -1703,7 +1442,7 @@
     },
     "node_modules/@fluentui/react-table": {
       "version": "9.19.18",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-table/-/react-table-9.19.18.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-table/-/react-table-9.19.18.tgz",
       "integrity": "sha1-uy3HCiR40XL86fq51Z/XAWSSdZM=",
       "license": "MIT",
       "dependencies": {
@@ -1731,7 +1470,7 @@
     },
     "node_modules/@fluentui/react-tabs": {
       "version": "9.12.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tabs/-/react-tabs-9.12.3.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tabs/-/react-tabs-9.12.3.tgz",
       "integrity": "sha1-2bsigoHcZeyRz8CDv1bYSIIPjww=",
       "license": "MIT",
       "dependencies": {
@@ -1753,7 +1492,7 @@
     },
     "node_modules/@fluentui/react-tabster": {
       "version": "9.26.16",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tabster/-/react-tabster-9.26.16.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tabster/-/react-tabster-9.26.16.tgz",
       "integrity": "sha1-W+25Rsa54NTNfNYD3z5+xTKTgdw=",
       "license": "MIT",
       "dependencies": {
@@ -1774,7 +1513,7 @@
     },
     "node_modules/@fluentui/react-tag-picker": {
       "version": "9.10.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tag-picker/-/react-tag-picker-9.10.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tag-picker/-/react-tag-picker-9.10.1.tgz",
       "integrity": "sha1-RqSKg67av8zTCnm7t6B4G3npc7E=",
       "license": "MIT",
       "dependencies": {
@@ -1804,7 +1543,7 @@
     },
     "node_modules/@fluentui/react-tags": {
       "version": "9.9.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tags/-/react-tags-9.9.3.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tags/-/react-tags-9.9.3.tgz",
       "integrity": "sha1-l4KCXnZD1o7tMffBs+kUOyH6MYs=",
       "license": "MIT",
       "dependencies": {
@@ -1829,7 +1568,7 @@
     },
     "node_modules/@fluentui/react-teaching-popover": {
       "version": "9.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.3.tgz",
       "integrity": "sha1-LYCg2Zm/44TB/5Wxrn58ZYy9Ebo=",
       "license": "MIT",
       "dependencies": {
@@ -1856,7 +1595,7 @@
     },
     "node_modules/@fluentui/react-text": {
       "version": "9.6.18",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-text/-/react-text-9.6.18.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-text/-/react-text-9.6.18.tgz",
       "integrity": "sha1-cAPzAcfQDcyLD6nBPsPnzFhe0S8=",
       "license": "MIT",
       "dependencies": {
@@ -1907,7 +1646,7 @@
     },
     "node_modules/@fluentui/react-toast": {
       "version": "9.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-toast/-/react-toast-9.8.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-toast/-/react-toast-9.8.1.tgz",
       "integrity": "sha1-VV7L0VRNiKyVlMfttNUvQfyfcNg=",
       "license": "MIT",
       "dependencies": {
@@ -1934,7 +1673,7 @@
     },
     "node_modules/@fluentui/react-toolbar": {
       "version": "9.8.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-toolbar/-/react-toolbar-9.8.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-toolbar/-/react-toolbar-9.8.3.tgz",
       "integrity": "sha1-dIbqsEt/g17lK8+bVlW4zWJdBA0=",
       "license": "MIT",
       "dependencies": {
@@ -1959,7 +1698,7 @@
     },
     "node_modules/@fluentui/react-tooltip": {
       "version": "9.10.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tooltip/-/react-tooltip-9.10.4.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tooltip/-/react-tooltip-9.10.4.tgz",
       "integrity": "sha1-kCLgr65fUQnkZHvIZI2/pksGW7s=",
       "license": "MIT",
       "dependencies": {
@@ -1983,7 +1722,7 @@
     },
     "node_modules/@fluentui/react-tree": {
       "version": "9.16.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tree/-/react-tree-9.16.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-tree/-/react-tree-9.16.4.tgz",
       "integrity": "sha1-TKzcRpevydyom6mkV2ionCqvhiM=",
       "license": "MIT",
       "dependencies": {
@@ -2014,7 +1753,7 @@
     },
     "node_modules/@fluentui/react-utilities": {
       "version": "9.26.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
       "integrity": "sha1-I/Czh8/18uiormwR0UuhB8mIMgs=",
       "license": "MIT",
       "dependencies": {
@@ -2029,7 +1768,7 @@
     },
     "node_modules/@fluentui/react-virtualizer": {
       "version": "9.0.0-alpha.114",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.114.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.114.tgz",
       "integrity": "sha1-J1d7PpDLCGs46tR5xxP/4PmAyDU=",
       "license": "MIT",
       "dependencies": {
@@ -2048,7 +1787,7 @@
     },
     "node_modules/@fluentui/tokens": {
       "version": "1.0.0-alpha.23",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
       "integrity": "sha1-T4RsHk/Ns8qA6zGALEo2bVWZsw4=",
       "license": "MIT",
       "dependencies": {
@@ -2057,7 +1796,7 @@
     },
     "node_modules/@griffel/core": {
       "version": "1.21.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/core/-/core-1.21.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/core/-/core-1.21.3.tgz",
       "integrity": "sha1-fhN+aJYuYq2OwVVj/TBRzH4elX0=",
       "license": "MIT",
       "dependencies": {
@@ -2071,7 +1810,7 @@
     },
     "node_modules/@griffel/react": {
       "version": "1.7.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/react/-/react-1.7.7.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/react/-/react-1.7.7.tgz",
       "integrity": "sha1-iQiFJzS/aqAnZ2NDAxoHkTFm/QM=",
       "license": "MIT",
       "dependencies": {
@@ -2084,43 +1823,11 @@
     },
     "node_modules/@griffel/style-types": {
       "version": "1.4.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/style-types/-/style-types-1.4.2.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@griffel/style-types/-/style-types-1.4.2.tgz",
       "integrity": "sha1-T2aXpznqvCzteNK/9POMN+SOkRU=",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.3"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2130,21 +1837,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "version": "0.142.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha1-C0vXhB7z3SZ6aRhLl0UswLMT+1I=",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2152,9 +1848,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha1-t9I11Fs4yE8miSrIBLtPF0OKu/4=",
       "cpu": [
         "arm64"
       ],
@@ -2169,9 +1865,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha1-kCHbIkFV8VpBq2mDMu2zADEY/c0=",
       "cpu": [
         "arm64"
       ],
@@ -2186,9 +1882,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha1-f521YY0M5GP5sLuu7qSNGzC7lpw=",
       "cpu": [
         "x64"
       ],
@@ -2203,9 +1899,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha1-X7uSUp+43XP+bJITqaC54f2LiuE=",
       "cpu": [
         "x64"
       ],
@@ -2220,9 +1916,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha1-qDaq36OOp3i9xVCO79UDb1u/gFI=",
       "cpu": [
         "arm"
       ],
@@ -2237,16 +1933,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha1-x321wkOoHYJBteTvapmoLIrPmkA=",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,16 +1950,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha1-BuzpiHLrPFsSln+qjgfvKwPgLQY=",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2277,16 +1967,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha1-tvVbzIOFIID4R47F2g6IsuP5ptE=",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,16 +1984,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha1-f6QW0sN69lTyi0MuJOW+lIO4nxk=",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2317,16 +2001,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha1-mu+mfnIkz9RGQ3OppPU4HNGcrjs=",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2337,16 +2018,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha1-jNcWCutbS6wz/Orz1+DGegx4yh0=",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2357,9 +2035,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha1-DDkaCKOaCXlK+XPuznghbIDhRPY=",
       "cpu": [
         "arm64"
       ],
@@ -2374,9 +2052,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha1-aJUmXiRhZO0ugWLLqRwMP8K/NoQ=",
       "cpu": [
         "arm64"
       ],
@@ -2391,9 +2069,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha1-Nd7ZIEMvp7FoFukELTZ5z9GxKYo=",
       "cpu": [
         "x64"
       ],
@@ -2408,16 +2086,16 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha1-R9K/TO9tRwsi9YMbQg+JZOC/dV8=",
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha1-p5tV26+GBIEvUtFAssmrQbwVC7g=",
       "dev": true,
       "license": "MIT"
     },
@@ -2432,7 +2110,7 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/dom/-/dom-10.4.1.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha1-1ET4qInppG6aO087iOD8s++2z5U=",
       "dev": true,
       "license": "MIT",
@@ -2453,7 +2131,7 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha1-dhOgThRt0pdtJN3wGXMNV6idVsI=",
       "dev": true,
       "license": "MIT",
@@ -2473,14 +2151,14 @@
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha1-mT6SXMHXPyxmLn113VpURSWaj9g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/react/-/react-16.3.2.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha1-ZyiDt6y453X8BJLZ6dJeBuiXhtA=",
       "dev": true,
       "license": "MIT",
@@ -2508,61 +2186,15 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha1-GjHD03iFDSd42rtjdNA23LpLpwg=",
       "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha1-tYGSlMUReZV6+uw0FEL5NB5BCKk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha1-B9cT1szg0mXJhJ2wy+YtP2Hzb3Q=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha1-jpzZ4cNYH6azQaWu1ViOsoW+C0o=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2572,19 +2204,19 @@
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha1-4CFRRk0C1KG0RkbQ/NuT+viP3ow=",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha1-NoyWGhjech2oIA6AvzlD+1MTavI=",
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha1-4o2xv7+mFwdvd3DdHZpI6qO2xRs=",
       "license": "MIT"
     },
@@ -2599,13 +2231,13 @@
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha1-9jKzgMOsoduo40qgSbzWpK8j34o=",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha1-V6L3ByQub+Hega17/Myq9gYXmvs=",
       "license": "MIT",
       "dependencies": {
@@ -2614,7 +2246,7 @@
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha1-0VFsxQh1O+BoUs0GdY47tUoisOM=",
       "license": "MIT",
       "dependencies": {
@@ -2623,7 +2255,7 @@
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha1-hHL+7NY5aRRQ3YAA6zPt1EThMj8=",
       "license": "MIT"
     },
@@ -2635,21 +2267,21 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha1-M0MRlx06BxIefrkbaEpgXn7qnL0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha1-5uWobWAr6spxzlFj+t9fldcJMcc=",
       "license": "MIT"
     },
@@ -2658,6 +2290,7 @@
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha1-teleKP/M6rjZgvM/LrB24XZTwqQ=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2665,38 +2298,44 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha1-uJ3fLNg7T+r8xOLqQa/fuVoNGU8=",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha1-ZHr057t1rTrdV452KtmEuQ9KJLk=",
+      "version": "6.0.5",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha1-SO55UQk/+QVJUs/51k6HQ1XN43I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha1-eZwG/ES7DPfieEE3tifFzBcyhdQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2713,8 +2352,8 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha1-JBOYerTNf6HCthS0BMQHv2rR6tE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2740,8 +2379,8 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha1-dVQucnOgjMEP1Nja1OPrHxbNlYw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2753,8 +2392,8 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha1-/r8KIakWhCFCLRlVNw5gb+q2A1U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2767,8 +2406,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha1-fj6f7H1NRyMuSTz9y9IXDeQ3HAQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2783,8 +2422,8 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha1-XAv6l7Vrup43QDyXbbd2/2q1b2U=",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2793,8 +2432,8 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha1-/8cQVfGL/Msf0FhjZevCgkiS5AM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2808,7 +2447,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "dev": true,
       "license": "MIT",
@@ -2818,22 +2457,20 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2853,8 +2490,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha1-9kGhlrM1aQsQcL8AtudZP+wZC/c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2868,56 +2505,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.11.12",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
-      "integrity": "sha1-QqxIdwv3PSkvYM6LpNxefrskLsM=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
-      "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.44",
-        "caniuse-lite": "^1.0.30001806",
-        "electron-to-chromium": "^1.5.393",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "dev": true,
       "license": "MIT",
@@ -2929,31 +2519,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha1-rkG1LJrKh3NFBTYnF/MlX6zaNg4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2962,7 +2531,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
       "license": "MIT",
       "engines": {
@@ -2971,7 +2540,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "license": "MIT",
@@ -2991,7 +2560,7 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css.escape/-/css.escape-1.5.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true,
       "license": "MIT"
@@ -3012,20 +2581,20 @@
     },
     "node_modules/cssstyle/node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha1-MCHRtDUvvzthSq7tC8DVc5q+C8I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-array/-/d3-array-3.2.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha1-Ff7DOyN/l6xdfJhtx32ic6jtC7U=",
       "license": "ISC",
       "dependencies": {
@@ -3037,7 +2606,7 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-color/-/d3-color-3.1.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha1-OVsoM9+scVB/EqwvevI7+BneJOI=",
       "license": "ISC",
       "engines": {
@@ -3055,7 +2624,7 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-format/-/d3-format-3.1.2.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha1-Af20a1i+sfVbELQq1wtuNE1esq4=",
       "license": "ISC",
       "engines": {
@@ -3064,7 +2633,7 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha1-PEeqWzLFs9+1bvP9Q0IHimMrQA0=",
       "license": "ISC",
       "dependencies": {
@@ -3076,7 +2645,7 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-path/-/d3-path-3.1.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha1-It+TkDL7WnGuixgA1h3beFHEJSY=",
       "license": "ISC",
       "engines": {
@@ -3085,7 +2654,7 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-scale/-/d3-scale-4.0.2.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha1-grOOjo/3CAdk+Nzsd71L45Nok5Y=",
       "license": "ISC",
       "dependencies": {
@@ -3101,7 +2670,7 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-shape/-/d3-shape-3.2.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha1-oag5y9m6RfKGdMadf4Vbz5HfxqU=",
       "license": "ISC",
       "dependencies": {
@@ -3125,7 +2694,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha1-erUlelBB0R7LT+cKXH0WoZW7QIo=",
       "license": "ISC",
       "dependencies": {
@@ -3137,7 +2706,7 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-timer/-/d3-timer-3.0.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha1-YoTSonCChbGrt+IB7aQ4CvNeY7A=",
       "license": "ISC",
       "engines": {
@@ -3160,7 +2729,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
@@ -3185,13 +2754,13 @@
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha1-E0/TJQjxniCPT7L42sDSYmqGeTQ=",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "license": "MIT",
@@ -3211,8 +2780,8 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3221,15 +2790,14 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha1-WnQp5gZus2ZNkR4z+w5F3o6whFM=",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha1-2UAFNrK/giWtmP4FLgKUUaxA6QI=",
       "license": "MIT",
       "dependencies": {
@@ -3239,7 +2807,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
       "dev": true,
       "license": "MIT",
@@ -3252,22 +2820,16 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.400",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
-      "integrity": "sha1-qbD7BkoRDFmOwqElNfLID8GkXGQ=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha1-q87f8r/zaZLqisJ80wCAyltqP1g=",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
       "integrity": "sha1-vIbJfeANUuw0sFBYc271Cvbg0OQ=",
       "license": "MIT",
       "peerDependencies": {
@@ -3276,7 +2838,7 @@
     },
     "node_modules/embla-carousel-fade": {
       "version": "8.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
       "integrity": "sha1-ktGezVREHrbzeRC/nhb9P1R+M3Q=",
       "license": "MIT",
       "peerDependencies": {
@@ -3285,7 +2847,7 @@
     },
     "node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-6.0.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-6.0.1.tgz",
       "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3298,7 +2860,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "dev": true,
       "license": "MIT",
@@ -3308,7 +2870,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "dev": true,
       "license": "MIT",
@@ -3318,14 +2880,14 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "dev": true,
       "license": "MIT",
@@ -3338,7 +2900,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
       "dev": true,
       "license": "MIT",
@@ -3352,20 +2914,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3380,7 +2932,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expect-type/-/expect-type-1.4.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expect-type/-/expect-type-1.4.0.tgz",
       "integrity": "sha1-JO338MxppE0AhWe6RZSrlvPDo9Y=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3390,7 +2942,7 @@
     },
     "node_modules/fast-equals": {
       "version": "5.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-equals/-/fast-equals-5.4.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-equals/-/fast-equals-5.4.1.tgz",
       "integrity": "sha1-qRdLA+7OUwfb1nW+bW1C9/odAO0=",
       "license": "MIT",
       "engines": {
@@ -3399,8 +2951,8 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3417,7 +2969,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "dev": true,
       "license": "MIT",
@@ -3434,10 +2986,9 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3449,7 +3000,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "dev": true,
       "license": "MIT",
@@ -3457,19 +3008,9 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "dev": true,
       "license": "MIT",
@@ -3494,7 +3035,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
       "dev": true,
       "license": "MIT",
@@ -3508,7 +3049,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "dev": true,
       "license": "MIT",
@@ -3521,7 +3062,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "dev": true,
       "license": "MIT",
@@ -3550,7 +3091,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "dev": true,
       "license": "MIT",
@@ -3563,7 +3104,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha1-aW31KafP2CRGNp3FGT5ZCjc1tEg=",
       "dev": true,
       "license": "MIT",
@@ -3590,7 +3131,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "dev": true,
       "license": "MIT",
@@ -3604,7 +3145,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
       "dev": true,
       "license": "MIT",
@@ -3617,7 +3158,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true,
       "license": "MIT",
@@ -3627,7 +3168,7 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internmap/-/internmap-2.0.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha1-ZoXyN1XkPFJOJR0py8lySOMGEAk=",
       "license": "ISC",
       "engines": {
@@ -3636,7 +3177,7 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=",
       "dev": true,
       "license": "MIT"
@@ -3653,6 +3194,7 @@
       "integrity": "sha1-iOSgfLndIQZ1FKYZ6fF7CQo5Sp8=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -3688,42 +3230,16 @@
         }
       }
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/keyborg": {
       "version": "2.14.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/keyborg/-/keyborg-2.14.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/keyborg/-/keyborg-2.14.1.tgz",
       "integrity": "sha1-BElZ/w5PldBi0eB+LToPvCrRHTA=",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha1-wIhn1xp5OFxuGQIU/XL+8+X5Xws=",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -3752,8 +3268,8 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha1-mmhB+IrlD8g1ApA4krQa9BvCuQc=",
       "cpu": [
         "arm64"
       ],
@@ -3773,8 +3289,8 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha1-wPLDHAv9GfpN0/GOlXofGhUgl9Y=",
       "cpu": [
         "arm64"
       ],
@@ -3794,8 +3310,8 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha1-ywcFllrLU4xmg5Sc5pJfs833w2E=",
       "cpu": [
         "x64"
       ],
@@ -3815,8 +3331,8 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha1-djU4gosmurJoDa2vzITueLDrUCs=",
       "cpu": [
         "x64"
       ],
@@ -3836,8 +3352,8 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha1-aGLjF2ozGu297B7TUrTX0N0HhN4=",
       "cpu": [
         "arm"
       ],
@@ -3857,15 +3373,12 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha1-xqOi7RUUHa9r3CYokw+OOb30c6o=",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3881,15 +3394,12 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha1-f6EzSXH8goRfmCffbvigsgkUusY=",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3905,15 +3415,12 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha1-i5J4YuqMK7xoMaRlCSRLUNmTblU=",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3929,15 +3436,12 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha1-DFJbsHff2UQEwFnP5C2teX6Wrq8=",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3953,8 +3457,8 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha1-hQ7hED2smJz6tQ46wi0aaeOU5j0=",
       "cpu": [
         "arm64"
       ],
@@ -3974,8 +3478,8 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha1-40OuFS7tNgncbhGUnRo785oclG8=",
       "cpu": [
         "x64"
       ],
@@ -3995,13 +3499,13 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "license": "MIT",
       "dependencies": {
@@ -4012,14 +3516,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+      "version": "10.4.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
+      "license": "ISC"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -4027,15 +3528,14 @@
       "integrity": "sha1-watQ93iHtxJiEgG6n9Tjpu0JmUE=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4044,7 +3544,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
       "dev": true,
       "license": "MIT",
@@ -4064,7 +3564,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "dev": true,
       "license": "MIT",
@@ -4077,7 +3577,7 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/min-indent/-/min-indent-1.0.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
       "dev": true,
       "license": "MIT",
@@ -4087,14 +3587,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.17",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
       "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
       "dev": true,
       "funding": [
@@ -4111,26 +3611,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.52",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.52.tgz",
-      "integrity": "sha1-2Cg7ol5Xek2XVtW0Xso1O6VQAwA=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.24",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nwsapi/-/nwsapi-2.2.24.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nwsapi/-/nwsapi-2.2.24.tgz",
       "integrity": "sha1-+JJwQ9TJtRar3r6ASjLI0flITR8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "license": "MIT",
       "engines": {
@@ -4139,8 +3629,8 @@
     },
     "node_modules/obug": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
-      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha1-kJDYpUilIlF5FdKqaq6QcZesbPg=",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -4153,7 +3643,7 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-7.3.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha1-1+Ik+nI5nHoXUJn0X8KtAksF7AU=",
       "dev": true,
       "license": "MIT",
@@ -4166,24 +3656,25 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha1-PsvsVUIWhbcKnahyss/z4cvtFxY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4193,7 +3684,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.25",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.25.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=",
       "dev": true,
       "funding": [
@@ -4226,7 +3717,6 @@
       "integrity": "sha1-IYGHn96lGnpYUfs52SD6pj8B2I4=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4238,7 +3728,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prop-types/-/prop-types-15.8.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
       "license": "MIT",
       "dependencies": {
@@ -4249,13 +3739,13 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-16.13.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
       "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/psl/-/psl-1.15.0.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/psl/-/psl-1.15.0.tgz",
       "integrity": "sha1-vazjGJbx2XzsannoIkiYzpPZdMY=",
       "dev": true,
       "license": "MIT",
@@ -4268,7 +3758,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -4278,16 +3768,17 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/querystringify/-/querystringify-2.2.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react/-/react-18.3.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react/-/react-18.3.1.tgz",
       "integrity": "sha1-SauJIAnFOTNiW9FrJTP8dUyrKJE=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4297,9 +3788,10 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-dom/-/react-dom-18.3.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha1-wiZdeVEbV9R5s90/36UVNklMXLQ=",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4322,22 +3814,11 @@
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
       "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha1-t+V5w2V/I9BOzL5K0uWKjtUeflM=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-smooth/-/react-smooth-4.0.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-smooth/-/react-smooth-4.0.4.tgz",
       "integrity": "sha1-pYdfi7YZY8phuBnO3FadwkU4lLQ=",
       "license": "MIT",
       "dependencies": {
@@ -4352,7 +3833,7 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha1-5T1OPzNE2oUhSJ+++PJYHUK+zdE=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4368,7 +3849,7 @@
     },
     "node_modules/recharts": {
       "version": "2.15.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recharts/-/recharts-2.15.4.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recharts/-/recharts-2.15.4.tgz",
       "integrity": "sha1-DtPmbAhDvPLZ+aFyyvl7HQUSel8=",
       "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
       "license": "MIT",
@@ -4392,7 +3873,7 @@
     },
     "node_modules/recharts-scale": {
       "version": "0.4.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/recharts-scale/-/recharts-scale-0.4.5.tgz",
       "integrity": "sha1-CWknHxTnMuZC/MW9SrJw1uh90dk=",
       "license": "MIT",
       "dependencies": {
@@ -4401,13 +3882,13 @@
     },
     "node_modules/recharts/node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-18.3.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
       "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/redent/-/redent-3.0.0.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/redent/-/redent-3.0.0.tgz",
       "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
       "dev": true,
       "license": "MIT",
@@ -4427,13 +3908,13 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha1-8oB2cWk2vO2gXg0FWVAqXOsKbp4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.143.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4443,32 +3924,25 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.3",
-        "@rolldown/binding-darwin-arm64": "1.2.3",
-        "@rolldown/binding-darwin-x64": "1.2.3",
-        "@rolldown/binding-freebsd-x64": "1.2.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-        "@rolldown/binding-linux-arm64-musl": "1.2.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-musl": "1.2.3",
-        "@rolldown/binding-openharmony-arm64": "1.2.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha1-xzRRpIS4bdfPseCyiY30twMYPks=",
       "dev": true,
       "license": "MIT"
@@ -4484,7 +3958,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true,
       "license": "MIT"
@@ -4504,20 +3978,10 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha1-DE74LWfR5cHjWej8dtOofwRf5b0=",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4528,7 +3992,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -4538,21 +4002,21 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stackback/-/stackback-0.0.2.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
-      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha1-jr4OxgSFZoq0ciezEvQlTN+AydM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-indent/-/strip-indent-3.0.0.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
       "dev": true,
       "license": "MIT",
@@ -4565,13 +4029,13 @@
     },
     "node_modules/stylis": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stylis/-/stylis-4.4.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha1-xYRsk0X0v8Ub0MvXyjWgdE9IWl0=",
       "license": "MIT"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true,
       "license": "MIT"
@@ -4588,21 +4052,21 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha1-RmgLeoc6DV0QAFmV65CnDXTWASc=",
       "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinybench/-/tinybench-2.9.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha1-EDyfi6bXI3pHq23R3P93JRhjQms=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha1-qswdux1Ok+atjdZJROCfmtFHpHQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4611,8 +4075,8 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4628,8 +4092,8 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha1-wBaDh9PY1wtrPCwJNt5f7nOM6iA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4638,7 +4102,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha1-lF8UYbRbWox2ghwz6knDrBksGzY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -4654,7 +4118,7 @@
     },
     "node_modules/tr46": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tr46/-/tr46-5.1.1.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha1-lq6GfN24/bZKScwwWajUKLzyOMo=",
       "dev": true,
       "license": "MIT",
@@ -4673,7 +4137,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -4687,7 +4151,7 @@
     },
     "node_modules/universalify": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.2.0.tgz",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha1-ZFF2BWb6hXU0dFqx3elS0bF2G+A=",
       "dev": true,
       "license": "MIT",
@@ -4695,40 +4159,9 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/url-parse/-/url-parse-1.5.10.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha1-nTwvc2wddd070r5QfcwRHx4uqcE=",
       "dev": true,
       "license": "MIT",
@@ -4739,7 +4172,7 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha1-sXS/plyytSZzLZ8qwKQIAnh28y0=",
       "license": "MIT",
       "peerDependencies": {
@@ -4769,16 +4202,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha1-kC/NPcAxL1U8hbbLxGJdysotjfg=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4848,8 +4282,8 @@
     },
     "node_modules/vitest": {
       "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha1-fpKF7+JksRZwULejp/80eI4bevw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4938,7 +4372,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha1-+SW6JoVRWFlNkHMTzt0UdsWWf2w=",
       "dev": true,
       "license": "MIT",
@@ -4951,7 +4385,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha1-JWtOGIK+feu/AdBfCqIDl3jqCAo=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4999,7 +4433,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha1-o/aalxB/SUs83Dvd3Yg6fWXOvwQ=",
       "dev": true,
       "license": "MIT",
@@ -5038,7 +4472,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha1-gr6blX96/az5YeWYDxvyJ8C/dnM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -5048,17 +4482,10 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/solution/apps/sales/Controls/SalesLeaderDashboard/package.json
+++ b/solution/apps/sales/Controls/SalesLeaderDashboard/package.json
@@ -22,10 +22,10 @@
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^24.1.1",
     "typescript": "^5.5.4",
-    "vite": "^8.2.1",
+    "vite": "^8.2.0",
     "vitest": "^4.1.10"
   }
 }


### PR DESCRIPTION
## What & why

Both page-level PCF controls were **uninstallable on `main`**. Dependabot (#78) bumped the dev toolchain to **`vite@^8.2.1`, which does not exist** (real latest is 8.2.0), and left **`@vitejs/plugin-react@^4`** (peer range vite <=7, incompatible with vite 8).

Result on a clean machine:
- `npm ci` -> ERESOLVE (plugin-react 4 vs vite 8)
- `npm install` -> `ETARGET No matching version found for vite@^8.2.1`, and against the MS proxy feed `E404 vite-8.2.1.tgz`

## Fix

Pin the consistent vite-8 set in both controls and regenerate both lockfiles:

| Control | vite | @vitejs/plugin-react | vitest |
| --- | --- | --- | --- |
| AdvisorCockpit | `^8.2.1` -> `^8.2.0` | `^4.3.1` -> `^6.0.5` | `^4.1.10` (unchanged) |
| SalesLeaderDashboard | `^8.2.1` -> `^8.2.0` | `^4.3.1` -> `^6.0.5` | `^4.1.10` (unchanged) |

## Evidence

- AdvisorCockpit dev harness boots clean: **`VITE v8.2.0 ready` at http://localhost:5173/** and renders (verified live).
- SalesLeaderDashboard: `npm install` clean (289 packages), lockfile now resolves vite 8.2.0 + plugin-react 6.0.5.

## Notes

- Dep/lockfile only; no source or behaviour change.
- Suggest a dependabot ignore/guard so a non-existent patch (`^8.2.1`) can't be reintroduced.