### PR TITLE
fix(security-roles): stop localizing role name/description (0x80044198)

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -2381,36 +2381,33 @@ function Invoke-RoleReconciliation {
         $request = [pscustomobject]@{
             Method = 'POST'; Path = '/roles'; Solution = $Role.solution
             EntityLogicalName = 'role'; IdProperty = 'roleid'
-            LocalizedFields = @{
-                name = $Role.metadata.label
-                description = $Role.metadata.description
-            }
             Body = @{
                 name = $Role.name
                 description = [string]$Role.metadata.description.'1033'
                 'businessunitid@odata.bind' = "/businessunits($businessUnitId)"
             }
         }
+        # Security roles are not in the SetLocLabels supported-attribute set;
+        # name/description are written as plain attributes (1033 base) only.
         $existing = Invoke-PlannedRequest $request
-        Set-RecordLocalizedFields -Request $request -CreatedRecord $existing
         if ($null -eq $existing -or -not $existing.roleid) {
             throw "Created role '$($Role.name)' did not return its role ID."
         }
         Write-Output "$($Role.name): Created"
     } else {
         Assert-SolutionOwnership $existing $Role.solution $Role.name
+        $roleId = [string]$existing.roleid
         $request = [pscustomobject]@{
-            Solution = $Role.solution
-            EntityLogicalName = 'role'
-            IdProperty = 'roleid'
-            LocalizedFields = @{
-                name = $Role.metadata.label
-                description = $Role.metadata.description
+            Method = 'PATCH'; Path = "/roles($roleId)"; Solution = $Role.solution
+            EntityLogicalName = 'role'; IdProperty = 'roleid'
+            Body = @{
+                name = $Role.name
+                description = [string]$Role.metadata.description.'1033'
             }
         }
-        # Role localized labels are not exposed as a complete language set by
-        # the record query. Idempotently repair every language on each run.
-        Set-RecordLocalizedFields -Request $request -CreatedRecord $existing
+        # Security roles do not support SetLocLabels; reconcile name/description
+        # as plain attributes (1033 base) instead.
+        Invoke-PlannedRequest $request | Out-Null
         Write-Output "$($Role.name): Updated"
     }
 

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1637,9 +1637,9 @@ Describe 'Insurance Foundation reconciliation' {
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/savedqueries','/SetLocLabels','/SetLocLabels',
             '/systemforms','/SetLocLabels','/SetLocLabels',
-            '/roles','/SetLocLabels','/SetLocLabels',
+            '/roles',
             '/roles(new-role)/Microsoft.Dynamics.CRM.AddPrivilegesRole',
-            '/roles','/SetLocLabels','/SetLocLabels',
+            '/roles',
             '/roles(new-role)/Microsoft.Dynamics.CRM.AddPrivilegesRole',
             '/PublishAllXml'
         )
@@ -2444,13 +2444,15 @@ Describe 'Insurance Foundation reconciliation' {
         }) | Should -BeNullOrEmpty
         @($script:calls | Where-Object Path -like '/roleprivileges*') |
             Should -BeNullOrEmpty
-        $localizationRepairs = @($script:calls |
-            Where-Object Path -eq '/SetLocLabels')
-        $localizationRepairs.Count | Should -Be 2
-        foreach ($repair in $localizationRepairs) {
-            @($repair.Body.Labels.LanguageCode) |
-                Should -Be @(1033, 1031, 1036, 1040)
-        }
+        @($script:calls | Where-Object Path -eq '/SetLocLabels') |
+            Should -BeNullOrEmpty
+        $roleUpdate = @($script:calls | Where-Object {
+            $_.Method -eq 'PATCH' -and $_.Path -eq "/roles($roleId)"
+        })
+        $roleUpdate.Count | Should -Be 1
+        $roleUpdate[0].Body.name | Should -Be $role.name
+        $roleUpdate[0].Body.description |
+            Should -Be ([string]$role.metadata.description.'1033')
         $wantedNames | Should -Contain 'prvReadcrmshow_PolicyProjection'
         ($wantedNames -ccontains 'prvReadcrmshow_policyprojection') |
             Should -BeFalse


### PR DESCRIPTION
## What & why

The security-role bootstrap (`Publish -Scope SecurityRoles`) failed with:

```
0x80044198 — Attribute name does not support localized labels.
```

Root cause (grounded in Microsoft Learn): `Invoke-RoleReconciliation` called **`SetLocLabels`** on role `name`/`description`, but the **`role` entity is not in the supported-attribute set** for `SetLocLabels`/`RetrieveLocLabels`. That set is limited to specific record types — `SavedQuery` (views), `SystemForm` (forms), `SavedQueryVisualization`, `Product`, `DynamicProperty*`, `TimeZone*` — **not `role`**. Security-role display names are only localizable through the solution translation (customization) layer, never per-record via the Web API.

This is **independent of #40**. #40 fixed *finding* the existing root role; this fixes *writing* to it. The #40 fix simply let execution reach the (previously unreached) `SetLocLabels` call, exposing this. Net effect: the bootstrap has never completed in this org and `CRM Showcase Insurance Data Steward` was never created.

## Decision

**Security roles are not localized** (confirmed with product owner). Set role `name`/`description` as **plain attributes (1033 base)**:

- **Create:** keep the `POST /roles` body (`name`/`description` already there); drop the `SetLocLabels` pass.
- **Update:** `PATCH /roles(id)` with `name`/`description`; drop the `SetLocLabels` pass.

Views (`savedquery`) and forms (`systemform`) keep `SetLocLabels` — they **are** in the supported set. Tables/columns/choices keep metadata `LocalizedLabels`. Only roles change.

## Tests / evidence

- Deterministic mutation-order test: role sequence is now `/roles` + `AddPrivilegesRole` (no `SetLocLabels`).
- Role-privileges test: asserts **zero** `SetLocLabels` and a plain `PATCH /roles(id)` with `name`/`description`.
- **Publish suite green: 103 passed / 0 failed** (Pester v6).
- DEV WhatIf against crmshowdev is clean; real run will reconcile the Reader + create the Data Steward.

## Docs

- https://learn.microsoft.com/dotnet/api/microsoft.crm.sdk.messages.retrieveloclabelsrequest (Supported Tables)
- https://learn.microsoft.com/dotnet/api/microsoft.crm.sdk.messages.setloclabelsrequest

## After merge

Re-run `Publish -Scope SecurityRoles` in DEV → verifier Ready → CD-DEV (DEV evidence) → CD-TEST (TEST evidence). No role deletion.