### PR TITLE
fix(convergence): brace ${typeName} in typed metadata URL (fixes #85)

### DIFF
--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -694,9 +694,12 @@ function Get-ConvergenceTypedAttributePath {
 
     $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
     $escapedAttributeName = ConvertTo-ODataKeyString ([string]$Column.logicalName)
+    # Brace ${typeName}: '?' is a valid PowerShell variable-name character, so the
+    # unbraced "$typeName?" parses as the (undefined) variable $typeName? and the
+    # cast type name plus the '?' both vanish, yielding a malformed metadata URL.
     return (
         "/EntityDefinitions(LogicalName='$escapedTableName')/Attributes/" +
-        "Microsoft.Dynamics.CRM.$typeName?" +
+        "Microsoft.Dynamics.CRM.${typeName}?" +
         "`$select=MetadataId,LogicalName,SchemaName,AttributeType," +
         "DisplayName,Description,RequiredLevel,IsAuditEnabled,$derivedProperties&" +
         "`$filter=LogicalName eq '$escapedAttributeName'"

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -1433,6 +1433,39 @@ Describe 'Convergence path builders' {
                 "`$filter=startswith(name,'CRM Showcase Insurance ')"
             )
     }
+
+    It 'emits a Microsoft.Dynamics.CRM cast type for every typed attribute' {
+        # Regression guard: '?' is a valid PowerShell variable-name character, so
+        # an unbraced "$typeName?" swallows both the cast type and the '?', which
+        # produced a malformed metadata URL and a Dataverse 500 in CD-DEV.
+        $expectedTypes = @{
+            Text     = 'StringAttributeMetadata'
+            DateOnly = 'DateTimeAttributeMetadata'
+            DateTime = 'DateTimeAttributeMetadata'
+            Lookup   = 'LookupAttributeMetadata'
+            Customer = 'LookupAttributeMetadata'
+        }
+        $expectedDerived = @{
+            Text     = 'MaxLength'
+            DateOnly = 'Format,DateTimeBehavior'
+            DateTime = 'Format,DateTimeBehavior'
+            Lookup   = 'Targets'
+            Customer = 'Targets'
+        }
+
+        foreach ($type in $expectedTypes.Keys) {
+            $column = [pscustomobject]@{ type = $type; logicalName = 'crmshow_probe' }
+            Get-ConvergenceTypedAttributePath `
+                -TableLogicalName 'crmshow_accountcontactrole' `
+                -Column $column | Should -Be (
+                    "/EntityDefinitions(LogicalName='crmshow_accountcontactrole')/Attributes/" +
+                    "Microsoft.Dynamics.CRM.$($expectedTypes[$type])?" +
+                    "`$select=MetadataId,LogicalName,SchemaName,AttributeType," +
+                    "DisplayName,Description,RequiredLevel,IsAuditEnabled,$($expectedDerived[$type])&" +
+                    "`$filter=LogicalName eq 'crmshow_probe'"
+                )
+        }
+    }
 }
 
 Describe 'Convergence fixture paths' {


### PR DESCRIPTION
## What

Fixes **#85** — the CD-DEV `Validate complete demo convergence` gate 500s in CI.

`Get-ConvergenceTypedAttributePath` built the attribute-metadata URL with an **unbraced** `"Microsoft.Dynamics.CRM.$typeName?"`. `?` is a valid PowerShell variable-name character, so this parsed as the **undefined** variable `$typeName?` and dropped **both** the cast type name and the `?`, yielding a malformed cast segment:

```
/EntityDefinitions(LogicalName='crmshow_accountcontactrole')/Attributes/Microsoft.Dynamics.CRM.$select=MetadataId,...,Targets&$filter=LogicalName eq 'crmshow_accountid'
```

Dataverse answers a malformed cast with a **500 HTML page** (not a clean OData error) — exactly the failure signature. It hit **every typed column** (Text/DateOnly/DateTime/Lookup/Customer); `GlobalChoice` was unaffected because its cast is a literal string.

## Fix

- Brace the variable: `Microsoft.Dynamics.CRM.${typeName}?`.
- Add a regression test asserting the full `Microsoft.Dynamics.CRM.<Type>?$select` cast for each typed column type (reproduces + guards the swallow).

## Why the earlier read missed it

The prior local check **hardcoded** `LookupAttributeMetadata?` in the URL instead of calling the builder, so it validated the endpoint but never exercised the defect.

## Evidence

- Reproduced locally against the real contract: before = type name and `?` missing on all typed columns; after = all typed URLs correct and **identical to the DEV-verified queries** (`Microsoft.Dynamics.CRM.LookupAttributeMetadata?$select=...`).
- Convergence Pester suite: **52/52** green (incl. the new regression test).

## Traceability

- Sprint: **#55** · Fixes **#85**
- Next after merge: dispatch CD-DEV to confirm the convergence gate passes, then #86 (Customer-cascade publisher fix) then the DEV/TEST evidence artifacts.