### PR TITLE
fix(convergence): direct-navigation relationship inventory; drop unsupported metadata startswith (#90)

### DIFF
--- a/scripts/solution/Test-InsuranceFoundationConvergence.ps1
+++ b/scripts/solution/Test-InsuranceFoundationConvergence.ps1
@@ -789,17 +789,36 @@ function Get-ConvergenceTableUnexpectedChildrenPath {
     )
 
     $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
-    $escapedPrefix = ConvertTo-ODataKeyString $PublisherPrefix
 
+    # Metadata OData supports neither startswith nor derived-property selection
+    # inside $expand, so children are fetched unfiltered and the publisher prefix
+    # is applied client-side. Relationships are read separately via direct
+    # navigation (see Get-ConvergenceTableRelationshipsPath).
     return (
         "/EntityDefinitions(LogicalName='$escapedLogicalName')?" +
         "`$select=MetadataId,LogicalName,SchemaName,PrimaryIdAttribute&" +
         "`$expand=" +
-        "Attributes(`$select=LogicalName,SchemaName,AttributeType,AttributeOf;" +
-        "`$filter=startswith(LogicalName,'$escapedPrefix') or startswith(SchemaName,'$escapedPrefix'))," +
-        "ManyToOneRelationships(`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute;" +
-        "`$filter=startswith(SchemaName,'$escapedPrefix') or startswith(ReferencingAttribute,'$escapedPrefix'))," +
-        "Keys(`$select=SchemaName,KeyAttributes;`$filter=startswith(SchemaName,'$escapedPrefix'))"
+        "Attributes(`$select=LogicalName,SchemaName,AttributeType,AttributeOf)," +
+        "Keys(`$select=SchemaName,KeyAttributes)"
+    )
+}
+
+function Get-ConvergenceTableRelationshipsPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LogicalName
+    )
+
+    $escapedLogicalName = ConvertTo-ODataKeyString $LogicalName
+
+    # Direct navigation, not $expand: metadata OData cannot select the derived
+    # OneToManyRelationshipMetadata properties (ReferencingAttribute, ...) inside
+    # an $expand of a relationship collection. The publisher prefix is applied
+    # client-side by the caller.
+    return (
+        "/EntityDefinitions(LogicalName='$escapedLogicalName')/ManyToOneRelationships?" +
+        "`$select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute"
     )
 }
 
@@ -3438,12 +3457,17 @@ function Test-InsuranceFoundationUnexpectedMetadata {
 
     foreach ($tableLogicalName in @($expectedInventory.ReviewedTables)) {
         $tableInventory = $null
+        $tableRelationships = @()
         try {
             $tableInventory = Invoke-DataverseRequest `
                 -Method GET `
                 -Path (Get-ConvergenceTableUnexpectedChildrenPath `
                     -LogicalName $tableLogicalName `
                     -PublisherPrefix $publisherPrefix)
+            $tableRelationships = @((Invoke-DataverseRequest `
+                        -Method GET `
+                        -Path (Get-ConvergenceTableRelationshipsPath `
+                            -LogicalName $tableLogicalName)).value)
         }
         catch {
             if (Test-ConvergenceTransportError $_) {
@@ -3480,7 +3504,7 @@ function Test-InsuranceFoundationUnexpectedMetadata {
             }
         }
 
-        foreach ($relationship in @($tableInventory.ManyToOneRelationships |
+        foreach ($relationship in @($tableRelationships |
                     Sort-Object SchemaName, ReferencingAttribute)) {
             if (-not (Test-ConvergenceUnexpectedRelationshipCandidate `
                         -Relationship $relationship `

--- a/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
+++ b/scripts/solution/tests/Test-InsuranceFoundationConvergence.Tests.ps1
@@ -1004,6 +1004,22 @@ BeforeAll {
             if ($Method -cne 'GET') {
                 throw "Unexpected mocked method: $Method"
             }
+
+            if ($Path -match "^/EntityDefinitions\(LogicalName='([^']+)'\)/ManyToOneRelationships") {
+                $relTable = $matches[1]
+                $entityPrefix = "/EntityDefinitions(LogicalName='$relTable')?"
+                $entityKey = @($script:responseMap.Keys |
+                        Where-Object {
+                            $_.StartsWith($entityPrefix, [System.StringComparison]::Ordinal)
+                        }) | Select-Object -First 1
+                $relationships = @()
+                if ($null -ne $entityKey -and
+                    $null -ne $script:responseMap[$entityKey].ManyToOneRelationships) {
+                    $relationships = @($script:responseMap[$entityKey].ManyToOneRelationships)
+                }
+                return [pscustomobject]@{ value = @($relationships) }
+            }
+
             if (-not $script:responseMap.ContainsKey($Path)) {
                 throw "Unexpected mocked path: $Path"
             }
@@ -1100,6 +1116,22 @@ if ($env:TEST_INSURANCE_CONVERGENCE_SCENARIO -eq 'RetrieveLocLabelsUnsupported' 
 }
 
 $map = Get-Content -LiteralPath '__MAP__' -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+
+if ($path -match "^/EntityDefinitions\(LogicalName='([^']+)'\)/ManyToOneRelationships") {
+    $relTable = $matches[1]
+    $entityPrefix = "/EntityDefinitions(LogicalName='$relTable')?"
+    $entityProperty = $map.PSObject.Properties |
+        Where-Object { $_.Name.StartsWith($entityPrefix, [System.StringComparison]::Ordinal) } |
+        Select-Object -First 1
+    $relationships = @()
+    if ($null -ne $entityProperty -and
+        $null -ne $entityProperty.Value.ManyToOneRelationships) {
+        $relationships = @($entityProperty.Value.ManyToOneRelationships)
+    }
+    Write-Json ([pscustomobject]@{ value = @($relationships) })
+    exit 0
+}
+
 $property = $map.PSObject.Properties[$path]
 if ($null -eq $property) {
     Write-Error "Unexpected az rest URL: $url"


### PR DESCRIPTION
## What

Third and largest fix in the convergence live-metadata chain (after #85/#88 and #89), addressing **#90**. With this, the CD-DEV `Validate complete demo convergence` gate **runs fully end-to-end against live Dataverse** for the first time.

## Root cause

The reverse-inventory query embedded relationships in `$expand`:
```
ManyToOneRelationships($select=SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute;$filter=startswith(...))
```
Verified against live DEV, metadata OData rejects this three ways:
- `ReferencingAttribute` is on the derived `OneToManyRelationshipMetadata`, not the base `RelationshipMetadataBase` the nav is typed as -> `0x80060888 Could not find a property...`
- casting the segment inside `$expand` -> `NavigationPropertySegment ... not supported`
- `startswith` on **any** metadata collection (relationships, Attributes, Keys) -> `The "startswith" function isn't supported for Metadata Entities.`

## Fix

- `Get-ConvergenceTableUnexpectedChildrenPath`: drop the `startswith` `$filter`s (the consumer already prefix-filters **every** candidate client-side via `Test-ConvergenceUnexpected*Candidate`, so they were redundant) and remove the `ManyToOneRelationships` `$expand`.
- New `Get-ConvergenceTableRelationshipsPath`: **direct navigation** `/EntityDefinitions(LogicalName='X')/ManyToOneRelationships?$select=...` — verified to resolve the derived properties (returns 200). Consumer fetches it and prefix-filters client-side.
- Both test transports (Pester `Mock` + `az.ps1` shim) synthesize the direct-navigation response from the entity mock's relationships — no per-fixture churn.

## How verified

A read-only local probe (dot-source the gate against DEV with an `Invoke-RestMethod` transport override) drove the gate to completion. Before: 400 here. After: the gate runs the **entire** GET-only flow and returns a classification. Convergence Pester suite **52/52**.

## Honest follow-up (not a transport bug)

Post-fix, the gate reaches the per-child contract checks and reports `ContractConflict` on some columns/views/forms. My **local probe does not run authoring first**, whereas the pipeline authors (`Reconcile demo-safe metadata`) **before** convergence. The flagged views/forms exist in DEV, so these are label/content diffs the author-first step should reconcile. True `Ready` confirmation = run CD-DEV from `main` after merge (author -> converge). If any child conflict survives authoring, it is a separate, real drift to file — not part of this transport fix.

## Traceability

- Sprint: **#55** · Addresses **#90** (follow-on to #85/#88, #89)
- Next: merge -> dispatch CD-DEV from `main` -> confirm gate `Ready` + DEV evidence artifact.