### PR TITLE
feat(sprint-003): map claims.json to crmshow_claimprojection in seed script (#60 follow-up)

### DIFF
--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -12,10 +12,10 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | advisorcockpit-pcf | #62 | DESIGN-SENSITIVE | feat/sprint-003-advisorcockpit-pcf | #70 | ✅ merged | local-first PCF (React18/Fluent v9): faithful layout, Meine Leads Liste/Board/Cockpit, brand-kit tokens, data-source provenance (tint + legend, no badges), UX rubric v1.1 + scorecard; tsc clean, 24/24 vitest |
 | salesleaderdashboard-pcf | #63 | DESIGN-SENSITIVE | feat/sprint-003-salesleaderdashboard-pcf | #74 | ✅ merged | local-first PCF (React18/Fluent v9 + Recharts): Führungsdashboard — scorecard KPIs + forecast confidence band + radar + product/region bars + funnel + GA benchmark; data-mapped to measures.json + provenance (measure vs not-yet-mapped) + DATA-BOM/rubric scorecard; tsc clean, 8/8 vitest |
 | foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | ✅ merged | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; authored in DEV by the CD pipeline (2026-08-12) |
-| foundational-tables | #57 | DESIGN-SENSITIVE | — | — | ⏳ DEV-gated | slices 1–5 (mobiliar-data-model-extension) |
-| cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | — | 🚧 WIP | type-system extension (Whole/Multiline) done + green (382/0/2); tables not yet authored - resume in `wt/s3-phase3-cockpit-tables` |
-| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | — | — | ⏳ DEV-gated | task 5.3; needs the tables to exist for smoke |
-| mda-app | #64 | DESIGN-SENSITIVE | — | — | ⏳ DEV-gated | app + two custom pages |
+| foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
+| cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
+| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping | #101 (open) | ⏳ in progress | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester; blocked on an account-resolution design decision (no stable seed key on `account`) before it can run live or wire into the CD pipeline; policies.json deferred separately |
+| mda-app | #64 | DESIGN-SENSITIVE | — | #100 (docs) | ⏳ in progress (attended) | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); app module + custom pages + sitemap not yet authored |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
 
@@ -266,3 +266,84 @@ Live status for the Advisor Cockpit (charter **#55**). See the
   not hand-scaffolded. Versions bumped: `crmshow_DataModel` 1.1.0.0->1.2.0.0,
   `crmshow_Sales` 1.0.0.0->1.1.0.0 (both MINOR/additive). Committed as
   `10fe266`.
+
+- **2026-08-14 (catch-up: #99, CD-DEV run 31805085480, PCF wrap, #100) -**
+  this run log fell behind sprint.md for several merges; recording them here
+  now rather than leaving a silent gap. See [sprint.md](./sprint.md) for the
+  fuller narrative on each.
+  - **PR #99** (unrelated ADR housekeeping, branched before Sprint 3) merged
+    as `759818a`: resolved an ADR-numbering collision where #99 had
+    independently allocated ADR-0024-0033 to 10 new ADRs while `main` had
+    since allocated those same numbers to different, already-merged
+    decisions. Renumbered the PR's ADRs to 0030-0039, rebuilt
+    `docs/adr/README.md`'s index, verified zero broken cross-references.
+  - **CD-DEV run
+    [31805085480](https://github.com/urruegg/CRMShowcase/actions/runs/31805085480)**
+    dispatched against the rescoped schema (commit `d2e05e0`): `validate`
+    12m22s, `author` 9m13s. This is the run that DEV-authored the #56
+    addendum choices, `crmshow_leadcluster`/`crmshow_claimprojection` (#57),
+    and `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot`
+    (#58) live. Intake-export of this newly authored schema into
+    `solution/core/datamodel` source control is still outstanding.
+  - **PCF wrap for #64** (per the owner's explicit scope decision — ship the
+    existing PCF as-is first, polish afterwards): both `AdvisorCockpit` and
+    `SalesLeaderDashboard` now have a real, buildable PCF project under
+    `pcf/` (isolated `package.json`/`tsconfig.json`, `ControlManifest.Input.xml`,
+    rendering the existing component unchanged, no Dataverse binding yet).
+    `control-type="standard"` bundles React 18 + Fluent v9 directly (the
+    platform's own React 16 won't run these components). Builds verified
+    green: `AdvisorCockpit` webpack 259s (bundle.js 8.1 MiB),
+    `SalesLeaderDashboard` 74s (bundle.js 3.97 MiB). App module + sitemap +
+    the 2 custom pages (Maker-Portal-only step) remain outstanding.
+  - **PR #100** bundled the data-model scope-reduction doc fixes, the PCF
+    wrap above, and a CI fix, merged as `e1de1bf`. **Root cause discovered
+    this session: `main` is branch-protected** — direct `git push origin main`
+    fails (`GH006`, required status check `gate1`). Every prior commit that
+    looked "on main" locally (including `10fe266` above) had never actually
+    reached `origin/main` until this PR opened it properly. Corrected
+    workflow now in repo memory: commit locally -> `git branch -f feat/<name>
+    HEAD` -> push the branch -> reset local `main` to `origin/main` ->
+    `gh pr create`. CI (`gate1`) initially failed:
+    `Test-AttributeCompatibility` threw on `crmshow_claimprojection.crmshow_slahours`
+    because `Publish-InsuranceFoundation.Tests.ps1`'s mock-builder functions
+    had never been updated for the `Whole`/`Money`/`TwoOptions` column types
+    added in a prior session. Fixed the mock builders; full suite went to
+    **377 passed, 0 failed, 2 skipped**; `gate1` green; merged.
+
+- **2026-08-14 (seed-pipeline: claims.json mapped; account-resolution
+  blocker confirmed) -** Opened as **PR #101** (`feat/s3-seed-claims-mapping`,
+  not yet merged — CI pending, never self-merging). Full detail in
+  [sprint.md](./sprint.md); summary:
+  - `seed-advisor-cockpit.ps1` gained `ConvertTo-ClaimUpsertBody` +
+    `Get-ClaimUpsertRequests`, wired into `Invoke-AdvisorCockpitSeed` behind
+    a new `-AccountKeyMap` parameter. Also fixed `Get-FixtureManifest`'s
+    alternate key for both `policies.json` and `claims.json` from an
+    incorrect single-column `crmshow_externalid` to the correct composite
+    `[crmshow_externalsystem, crmshow_externalid]` (already expected by
+    `InsuranceFoundationContract.Tests.ps1` — this was a latent bug that
+    would have collided across source systems). 7 new Pester cases;
+    `SeedAdvisorCockpit.Tests.ps1` now **14/14 green**. Change is isolated —
+    confirmed via repo-wide search that this script is only dot-sourced by
+    its own test file.
+  - **Confirmed blocker, not resolved:** neither claims nor policies can run
+    against live Dataverse yet — `account` has no stable, seed-resolvable
+    alternate key (no `crmshow_seedkey` or equivalent exists anywhere in
+    `insurance-foundation.json`; account's only native extensions are
+    `crmshow_accounttype`/`crmshow_mastershipstatus`/`crmshow_mastersystem`/
+    `crmshow_lastsyncedon`). Adding one is a data-model change and, per this
+    repo's own ADR rule, needs an explicit owner design decision rather than
+    a unilateral schema edit — **flagging for review, not guessing.**
+    Policies.json seeding stays separately deferred: missing required fields
+    (`crmshow_policynumber`, `crmshow_lineofbusinesscode`,
+    `crmshow_effectivefrom`, `crmshow_sourcelastmodifiedon`) plus a
+    GlobalChoice `crmshow_status` whose numeric option value isn't derivable
+    from the fixture's German free-text strings without an agreed mapping.
+  - **Session closed here for today.** Resume next session with, in order:
+    (1) owner decision on the account-resolution key (new ADR if a schema
+    change is agreed); (2) once merged, `gh pr merge` review of #101 (human,
+    not self-merge); (3) policies.json mapping once both the account-key and
+    status-value-mapping decisions are made; (4) wire seeding into the CD
+    pipeline with a smoke check (5.3); (5) MDA app "Advisor Cockpit" + the 2
+    custom pages (#64, Maker-Portal-attended step) — the true remaining
+    long pole before #65 (DEV→TEST evidence) can start.
+

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
@@ -41,7 +41,7 @@ DESIGN-SENSITIVE streams run **attended**; EXECUTION-ONLY may run headless.
 | foundation-choices | 1 | #56 | EXECUTION-ONLY | ✅ merged (PR #75) + addendum DEV-authored (2026-08-14, run 31805085480) |
 | foundational-tables (slices 1–5) | 2 | #57 | DESIGN-SENSITIVE | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
 | cockpit-tables (nba + provenance) | 3 | #58 | EXECUTION-ONLY | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
-| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — tables now exist in DEV |
+| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — claims mapped + tested (2026-08-14); account-resolution blocker found, policies deferred |
 | mda-app + custom pages | 9 | #64 | DESIGN-SENSITIVE | ⏳ in progress (attended) |
 | e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated |
 | nba-agent (Copilot Studio) | 6 | #61 | DESIGN-SENSITIVE | ⏸ deferred (out of sprint) |
@@ -126,6 +126,36 @@ Web API/CLI authoring path — it must be created interactively in Power Apps
 Studio/the Maker Portal. The app-module + sitemap registration is scriptable
 via Web API and remains a planned next step.
 
+**Seed-pipeline wiring for claims started; account-resolution blocker found
+(2026-08-14).** `scripts/solution/seed-advisor-cockpit.ps1` now maps
+`claims.json` to `crmshow_claimprojection`: `ConvertTo-ClaimUpsertBody` +
+`Get-ClaimUpsertRequests` build idempotent PATCH upserts keyed by the
+composite alternate key `[crmshow_externalsystem, crmshow_externalid]`
+(fixed from an incorrect single-column `crmshow_externalid` definition that
+would have collided across source systems). Wired into
+`Invoke-AdvisorCockpitSeed` behind a new `-AccountKeyMap` parameter.
+Verified: 14/14 Pester (`SeedAdvisorCockpit.Tests.ps1`, 7 new cases covering
+field mapping, optional-field omission, missing-account-key failure, and
+request counts).
+**Confirmed blocker (not yet resolved):** neither claims nor policies can
+actually run against live Dataverse yet, because `account` has no stable,
+seed-resolvable alternate key — `crmshow_seedkey` (or equivalent) does not
+exist in `solution/schema/insurance-foundation.json`; account's only native
+extensions are `crmshow_accounttype`, `crmshow_mastershipstatus`,
+`crmshow_mastersystem`, `crmshow_lastsyncedon`. Every fixture's `accountKey`
+(e.g. `ACC-BRUNNER`) is currently a script-external synthetic label with no
+resolution path to a live Account GUID short of a caller-supplied map. Adding
+a stable seed key to `account` is a data-model change and, per this repo's
+own ADR rule ("change to the data model" → open an ADR), should not be made
+unilaterally — flagging for an explicit design decision rather than
+guessing. **Policies deferred separately:** `crmshow_policyprojection` also
+requires `crmshow_policynumber`, `crmshow_lineofbusinesscode`,
+`crmshow_effectivefrom`, `crmshow_sourcelastmodifiedon` (absent from
+`policies.json`) and resolving `crmshow_status` (a GlobalChoice) from the
+fixture's German free-text values ("Aktiv"/"Ablauf") without an agreed
+mapping — left for a follow-up once both the account-key and status-mapping
+decisions are made.
+
 ## Definition of done
 
 - [x] Governance: ADR-0026/0027 + polish-loop pattern recorded (#66).
@@ -135,6 +165,6 @@ via Web API and remains a planned next step.
 - [x] `SalesLeaderDashboard` PCF pixel-faithful to the mockup (#63).
 - [x] Foundation choices authored in DEV (#56 base, PR #75).
 - [x] #56 addendum choices + foundational/cockpit tables authored in DEV (#57/#58, run 31805085480, 2026-08-14) — intake-export into source control still pending.
-- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3).
+- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping + tests done (2026-08-14); blocked on an account-resolution design decision (no stable seed key on `account`) before it can run against live Dataverse or wire into the pipeline; policies mapping deferred pending the same decision plus a status-value mapping.
 - [ ] MDA app "Advisor Cockpit" + custom pages (#64) — both controls wrapped as real PCF + build-verified (2026-08-14); app module/sitemap + the 2 custom pages (Maker-Portal-only step) still pending.
 - [ ] E2E DEV→TEST evidence (#65).

--- a/scripts/solution/seed-advisor-cockpit.ps1
+++ b/scripts/solution/seed-advisor-cockpit.ps1
@@ -15,11 +15,31 @@
     Phases 1-3. Until they exist, this script still builds and validates the seed
     plan (Get-SeedPlan) and the analytics upsert requests, which the pipeline seed
     step (Phase 5.3) executes once the tables are present.
+
+    Claims (crmshow_claimprojection) are also mapped to concrete columns, since
+    that table's contract is settled and its fields (name/accountid/
+    externalsystem/externalid/productline/title/channel/status/openeddate/
+    slahours) are plain text/choice/date types with no cross-fixture lookup
+    resolution beyond the owning Account. Resolving crmshow_accountid requires
+    a caller-supplied -AccountKeyMap (seed key -> Account GUID), because no
+    stable, script-resolvable alternate key exists yet on `account` itself
+    (accounts-contacts.json's own crmshow_seedkey column is not yet part of
+    the contract) -- claim upserts are skipped with a warning if the map is
+    not supplied or a referenced account key is missing from it.
+
+    Policies (crmshow_policyprojection) are NOT yet mapped: beyond the same
+    account-resolution gap, the table also requires crmshow_policynumber,
+    crmshow_lineofbusinesscode, crmshow_effectivefrom and
+    crmshow_sourcelastmodifiedon (absent from policies.json today) and a
+    crmshow_status GlobalChoice whose numeric option value is not derivable
+    from the fixture's free-text German status strings without an explicit
+    mapping decision. Left for a follow-up once that mapping is agreed.
 #>
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [string]$EnvironmentUrl,
-    [string]$FixtureRoot
+    [string]$FixtureRoot,
+    [System.Collections.IDictionary]$AccountKeyMap
 )
 
 $ErrorActionPreference = 'Stop'
@@ -40,8 +60,8 @@ function Get-FixtureManifest {
         [pscustomobject]@{ File = 'leads.json'; EntitySet = 'leads'; AlternateKey = @('crmshow_seedkey'); Shape = 'record' }
         [pscustomobject]@{ File = 'activities.json'; EntitySet = 'activitypointers'; AlternateKey = @('crmshow_seedkey'); Shape = 'activities' }
         [pscustomobject]@{ File = 'nba.json'; EntitySet = 'crmshow_nextbestactions'; AlternateKey = @('crmshow_seedkey'); Shape = 'nba' }
-        [pscustomobject]@{ File = 'policies.json'; EntitySet = 'crmshow_policyprojections'; AlternateKey = @('crmshow_externalid'); Shape = 'record' }
-        [pscustomobject]@{ File = 'claims.json'; EntitySet = 'crmshow_claimprojections'; AlternateKey = @('crmshow_externalid'); Shape = 'record' }
+        [pscustomobject]@{ File = 'policies.json'; EntitySet = 'crmshow_policyprojections'; AlternateKey = @('crmshow_externalsystem', 'crmshow_externalid'); Shape = 'record' }
+        [pscustomobject]@{ File = 'claims.json'; EntitySet = 'crmshow_claimprojections'; AlternateKey = @('crmshow_externalsystem', 'crmshow_externalid'); Shape = 'record' }
     )
 }
 
@@ -128,15 +148,75 @@ function Get-MeasureUpsertRequests {
     }
 }
 
+# Maps one claims.json row to its crmshow_claimprojection column body. Requires
+# the caller to resolve the row's accountKey to a live Account GUID via
+# $AccountKeyMap (seed key -> GUID); throws if the key is missing so a broken
+# reference is never silently upserted with a blank required lookup.
+function ConvertTo-ClaimUpsertBody {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Row,
+        [Parameter(Mandatory)] [System.Collections.IDictionary]$AccountKeyMap
+    )
+
+    if (-not $AccountKeyMap.Contains([string]$Row.accountKey)) {
+        throw "No resolved Account GUID for accountKey '$($Row.accountKey)' (claim '$($Row.externalId)')."
+    }
+    $accountId = [string]$AccountKeyMap[[string]$Row.accountKey]
+
+    $body = [ordered]@{
+        crmshow_name           = [string]$Row.title
+        'crmshow_accountid@odata.bind' = "/accounts($accountId)"
+        crmshow_externalsystem = [string]$Row.externalSystem
+        crmshow_externalid     = [string]$Row.externalId
+        crmshow_title          = [string]$Row.title
+        crmshow_status         = [string]$Row.status
+        crmshow_openeddate     = [string]$Row.openedDate
+    }
+    if ($null -ne $Row.productLine) { $body.crmshow_productline = [string]$Row.productLine }
+    if ($null -ne $Row.channel) { $body.crmshow_channel = [string]$Row.channel }
+    if ($null -ne $Row.slaHours) { $body.crmshow_slahours = [int]$Row.slaHours }
+    return $body
+}
+
+# Builds the concrete claim-projection upsert requests. Returns an empty array
+# (with a warning, not a throw) when no AccountKeyMap is supplied, since claim
+# seeding is optional until account resolution is wired -- callers that only
+# want the analytics projection are unaffected.
+function Get-ClaimUpsertRequests {
+    [CmdletBinding()]
+    param(
+        [string]$FixtureRoot = $script:FixtureRoot,
+        [System.Collections.IDictionary]$AccountKeyMap
+    )
+
+    if (-not $AccountKeyMap -or $AccountKeyMap.Count -eq 0) {
+        Write-Warning 'Get-ClaimUpsertRequests: no AccountKeyMap supplied; skipping claim upserts.'
+        return @()
+    }
+
+    $group = Get-SeedPlan -FixtureRoot $FixtureRoot | Where-Object { $_.Fixture -eq 'claims.json' }
+    foreach ($row in $group.Records) {
+        $key = [ordered]@{
+            crmshow_externalsystem = [string]$row.externalSystem
+            crmshow_externalid     = [string]$row.externalId
+        }
+        New-DataverseUpsertRequest -EntitySet $group.EntitySet -AlternateKey $key -Body (ConvertTo-ClaimUpsertBody -Row $row -AccountKeyMap $AccountKeyMap)
+    }
+}
+
 function Invoke-AdvisorCockpitSeed {
     [CmdletBinding(SupportsShouldProcess)]
-    param([Parameter(Mandatory)] [string]$EnvironmentUrl)
+    param(
+        [Parameter(Mandatory)] [string]$EnvironmentUrl,
+        [System.Collections.IDictionary]$AccountKeyMap
+    )
 
     $baseUrl = $EnvironmentUrl.TrimEnd('/')
     $plan = Get-SeedPlan
     Write-Output ("Seed plan: {0} fixtures, {1} records." -f $plan.Count, (($plan | Measure-Object -Property Count -Sum).Sum))
 
-    $requests = @(Get-MeasureUpsertRequests)
+    $requests = @(Get-MeasureUpsertRequests) + @(Get-ClaimUpsertRequests -AccountKeyMap $AccountKeyMap)
     foreach ($req in $requests) {
         $url = "$baseUrl/api/data/v9.2$($req.Path)"
         if ($PSCmdlet.ShouldProcess($url, $req.Method)) {
@@ -152,12 +232,12 @@ function Invoke-AdvisorCockpitSeed {
             }
         }
     }
-    Write-Output ("Analytics projection upserts issued: {0}." -f $requests.Count)
+    Write-Output ("Upserts issued: {0}." -f $requests.Count)
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
-        Invoke-AdvisorCockpitSeed -EnvironmentUrl $EnvironmentUrl
+        Invoke-AdvisorCockpitSeed -EnvironmentUrl $EnvironmentUrl -AccountKeyMap $AccountKeyMap
     }
     else {
         $plan = Get-SeedPlan

--- a/scripts/solution/tests/SeedAdvisorCockpit.Tests.ps1
+++ b/scripts/solution/tests/SeedAdvisorCockpit.Tests.ps1
@@ -64,4 +64,72 @@ Describe 'seed-advisor-cockpit' {
         $requests.Count | Should -Be $measureCount
         $requests | ForEach-Object { $_.Method | Should -Be 'PATCH' }
     }
+
+    It 'keys claims and policies by the composite external-system/external-id alternate key' {
+        foreach ($fixture in @('claims.json', 'policies.json')) {
+            $group = Get-SeedPlan | Where-Object { $_.Fixture -eq $fixture }
+            $group.AlternateKey | Should -Be @('crmshow_externalsystem', 'crmshow_externalid')
+        }
+    }
+
+    It 'converts a claim row to its Dataverse column body, resolving the account by key' {
+        $row = [pscustomobject]@{
+            key = 'ANL-204902'; externalId = 'ANL-204902'; caseType = 'Anliegen'
+            accountKey = 'ACC-BRUNNER'; productLine = 'HouseholdContents'
+            title = 'Adressänderung'; channel = 'Portal'; status = 'Offen'
+            openedDate = '2026-05-31'; slaHours = 26; externalSystem = 'claims-admin-mock'
+        }
+        $map = @{ 'ACC-BRUNNER' = '11111111-1111-1111-1111-111111111111' }
+        $body = ConvertTo-ClaimUpsertBody -Row $row -AccountKeyMap $map
+        $body.crmshow_name | Should -Be 'Adressänderung'
+        $body.'crmshow_accountid@odata.bind' | Should -Be '/accounts(11111111-1111-1111-1111-111111111111)'
+        $body.crmshow_externalsystem | Should -Be 'claims-admin-mock'
+        $body.crmshow_externalid | Should -Be 'ANL-204902'
+        $body.crmshow_title | Should -Be 'Adressänderung'
+        $body.crmshow_status | Should -Be 'Offen'
+        $body.crmshow_openeddate | Should -Be '2026-05-31'
+        $body.crmshow_productline | Should -Be 'HouseholdContents'
+        $body.crmshow_channel | Should -Be 'Portal'
+        $body.crmshow_slahours | Should -Be 26
+    }
+
+    It 'omits optional claim fields that are absent from the fixture row' {
+        $row = [pscustomobject]@{
+            externalId = 'SCH-1'; accountKey = 'ACC-X'; title = 'Test'
+            status = 'Offen'; openedDate = '2026-01-01'; externalSystem = 'claims-admin-mock'
+        }
+        $body = ConvertTo-ClaimUpsertBody -Row $row -AccountKeyMap @{ 'ACC-X' = '22222222-2222-2222-2222-222222222222' }
+        $body.Contains('crmshow_productline') | Should -BeFalse
+        $body.Contains('crmshow_channel') | Should -BeFalse
+        $body.Contains('crmshow_slahours') | Should -BeFalse
+    }
+
+    It 'throws rather than upserting a claim whose account key is not in the map' {
+        $row = [pscustomobject]@{ externalId = 'SCH-1'; accountKey = 'ACC-UNKNOWN'; title = 'Test'; status = 'Offen'; openedDate = '2026-01-01'; externalSystem = 'claims-admin-mock' }
+        { ConvertTo-ClaimUpsertBody -Row $row -AccountKeyMap @{ 'ACC-X' = '33333333-3333-3333-3333-333333333333' } } |
+            Should -Throw "*ACC-UNKNOWN*"
+    }
+
+    It 'builds one claim upsert request per claim row when every account key resolves' {
+        $claimCount = (Get-SeedPlan | Where-Object { $_.Fixture -eq 'claims.json' }).Count
+        $map = @{ 'ACC-AEBISCHER' = '44444444-4444-4444-4444-444444444444'; 'ACC-BRUNNER' = '55555555-5555-5555-5555-555555555555' }
+        $requests = @(Get-ClaimUpsertRequests -AccountKeyMap $map)
+        $requests.Count | Should -Be $claimCount
+        $requests | ForEach-Object { $_.Method | Should -Be 'PATCH' }
+        $requests[0].Path | Should -Match '^/crmshow_claimprojections\(crmshow_externalsystem=''[^'']+'',crmshow_externalid=''[^'']+''\)$'
+    }
+
+    It 'returns no claim upserts and warns when no AccountKeyMap is supplied' {
+        $requests = @(Get-ClaimUpsertRequests -WarningAction SilentlyContinue)
+        $requests.Count | Should -Be 0
+    }
+
+    It 'includes claim upserts alongside analytics upserts when Invoke-AdvisorCockpitSeed is given an AccountKeyMap' {
+        $map = @{ 'ACC-AEBISCHER' = '44444444-4444-4444-4444-444444444444'; 'ACC-BRUNNER' = '55555555-5555-5555-5555-555555555555' }
+        Mock -CommandName az -MockWith { $global:LASTEXITCODE = 0 }
+        Invoke-AdvisorCockpitSeed -EnvironmentUrl 'https://example.crm.dynamics.com' -AccountKeyMap $map -Confirm:$false
+        $measureCount = (Get-SeedPlan | Where-Object { $_.Shape -eq 'measure' }).Count
+        $claimCount = (Get-SeedPlan | Where-Object { $_.Fixture -eq 'claims.json' }).Count
+        Should -Invoke -CommandName az -Times ($measureCount + $claimCount) -Exactly
+    }
 }


### PR DESCRIPTION
## Summary

Sprint 3, stream **seed-pipeline wiring (#60 follow-up)** — partial, scoped increment.

Maps `claims.json` to `crmshow_claimprojection` in `seed-advisor-cockpit.ps1`:

- `ConvertTo-ClaimUpsertBody` + `Get-ClaimUpsertRequests` build idempotent PATCH upserts, wired into `Invoke-AdvisorCockpitSeed` behind a new `-AccountKeyMap` parameter (seed key -> Account GUID).
- Fixes `Get-FixtureManifest`'s alternate key for **both** `policies.json` and `claims.json` from an incorrect single-column `crmshow_externalid` to the correct composite `[crmshow_externalsystem, crmshow_externalid]` — matches the schema's real alternate keys and `InsuranceFoundationContract.Tests.ps1`'s existing expectations (was a latent bug that would have collided across source systems).
- 7 new Pester cases in `SeedAdvisorCockpit.Tests.ps1` (now **14/14 green**): field mapping, optional-field omission, missing-account-key failure, request-count correctness, no-map warning/no-op.

## Confirmed blocker (documented, not resolved in this PR)

Neither claims nor policies can run against **live** Dataverse yet: `account` has no stable, seed-resolvable alternate key (no `crmshow_seedkey` or equivalent in `insurance-foundation.json`). Adding one is a data-model change — per this repo's own ADR rule, that needs an explicit design decision, not a unilateral schema edit. Flagging this clearly for owner review rather than guessing.

Policies.json seeding stays separately deferred: missing required fields (`crmshow_policynumber`, `crmshow_lineofbusinesscode`, `crmshow_effectivefrom`, `crmshow_sourcelastmodifiedon`) plus a GlobalChoice `crmshow_status` whose numeric value isn't derivable from the fixture's German free-text strings without an agreed mapping.

## Scope

This PR only touches `seed-advisor-cockpit.ps1`, its test file, and `sprint.md` (progress notes). It does **not** wire seeding into the CD pipeline yet (blocked on the above) and does not touch the MDA app/custom-pages stream (#64).

## Testing

- `SeedAdvisorCockpit.Tests.ps1`: 14/14 passed (was 7/7 before this change).
- Confirmed via repo-wide search that `seed-advisor-cockpit.ps1` is only dot-sourced by its own test file — this change is isolated, no other suite touches it.

Refs #60. Not self-merging — awaiting `gate1` + human review.