### PR TITLE
docs(sprint-003): close out DEV bring-up session; log #80-#84, file #85/#86

### DIFF
--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -11,7 +11,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | seed-fixtures + loader | #60 | EXECUTION-ONLY | feat/s3-phase5-seed-fixtures | #68 | ✅ merged | 7 synthetic fixtures (exact mockup labels/KPIs) + `seed-advisor-cockpit.ps1` + tests; full suite 367 passed / 2 skipped |
 | advisorcockpit-pcf | #62 | DESIGN-SENSITIVE | feat/sprint-003-advisorcockpit-pcf | #70 | ✅ merged | local-first PCF (React18/Fluent v9): faithful layout, Meine Leads Liste/Board/Cockpit, brand-kit tokens, data-source provenance (tint + legend, no badges), UX rubric v1.1 + scorecard; tsc clean, 24/24 vitest |
 | salesleaderdashboard-pcf | #63 | DESIGN-SENSITIVE | feat/sprint-003-salesleaderdashboard-pcf | #74 | ✅ merged | local-first PCF (React18/Fluent v9 + Recharts): Führungsdashboard — scorecard KPIs + forecast confidence band + radar + product/region bars + funnel + GA benchmark; data-mapped to measures.json + provenance (measure vs not-yet-mapped) + DATA-BOM/rubric scorecard; tsc clean, 8/8 vitest |
-| foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | 🔜 in review | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; 210 foundation tests green. DEV/TEST authored by the CD pipeline on merge |
+| foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | ✅ merged | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; authored in DEV by the CD pipeline (2026-08-12) |
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | — | ⏳ DEV-gated | slices 1–5 (mobiliar-data-model-extension) |
 | cockpit-tables | #58 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | crmshow_nextbestaction + provenance |
 | seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | — | — | ⏳ DEV-gated | task 5.3; needs the tables to exist for smoke |
@@ -46,3 +46,34 @@ Live status for the Advisor Cockpit (charter **#55**). See the
   a DATA-BOM and PCF Review rubric v1.1 scorecard. `tsc` clean, 8/8 vitest.
   Honest gap surfaced: several figures (radar/funnel/backlog/peer-GAs) are
   illustrative and **not yet in the Measure contract** — flagged in-UI + filed.
+
+- **2026-08-12 (DEV bring-up)** - #75 (#56 foundation-choices) **merged**; the
+  5 cockpit choices are authored in DEV by the CD pipeline. A full DEV bring-up
+  push then exposed and cleared a chain of latent, never-before-run bugs:
+  - **#80** root-role detection (self-referencing root-BU roles) - merged.
+  - **#82** stop localizing security-role name/description (`SetLocLabels` is
+    unsupported on the `role` entity) - merged.
+  - **#83** `cd-bootstrap-roles.yml`: dispatch-only workflow to reconcile the
+    reviewed roles on Ubuntu (local Windows `az.cmd` mangles parenthesised
+    metadata URLs) - merged. Human granted **System Administrator** to the CI
+    application user (role/metadata authoring needs it).
+  - **#84** platform-baseline privileges out of role-contract scope (the
+    SharePoint doc-management auto-grant is inert + unremovable; **ADR-0029**) -
+    merged. Security roles now **bootstrap and verify Ready** in DEV.
+  - **#81** corrected a bogus dependabot bump (`vite@^8.2.1` does not exist +
+    `@vitejs/plugin-react@4`) in **both** PCF controls - merged. The
+    **AdvisorCockpit local harness runs** at http://localhost:5173/ (vite 8.2.0).
+  - CD-DEV now authors **everything** (5 choices + 3 tables + keys + views +
+    forms + roles). Two items remain before the DEV/TEST evidence artifacts,
+    both filed:
+    - **#86** - the publisher must enforce `Delete=Restrict` on the Customer
+      (`crmshow_partyid`) relationships (Dataverse creates them `RemoveLink`).
+      Feasibility proven; both DEV relationships manually set to `Restrict`
+      (correct now); the publisher code fix (fresh-org reproducibility) follows.
+    - **#85** - CD-DEV *convergence* self-check 500s in CI on one
+      attribute-metadata query that works everywhere locally; needs one
+      instrumented run to capture the exact URL/status, then a targeted fix
+      (and/or retry-hardening). DEV is otherwise fully provisioned.
+  - Also open: **PCF multi-language i18n** (Phase 9 - both controls are
+    German-only, no resx / `context.userSettings`); and a note that the local
+    `main` working copy drifted behind `origin/main` during the session.


### PR DESCRIPTION
## What

Session close-out for the Sprint-003 DEV bring-up. Updates the sprint status board only (docs).

- Marks **#56/#75** (foundation-choices) **merged**.
- Adds a **2026-08-12 DEV bring-up** run-log entry capturing the chain of latent bugs cleared today (**#80/#81/#82/#83/#84** + System Administrator grant on the CI app user) and the current state: security roles bootstrap+verify **Ready** in DEV, CD-DEV authors all schema, AdvisorCockpit local harness runs.
- Records the **two remaining blockers** before the DEV/TEST evidence artifacts, both filed as issues:
  - **#85** - CD-DEV convergence self-check 500s in CI on an attribute-metadata query that works locally.
  - **#86** - publisher must enforce `Delete=Restrict` on the Customer relationships (DEV already manually corrected).

## Why

Clean handoff for tomorrow's restart. No code/behaviour change - documentation only.

## Traceability

- Sprint: **#55** (Advisor Cockpit)
- Closes-out session; opens **#85**, **#86** as the next actions.

## Evidence

Docs-only change; no CI-affecting code. Sprint status board updated.