### PR TITLE
feat(sprint-003): add crmshow_seedkey on Account, completing PR #68's seed-loader assumption

### DIFF
--- a/docs/superpowers/specs/2026-08-14-advisor-cockpit-datamodel-scope-reduction-design.md
+++ b/docs/superpowers/specs/2026-08-14-advisor-cockpit-datamodel-scope-reduction-design.md
@@ -439,6 +439,56 @@ issues untouched.
   (`crmshow_mastershipstatus`, `crmshow_mastersystem`, `crmshow_lastsyncedon`)
   — see the new schema subsection and the ADR-0008 update.
 
+## Addendum: `crmshow_seedkey` on Account (2026-08-14, produced autonomously)
+
+While implementing claims seeding (#60 follow-up, PR #101), found that the
+seed loader's own fixture manifest (`Get-FixtureManifest` in
+`seed-advisor-cockpit.ps1`, merged in **PR #68**, EXECUTION-ONLY) has
+**always** declared `AlternateKey = @('crmshow_seedkey')` for
+`accounts-contacts.json` (and also `leads.json`) — but the field itself was
+never authored in `insurance-foundation.json`. This is a completion of an
+already-approved design intent, not a new decision, so it's implemented
+directly (additive, non-controversial) rather than added to "Open questions"
+below.
+
+- **Added:** `account.crmshow_seedkey` (Text, optional, maxLength 100,
+  `mastership: Configuration` — the same category already used for every
+  other natural/idempotency key in this contract, e.g.
+  `crmshow_policyprojectionexternalkey`'s columns). Metadata is explicit that
+  this is demo/seed-pipeline scaffolding only — never a production business
+  field, never shown on a form, never used in a business decision. Contract
+  version bumped `1.1.0` → `1.2.0` (additive).
+- **Scope deliberately kept narrow:** this unblocks resolving a claims/policy
+  fixture's `accountKey` (e.g. `"ACC-BRUNNER"`) to a live Account GUID via a
+  plain OData `$filter` query — sufficient for `seed-advisor-cockpit.ps1`'s
+  already-built `-AccountKeyMap` parameter (PR #101). It is **not** wired up
+  as a true Dataverse alternate key: this contract's `alternateKeys` array
+  (used for `crmshow_policyprojectionexternalkey` etc.) is a **custom-table
+  ­only** mechanism today — `nativeExtensions` (account/contact/lead/incident)
+  have no equivalent schema/pipeline support for declaring an alternate key
+  on a native table's own column. Building that is a separable, larger
+  pipeline capability, not required to unblock the confirmed problem, and is
+  **not** attempted here.
+- **Not resolved / explicitly out of scope this round:** the seed manifest
+  also references `crmshow_seedkey` on `lead` (native — same missing-pipeline
+  gap as account) and on `activitypointer` (native, and not even in this
+  contract's `table` enum for native extensions at all — `["account",
+  "contact", "lead", "incident"]`) and on the custom
+  `crmshow_nextbestaction` table (which, being custom, *could* get a real
+  alternate key today via the existing mechanism, but doing so wasn't needed
+  to unblock claims/policies and is left for whoever picks up `nba.json`
+  seeding). None of `accounts-contacts.json`/`leads.json`/`activities.json`/
+  `nba.json` seeding is implemented yet at all (only `Get-FixtureManifest`
+  declares their intended shape — no `Get-XUpsertRequests` builder exists for
+  any of them), so nothing here regresses a working capability.
+- **Still needed as a follow-up, not done here:** a `Get-AccountKeyMap`-style
+  resolver in `seed-advisor-cockpit.ps1` that queries
+  `GET /accounts?$select=accountid,crmshow_seedkey&$filter=crmshow_seedkey ne null`
+  and builds the hashtable PR #101's `-AccountKeyMap` parameter expects.
+  Deliberately not added in this PR to avoid touching the already-green,
+  already-reviewable `feat/s3-seed-claims-mapping` branch while it's pending
+  human merge.
+
 ## Open questions for the owner
 
 1. Resolve the premium vs. `excludedConcepts` conflict — narrow the exclusion

--- a/scripts/solution/tests/InsuranceFoundationContract.Tests.ps1
+++ b/scripts/solution/tests/InsuranceFoundationContract.Tests.ps1
@@ -255,7 +255,7 @@ Describe 'Insurance Foundation JSON contract' {
         @($contract.nativeExtensions.logicalName) |
             Should -Be @(
                 'crmshow_accounttype', 'crmshow_lifecyclestage',
-                'crmshow_mastershipstatus', 'crmshow_mastersystem', 'crmshow_lastsyncedon',
+                'crmshow_mastershipstatus', 'crmshow_mastersystem', 'crmshow_lastsyncedon', 'crmshow_seedkey',
                 'crmshow_mastershipstatus', 'crmshow_mastersystem', 'crmshow_lastsyncedon',
                 'crmshow_consentemail', 'crmshow_consentphone',
                 'crmshow_leadclusterid', 'crmshow_channel', 'crmshow_slalabel', 'crmshow_score', 'crmshow_leadqueuestatus',
@@ -265,6 +265,17 @@ Describe 'Insurance Foundation JSON contract' {
             Should -BeTrue
         ($contract.nativeExtensions | Where-Object logicalName -eq 'crmshow_lifecyclestage').required |
             Should -BeFalse
+    }
+
+    It 'defines crmshow_seedkey on account as an optional Text field for seed-pipeline resolution' {
+        $contract = Get-Contract
+        $seedKey = $contract.nativeExtensions | Where-Object logicalName -eq 'crmshow_seedkey'
+        $seedKey.table | Should -Be 'account'
+        $seedKey.type | Should -Be 'Text'
+        $seedKey.maxLength | Should -Be 100
+        $seedKey.required | Should -BeFalse
+        $seedKey.auditing | Should -BeTrue
+        $seedKey.metadata.mastership | Should -Be 'Configuration'
     }
 
     It 'resolves every choice reference and locks the exact choice mappings' {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1123,7 +1123,7 @@ Describe 'Insurance Foundation reconciliation' {
                 Should -Match '^<importexportxml><entities><entity>crmshow_[a-z]+</entity></entities></importexportxml>$'
         }
         @($created | Where-Object Path -match "EntityDefinitions\(LogicalName='(?:account|contact|lead|incident)'\)/Attributes").Count |
-            Should -Be 20
+            Should -Be 21
         @($created | Where-Object Path -match '/Keys$').Count | Should -Be 8
         @($created | Where-Object Path -eq '/workflows').Count | Should -Be 0
         @($created | Where-Object Path -eq '/systemforms').Count | Should -Be 8
@@ -1413,7 +1413,7 @@ Describe 'Insurance Foundation reconciliation' {
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and
             $_.Path -match "EntityDefinitions\(LogicalName='(?:account|contact|lead|incident)'\)/Attributes$"
-        }).Count | Should -Be 20
+        }).Count | Should -Be 21
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
         }).Count | Should -Be 8
@@ -1731,6 +1731,7 @@ Describe 'Insurance Foundation reconciliation' {
             '/GlobalOptionSetDefinitions','/GlobalOptionSetDefinitions',
             "/EntityDefinitions(LogicalName='account')/Attributes",
             "/EntityDefinitions(LogicalName='contact')/Attributes",
+            "/EntityDefinitions(LogicalName='account')/Attributes",
             "/EntityDefinitions(LogicalName='account')/Attributes",
             "/EntityDefinitions(LogicalName='account')/Attributes",
             "/EntityDefinitions(LogicalName='account')/Attributes",

--- a/solution/schema/insurance-foundation.json
+++ b/solution/schema/insurance-foundation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./insurance-foundation.schema.json",
   "contractId": "crmshow.insurance-foundation",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "languages": ["1033", "1031", "1036", "1040"],
   "solutions": ["crmshow_Foundation", "crmshow_DataModel"],
   "choices": [
@@ -433,6 +433,19 @@
           "1040":"Istante UTC dell'ultima sincronizzazione riuscita dei dati identificativi principali di questo account dal sistema master; vuoto finché gestito dal CRM."
         },
         "mastership":"SourceProjection","sensitivity":"Internal","permittedUse":"Technical integration freshness indicator on the standard form only.","lifecycle":"Updated on every successful sync from the master system."
+      }
+    },
+    {
+      "table":"account","logicalName":"crmshow_seedkey","schemaName":"crmshow_SeedKey","type":"Text","maxLength":100,"format":"Text","required":false,"auditing":true,"solution":"crmshow_DataModel",
+      "metadata":{
+        "label":{"1033":"Seed Key","1031":"Seed-Schlüssel","1036":"Clé de seed","1040":"Chiave di seed"},
+        "description":{
+          "1033":"Demo-only synthetic identifier letting the pipeline seed loader resolve this Account idempotently from fixture data; not a production business field, never shown on a form, and carries no meaning outside the showcase's own seed scripts.",
+          "1031":"Rein demobezogener synthetischer Bezeichner, der es dem Pipeline-Seed-Loader ermöglicht, dieses Konto anhand von Fixture-Daten idempotent aufzulösen; kein Geschäftsfeld, wird auf keinem Formular angezeigt und hat ausserhalb der Seed-Skripte des Showcases keine Bedeutung.",
+          "1036":"Identifiant synthétique réservé à la démonstration, permettant au chargeur de seed du pipeline de résoudre ce compte de façon idempotente à partir des données de fixture ; ce n'est pas un champ métier, jamais affiché sur un formulaire, et sans signification hors des scripts de seed de la démo.",
+          "1040":"Identificatore sintetico solo dimostrativo che consente al loader di seed della pipeline di risolvere questo account in modo idempotente a partire dai dati fixture; non è un campo di business, non viene mai mostrato su un modulo e non ha alcun significato al di fuori degli script di seed della demo."
+        },
+        "mastership":"Configuration","sensitivity":"Internal","permittedUse":"Dataverse seed-pipeline resolution only \u2014 not a production business field, never shown on a form or used in a business decision.","lifecycle":"Set once by the seed loader at demo-data creation; not maintained afterwards."
       }
     },
     {


### PR DESCRIPTION
## Summary

Sprint 3, data-model completion — resolves the account-resolution blocker flagged in PR #101's description.

While implementing claims seeding (#60 follow-up, PR #101), found that `seed-advisor-cockpit.ps1`'s `Get-FixtureManifest` (merged **PR #68**, EXECUTION-ONLY) has always declared `AlternateKey = @('crmshow_seedkey')` for `accounts-contacts.json` and `leads.json` — but `insurance-foundation.json` never authored that field. This is **completing an already-approved design intent**, not introducing a new one.

Adds `account.crmshow_seedkey` (Text, optional, maxLength 100, `mastership: Configuration` — the same category already used for every other natural/idempotency key in this contract). Metadata is explicit this is demo/seed-pipeline scaffolding only, never a production business field, never shown on a form. Contract version `1.1.0` → `1.2.0` (additive).

## Scope — deliberately narrow

This unblocks resolving a claim/policy fixture's `accountKey` (e.g. `"ACC-BRUNNER"`) to a live Account GUID via a plain OData `$filter` query — sufficient for PR #101's already-built `-AccountKeyMap` parameter.

**Does NOT:**
- Add a true Dataverse alternate key on the native `account` table. This contract's `alternateKeys` mechanism (used for `crmshow_policyprojectionexternalkey` etc.) is **custom-table-only** today — extending it to native tables (account/contact/lead/incident) is a separable, larger pipeline capability, not required to unblock the confirmed problem.
- Touch `seed-advisor-cockpit.ps1` itself (a `Get-AccountKeyMap`-style resolver is the natural next step, left as a follow-up so this PR doesn't touch the already-green, pending-review `feat/s3-seed-claims-mapping` branch).
- Resolve the same `crmshow_seedkey` gap on `lead`/`activitypointer` (native, same missing-pipeline-capability issue; `activitypointer` isn't even in this contract's native-extension `table` enum) or on `crmshow_nextbestaction` (custom, could get a real alternate key today, but not needed to unblock claims/policies). None of those fixtures' seeding is implemented yet at all (`accounts-contacts.json`/`leads.json`/`activities.json`/`nba.json` — only declared in the manifest, no upsert-builder functions exist), so nothing here regresses a working capability.

Full rationale in the design-doc addendum: [2026-08-14-advisor-cockpit-datamodel-scope-reduction-design.md](https://github.com/urruegg/CRMShowcase/blob/feat/s3-account-seedkey/docs/superpowers/specs/2026-08-14-advisor-cockpit-datamodel-scope-reduction-design.md).

## Governance note

This is a data-model change. Per [AGENTS.md](https://github.com/urruegg/CRMShowcase/blob/main/AGENTS.md) §Authority, "any change to... the data model core" needs Enterprise Architect approval and isn't a decision an agent makes alone — flagging explicitly for that review rather than treating this as routine. The change itself is additive/reversible/low-risk (new optional column, no removals), consistent with the existing `crmshow_mastersystem`/`crmshow_lastsyncedon` mastership pattern already on `account`.

## Testing

- Fixed 3 `Publish-InsuranceFoundation.Tests.ps1` assertions that hardcode the native-extension count against the real contract file (20 → 21 attribute-creation calls; deterministic mutation order list).
- `InsuranceFoundationContract.Tests.ps1`: **29/29 green** (added 1 new case asserting the field's exact shape).
- `Publish-InsuranceFoundation.Tests.ps1`: **104/104 green**.
- Did **not** run the ~640s `Test-InsuranceFoundationConvergence.Tests.ps1` locally — grep-verified it builds its expected native-extension list dynamically from the loaded contract (not hardcoded), so it should be unaffected. Relying on CI (`gate1`) to confirm before merge.

## Sequencing note

Complements PR #101 (open, unmerged) but is a **separate branch off `main`**, not built on top of it, to avoid touching that already-green PR mid-review. `sprint.md`/`STATUS.md` are intentionally **not** touched here — this branch predates PR #101's doc edits to those files, and editing them here risked a conflict. Will reconcile both docs in a small follow-up once merge order is known.

Refs #60. Not self-merging — awaiting `gate1` + Enterprise Architect / human review.