### PR TITLE
fix(security-roles): platform baseline privileges out of role-contract scope (ADR-0029)

### DIFF
--- a/docs/adr/ADR-0029-platform-baseline-privileges-out-of-role-contract.md
+++ b/docs/adr/ADR-0029-platform-baseline-privileges-out-of-role-contract.md
@@ -1,0 +1,79 @@
+# ADR-0029 — Platform-managed baseline privileges are out of reviewed-role contract scope
+
+| Field | Value |
+| --- | --- |
+| **Status** | Accepted |
+| **Date** | 2026-08-12 |
+| **Decision mode** | Committed decision |
+| **Confidence** | High — verified against the live DEV org; repo owner approved |
+| **Deciders** | Business owner / repo owner (human) · Enterprise Architect (AG-E-03) · SecDevOps (AG-E-04) · Responsible-AI Officer (AG-E-06) |
+| **Topic area** | A5 — Security · RBAC / reviewed security roles |
+| **Licence** | 🧩 configuration (Dataverse security roles + CI verifier) |
+| **Upgrade impact** | None — verifier comparison logic only; no schema or app surface change |
+| **CAF methodology** | Secure · Govern |
+| **WAF pillar(s)** | Primary: Security (keeps reviewed roles least-privileged on everything we control). Trade-off: absolute-exactness vs. platform reality — bounded to an inert, platform-managed baseline. |
+| **Zero Trust** | Least-privilege preserved: the contract still governs every CRM privilege + denied verb; only an inert, non-removable platform baseline is excluded from the exact-match check. |
+| **Responsible AI** | Accountability — the reviewed-role contract remains the source of truth for all governed privileges; the exclusion is explicit, named, and pattern-scoped. |
+
+## Context
+
+The reviewed Insurance Foundation security roles (`CRM Showcase Insurance
+Reader` / `Data Steward`) are authored from the contract and verified with an
+**exact privilege-set** check ([`Test-InsuranceSecurityRoles.ps1`](../../scripts/solution/Test-InsuranceSecurityRoles.ps1)):
+any privilege on the role that is not in the contract is a `ContractConflict`.
+
+When the bootstrap finally ran end-to-end (after ADR‑#40 root-role detection and
+the role-localization fix), the verifier reported `ContractConflict` on **four
+privileges nobody put in the contract**:
+
+- `prvReadSharePointDocument`, `prvReadSharePointData`, `prvWriteSharePointData`, `prvCreateSharePointData`
+
+Verified against the live DEV org (read-only):
+
+- **Server-Based SharePoint Integration is OFF** — `sharepointdeploymenttype = 0`
+  (None), **0** SharePoint sites. There is nothing to disable.
+- Dataverse **auto-grants these privileges to every newly created security role**
+  as a protected baseline. They are present on both the pre-existing Reader
+  (9 privileges = 5 contract + 4 baseline) and the freshly created Data Steward
+  (21 = 17 contract + 4 baseline).
+- They **survive `ReplacePrivilegesRole`** — the publisher already tries to set
+  the exact set, and they come back. The publisher cannot remove them.
+- They are **inert** here: no sites, integration off → nothing to read or write.
+
+So the roles are correct for everything we govern; the exact-match rule fails
+only on a platform baseline outside our control.
+
+## Options
+
+### Option A — Allowlist the platform baseline in the verifier ✅ preferred
+Exclude platform-managed baseline privileges (matched by pattern, e.g.
+`*SharePoint*`) from the verifier's "unexpected" comparison. The contract still
+fully governs every CRM privilege, depth, and denied verb.
+
+### Option B — Enumerate the baseline privileges in the contract per role
+Rejected: brittle and org-specific — the baseline set varies by which platform
+features are provisioned, so the contract would drift per environment.
+
+### Option C — Disable Server-Based SharePoint Integration in DEV
+Not actionable: it is already off (`sharepointdeploymenttype = 0`, 0 sites), yet
+the privileges are still granted. Nothing to disable.
+
+## Decision
+
+Adopt **Option A**. The reviewed-role contract governs the CRM privilege set and
+denied verbs; **platform-managed baseline privileges** (currently the SharePoint
+document-management set, matched by the `SharePoint` name pattern) are treated as
+out of contract scope and excluded from the exact-match "unexpected" check in
+[`Test-InsuranceSecurityRoles.ps1`](../../scripts/solution/Test-InsuranceSecurityRoles.ps1)
+(`Test-InsuranceRoleBaselinePrivilege`). `Missing`, `WrongDepth`, denied-verb,
+and duplicate checks are unchanged — least-privilege on everything we control is
+preserved.
+
+## Consequences
+
+- The bootstrap verifier converges to `Ready`, unblocking DEV/TEST evidence.
+- If a future org grants a different platform baseline, extend the pattern in
+  `Test-InsuranceRoleBaselinePrivilege` (single, named location) — do not add
+  baselines to the contract.
+- Should real SharePoint integration ever be in scope, revisit this ADR: the
+  SharePoint privileges would then be governed intentionally, not inert.

--- a/scripts/solution/Test-InsuranceSecurityRoles.ps1
+++ b/scripts/solution/Test-InsuranceSecurityRoles.ps1
@@ -316,7 +316,7 @@ function New-InsuranceSecurityRoleResult {
         State = $State
         Missing = @(Get-UniqueExactStrings -Value $Missing)
         Unexpected = @(Get-UniqueExactStrings -Value $Unexpected)
-        WrongDepth = @($WrongDepth)
+        WrongDepth = @($WrongDepth | Where-Object { $null -ne $_ })
         DuplicateExpected = @(Get-UniqueExactStrings -Value $DuplicateExpected)
         DuplicateActual = @(Get-UniqueExactStrings -Value $DuplicateActual)
         Details = @($Details | Where-Object {
@@ -418,6 +418,20 @@ function Normalize-InsuranceRolePrivilegeCollection {
     return @($normalized)
 }
 
+function Test-InsuranceRoleBaselinePrivilege {
+    # Dataverse auto-grants a protected baseline (e.g. SharePoint document
+    # management) to every security role; ReplacePrivilegesRole cannot remove
+    # it and it is outside the reviewed-role contract scope (ADR-0029).
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Name
+    )
+
+    return ([string]$Name -imatch 'SharePoint')
+}
+
 function Compare-InsuranceRolePrivileges {
     [CmdletBinding()]
     param(
@@ -444,9 +458,15 @@ function Compare-InsuranceRolePrivileges {
     }
 
     $unexpected = foreach ($name in @(Get-UniqueExactStrings -Value @($actualItems.Name))) {
-        if (-not (Test-ContainsExactString -Value @($expectedItems.Name) -Expected $name)) {
-            $name
+        if (Test-ContainsExactString -Value @($expectedItems.Name) -Expected $name) {
+            continue
         }
+        # Platform-managed baseline privileges (e.g. SharePoint document
+        # management) are auto-granted to every role and out of contract scope.
+        if (Test-InsuranceRoleBaselinePrivilege -Name $name) {
+            continue
+        }
+        $name
     }
 
     $wrongDepth = foreach ($name in @(Get-UniqueExactStrings -Value @($expectedItems.Name))) {

--- a/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceSecurityRoles.Tests.ps1
@@ -632,6 +632,26 @@ Describe 'Compare-InsuranceRolePrivileges' {
         @($result.Unexpected) | Should -Be @('prvDeleteAccount')
     }
 
+    It 'ignores platform-managed SharePoint baseline privileges' {
+        $result = Compare-InsuranceRolePrivileges `
+            -RoleName 'Reader' `
+            -Expected @([pscustomobject]@{
+                    Name = 'prvReadAccount'
+                    Depth = 'Global'
+                }) `
+            -Actual @(
+                [pscustomobject]@{ Name = 'prvReadAccount'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvReadSharePointDocument'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvReadSharePointData'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvWriteSharePointData'; Depth = 'Global' },
+                [pscustomobject]@{ Name = 'prvCreateSharePointData'; Depth = 'Global' }
+            )
+
+        $result.State | Should -Be 'Ready'
+        @($result.Unexpected) | Should -Be @()
+        @($result.WrongDepth) | Should -Be @()
+    }
+
     It 'reports wrong depth per privilege entry' {
         $result = Compare-InsuranceRolePrivileges `
             -RoleName 'Reader' `


### PR DESCRIPTION
## What & why

The security-role verifier uses a strict **exact privilege-set** check. When the bootstrap finally ran end-to-end, it reported `ContractConflict` on **4 privileges nobody put in the contract**: `prvReadSharePointDocument`, `prvReadSharePointData`, `prvWriteSharePointData`, `prvCreateSharePointData`.

Verified read-only against DEV (`crmshowdev`):
- **Server-Based SharePoint Integration is OFF** — `sharepointdeploymenttype = 0` (None), **0** sites. Nothing to disable.
- Dataverse **auto-grants these as a protected baseline to every new role** — present on the Reader (9 = 5 contract + 4 baseline) and the freshly created Data Steward (21 = 17 contract + 4 baseline).
- They **survive `ReplacePrivilegesRole`** (the publisher already tries the exact set) and are **inert** (no sites, integration off).

So the roles are correct on everything we govern; the exact-match rule fails only on an unremovable, inert platform baseline. (Options B "enumerate in contract" = brittle/org-specific; C "disable SBI" = not actionable, already off.)

## Change (Option A)

- New `Test-InsuranceRoleBaselinePrivilege` (matches the `SharePoint` name pattern) — excluded from the verifier's **unexpected** comparison only.
- `Missing` / `WrongDepth` / denied-verb / duplicate checks **unchanged** → least-privilege on every governed CRM privilege preserved.
- Defensively drop null `WrongDepth` entries (kills the cosmetic `Privilege '' depth mismatch` line).
- **ADR-0029** records the decision + how to extend the pattern if another org grants a different baseline.

## Tests

- New regression: baseline SharePoint privileges → `Ready`.
- Verifier suite green: **32 passed / 0 failed** (Pester v6).

## After merge

Re-dispatch `cd-bootstrap-roles.yml` (dev) → verifier **Ready** → CD-DEV (DEV evidence) → CD-TEST (TEST evidence).