### PR TITLE
ci(bootstrap): dispatch workflow to reconcile security roles on Ubuntu

### DIFF
--- a/.github/workflows/cd-bootstrap-roles.yml
+++ b/.github/workflows/cd-bootstrap-roles.yml
@@ -1,0 +1,73 @@
+name: CD — Bootstrap Security Roles
+
+# Deliberate, dispatch-only bootstrap of the reviewed Insurance Foundation
+# security roles (CRM Showcase Insurance Reader / Data Steward). These are a
+# ManualPrerequisite that the CD-DEV/CD-TEST authoring pipelines only *verify*;
+# this workflow *creates and reconciles* them. It runs on Ubuntu because the
+# Publish script issues parenthesised Dataverse Web API calls (e.g.
+# /roles(<id>)) that the Windows az.cmd batch wrapper mangles.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target Dataverse environment (GitHub environment name)
+        type: choice
+        options:
+          - dev
+          - test
+        default: dev
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      POWER_PLATFORM_ENV_URL: ${{ vars.POWER_PLATFORM_ENV_URL }}
+    steps:
+      - name: Check out reviewed commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Sign in with workload identity
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Reconcile security roles
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          & (Join-Path $root 'scripts/solution/Publish-InsuranceFoundation.ps1') `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -ContractPath (Join-Path $root 'solution/schema/insurance-foundation.json') `
+            -Scope SecurityRoles `
+            -Confirm:$false
+          if ($LASTEXITCODE -ne 0) { throw 'Security role bootstrap failed.' }
+
+      - name: Verify security roles converged
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          $pwsh = (Get-Command pwsh -ErrorAction Stop).Source
+          $verifier = Join-Path $root 'scripts/solution/Test-InsuranceSecurityRoles.ps1'
+          $contract = Join-Path $root 'solution/schema/insurance-foundation.json'
+          $json = & $pwsh -NoLogo -NoProfile -NonInteractive -File $verifier `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -ContractPath $contract
+          $exitCode = $LASTEXITCODE
+          Write-Host (@($json | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine)
+          if ($exitCode -ne 0) {
+            throw "Security roles did not converge to Ready (verifier exit $exitCode)."
+          }


### PR DESCRIPTION
## What & why

Adds a **dispatch-only** workflow to bootstrap the reviewed Insurance Foundation security roles (`CRM Showcase Insurance Reader` / `CRM Showcase Insurance Data Steward`).

These roles are a **ManualPrerequisite**: CD-DEV/CD-TEST only *verify* they exist (preflight), nothing creates them. `Publish -Scope SecurityRoles` **cannot run reliably on Windows** — `Invoke-DataverseRequest` shells out to `az`, and the Windows `az.cmd` batch wrapper mangles parenthesised Web API URLs (`/roles(<id>)`, `RetrieveRolePrivilegesRole(RoleId=…)`) that have no spaces → `--resource was unexpected at this time`. The identical script runs cleanly on the Ubuntu runner (real `az`), which is why CD-DEV works.

This is the last blocker to DEV/TEST evidence: with the #40 (detection) and #82 (no role localization) fixes merged, the bootstrap can finally complete — but only on Ubuntu.

## What it does

`workflow_dispatch` (input: `environment` = `dev`|`test`) → on `ubuntu-latest`, in the selected GitHub environment:
1. `azure/login` (OIDC workload identity — same as CD-DEV; the Publish script uses `az rest` only, no `pac`).
2. `Publish -Scope SecurityRoles` (create + reconcile — no deletion).
3. Read-only `Test-InsuranceSecurityRoles.ps1` verifier; the job fails unless roles report **Ready**.

## Design / governance

- Kept **separate from CD-DEV** deliberately: creating security roles is a privileged act, so it stays an explicit, human-dispatched step (preserves the ManualPrerequisite intent) rather than auto-running on every publish.
- Idempotent: safe to re-run; reconciles existing roles and creates missing ones.

## Hardening (per github-actions-hardening)

- All actions pinned to full commit SHAs (`checkout` v4.4.0, `azure/login` v2.3.1).
- Least privilege: top-level `contents: read`; `id-token: write` scoped to the job only.
- `persist-credentials: false`; `environment` input is `choice`-typed (not free-text → no injection).

## After merge

Dispatch it against `dev` → creates Data Steward + reconciles Reader → then `cd-solution-dev.yml` (DEV evidence) → `cd-solution-test.yml` (TEST evidence).