### PR TITLE
fix(convergence): select rootsolutioncomponentid (not lookup _value) in reverse inventory

### DIFF
--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -601,8 +601,11 @@ function Get-ConvergenceSolutionInventoryPath {
             "componenttype eq $([int]$_)"
         }) -join ' or '
 
+    # rootsolutioncomponentid is a Uniqueidentifier (not a lookup), so it is selected
+    # directly; the lookup-style _rootsolutioncomponentid_value property does not exist
+    # on solutioncomponent and makes the whole request 400. solutionid IS a lookup.
     return (
-        "/solutioncomponents?`$select=solutioncomponentid,objectid,componenttype,rootcomponentbehavior,_rootsolutioncomponentid_value&" +
+        "/solutioncomponents?`$select=solutioncomponentid,objectid,componenttype,rootcomponentbehavior,rootsolutioncomponentid&" +
         "`$filter=_solutionid_value eq $resolvedSolutionId and ($typeFilter)"
     )
 }

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -573,7 +573,7 @@ BeforeAll {
             objectid                     = $resolvedObjectId
             componenttype                = [int]$ComponentType
             rootcomponentbehavior        = $RootComponentBehavior
-            _rootsolutioncomponentid_value = $resolvedRootSolutionComponentId
+            rootsolutioncomponentid      = $resolvedRootSolutionComponentId
         }
     }
 
@@ -1401,7 +1401,7 @@ Describe 'Convergence path builders' {
         Get-ConvergenceSolutionInventoryPath `
             -SolutionId '{11111111-1111-1111-1111-111111111111}' `
             -ComponentType @(60, 1, 9, 26, 1) | Should -Be (
-                "/solutioncomponents?`$select=solutioncomponentid,objectid,componenttype,rootcomponentbehavior,_rootsolutioncomponentid_value&" +
+                "/solutioncomponents?`$select=solutioncomponentid,objectid,componenttype,rootcomponentbehavior,rootsolutioncomponentid&" +
                 "`$filter=_solutionid_value eq 11111111-1111-1111-1111-111111111111 and (componenttype eq 1 or componenttype eq 9 or componenttype eq 26 or componenttype eq 60)"
             )
 


### PR DESCRIPTION
## What

Second convergence fix, surfaced by CD-DEV run 31640981375 (from `main`, after #88 merged). The `${typeName}` fix (#88) cleared the attribute-metadata 500, and convergence then progressed to the **reverse-inventory** read, which 400'd:

```
Dataverse convergence transport failed (GET /solutioncomponents?$select=...,_rootsolutioncomponentid_value&$filter=_solutionid_value eq ...)
"Could not find a property named '_rootsolutioncomponentid_value' on type 'Microsoft.Dynamics.CRM.solutioncomponent'."
```

## Root cause

On `solutioncomponent`, `rootsolutioncomponentid` is a **Uniqueidentifier**, not a lookup — verified against DEV metadata:

```
rootsolutioncomponentid  [Uniqueidentifier]  schema=RootSolutionComponentId
solutionid               [Lookup]            schema=SolutionId
```

The `_<name>_value` navigation form only exists for **lookup** attributes, so `_rootsolutioncomponentid_value` does not exist and 400s the whole request. (`solutionid` IS a lookup, so the `_solutionid_value` **filter** is correct and unchanged.)

This was a second latent bug, masked until #88 let convergence get past the attribute-metadata queries.

## Fix

- `Get-ConvergenceSolutionInventoryPath`: `$select` uses `rootsolutioncomponentid` directly.
- The consumer `Get-ConvergenceRootSolutionComponentInventoryId` already read both property shapes, so no production consumer change was needed.
- Test fixture + expectation updated to model the real response.

## Evidence

- Corrected query returns **200** against DEV (10 components).
- Reverse-inventory + path-builder Pester describes **22/22** green.

## Traceability

- Sprint: **#55** · Follow-on to **#85/#88**
- After merge: dispatch CD-DEV from `main` again to confirm the convergence gate passes end-to-end and emits the DEV evidence artifact.