### PR TITLE
docs(sprint-003): fix self-contradicting 'resolver still pending' text (PR #103 merged)

### DIFF
--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -14,7 +14,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | ✅ merged | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; authored in DEV by the CD pipeline (2026-08-12) |
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
-| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey | #101 ✅ merged, #102 ✅ merged | ⏳ in progress | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); still needs a `Get-AccountKeyMap` resolver + CD pipeline wiring before it can run live; policies.json deferred separately |
+| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged | ⏳ in progress | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester) — code-complete end-to-end; blocked only on DEV account seed-key data + CD pipeline wiring; policies.json deferred separately |
 | mda-app | #64 | DESIGN-SENSITIVE | — | #100 (docs) | ⏳ in progress (attended) | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); app module + custom pages + sitemap not yet authored |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
@@ -398,4 +398,42 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     into the CD pipeline with a smoke check (5.3); (4) MDA app "Advisor
     Cockpit" + the 2 custom pages (#64, Maker-Portal-attended step); (5) E2E
     DEV→TEST evidence (#65).
+
+- **2026-08-15 (`Get-AccountKeyMap` resolver merged, PR #103 as `10d2546` —
+  claims seeding now code-complete end-to-end) -** Owner confirmed "PR is
+  approved"; verified merged and synced local `main`.
+  - Implemented `Get-AccountKeyMap` in `seed-advisor-cockpit.ps1`: queries
+    live Dataverse (`GET /accounts?$select=accountid,crmshow_seedkey&$filter=crmshow_seedkey ne null`)
+    and builds the seed-key -> Account GUID map. `Invoke-AdvisorCockpitSeed`
+    now auto-resolves this map itself when the caller supplies none, so the
+    pipeline seed step (5.3) needs no extra wiring beyond
+    `Invoke-AdvisorCockpitSeed -EnvironmentUrl $url`. An explicit
+    `-AccountKeyMap` is still honored when supplied.
+  - 4 new Pester cases; `SeedAdvisorCockpit.Tests.ps1` now **17/17 green**.
+    Change remains isolated to this script's own test file.
+  - Not self-merged — merged by the owner as `10d2546`.
+  - **Net effect: the claims seeding path is now code-complete
+    end-to-end** — no remaining code gap. What remains is data, not code:
+    no live DEV account has a `crmshow_seedkey` value yet
+    (`accounts-contacts.json` seeding itself is still entirely
+    unimplemented — only declared in `Get-FixtureManifest`, no
+    `Get-AccountUpsertRequests` function exists), and policies.json mapping
+    is still separately deferred pending the `crmshow_status` GlobalChoice
+    value-mapping decision.
+  - **Caught and fixed a doc-staleness bug** while reconciling this: an
+    earlier paragraph in this same PR's own commit had described the
+    resolver as "still not done" — introduced because the sprint.md/
+    STATUS.md reconciliation pass was written *before* the resolver code in
+    the same working session, and the doc text was never revisited
+    afterward. Fixed both files' stream-table rows and narrative text to
+    stop contradicting themselves.
+  - **Resume next session with, in order:** (1) `accounts-contacts.json`
+    seeding — needs a `ConvertTo-AccountUpsertBody`/`Get-AccountUpsertRequests`
+    pair (following the claims TDD pattern) before any live account gets a
+    `crmshow_seedkey`, which is what actually exercises this whole chain
+    end-to-end; (2) policies.json mapping (separate GlobalChoice
+    value-mapping decision needed — an owner call, not a technical one);
+    (3) wire seeding into the CD pipeline with a smoke check (5.3); (4) MDA
+    app "Advisor Cockpit" + the 2 custom pages (#64, Maker-Portal-attended
+    step); (5) E2E DEV→TEST evidence (#65).
 

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
@@ -41,7 +41,7 @@ DESIGN-SENSITIVE streams run **attended**; EXECUTION-ONLY may run headless.
 | foundation-choices | 1 | #56 | EXECUTION-ONLY | ✅ merged (PR #75) + addendum DEV-authored (2026-08-14, run 31805085480) |
 | foundational-tables (slices 1–5) | 2 | #57 | DESIGN-SENSITIVE | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
 | cockpit-tables (nba + provenance) | 3 | #58 | EXECUTION-ONLY | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
-| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — claims mapped + tested (2026-08-14); `crmshow_seedkey` schema gap closed (2026-08-15, PR #102); account-GUID resolver + pipeline wiring + policies still pending |
+| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — claims mapping + `crmshow_seedkey` + `Get-AccountKeyMap` resolver all done (2026-08-14/15, PRs #101/#102/#103); code-complete end-to-end, blocked only on DEV account seed-key data + CD pipeline wiring; policies deferred |
 | mda-app + custom pages | 9 | #64 | DESIGN-SENSITIVE | ⏳ in progress (attended) |
 | e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated |
 | nba-agent (Copilot Studio) | 6 | #61 | DESIGN-SENSITIVE | ⏸ deferred (out of sprint) |
@@ -172,11 +172,24 @@ keys aren't a supported pipeline capability at all today, custom-table-only),
 in the [design-doc addendum](../../specs/2026-08-14-advisor-cockpit-datamodel-scope-reduction-design.md).
 Flagged in the PR for Enterprise Architect review per `AGENTS.md` §Authority
 since it's a data-model change, even though additive/low-risk; merged as
-`ab41e42`. **Still not done:** the `Get-AccountKeyMap`-style resolver in
-`seed-advisor-cockpit.ps1` that queries Dataverse by this field and builds
-the `-AccountKeyMap` hashtable `Get-ClaimUpsertRequests` already expects —
-this is the concrete next step before claims (or policies) can actually run
-against live Dataverse.
+`ab41e42`.
+
+**`Get-AccountKeyMap` resolver implemented, closing the code gap
+(2026-08-15, PR #103, merged as `10d2546`).** Added `Get-AccountKeyMap` to
+`seed-advisor-cockpit.ps1`: queries live Dataverse
+(`GET /accounts?$select=accountid,crmshow_seedkey&$filter=crmshow_seedkey ne null`)
+and builds the seed-key → Account GUID map. `Invoke-AdvisorCockpitSeed` now
+auto-resolves this map itself when the caller supplies none, so the pipeline
+seed step (5.3) needs no extra wiring beyond
+`Invoke-AdvisorCockpitSeed -EnvironmentUrl $url`. 4 new Pester cases;
+`SeedAdvisorCockpit.Tests.ps1` now **17/17 green**. **Net effect: the claims
+seeding path is now code-complete end-to-end** — no remaining code gap. What
+remains is data, not code: no live DEV account has a `crmshow_seedkey` value
+yet (`accounts-contacts.json` seeding itself is still entirely unimplemented
+— only declared in `Get-FixtureManifest`, no `Get-AccountUpsertRequests`
+function exists), and policies.json mapping is still separately deferred
+pending the `crmshow_status` GlobalChoice value-mapping decision above.
+
 ## Definition of done
 
 - [x] Governance: ADR-0026/0027 + polish-loop pattern recorded (#66).
@@ -186,6 +199,6 @@ against live Dataverse.
 - [x] `SalesLeaderDashboard` PCF pixel-faithful to the mockup (#63).
 - [x] Foundation choices authored in DEV (#56 base, PR #75).
 - [x] #56 addendum choices + foundational/cockpit tables authored in DEV (#57/#58, run 31805085480, 2026-08-14) — intake-export into source control still pending.
-- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping + tests done (2026-08-14); `crmshow_seedkey` schema gap closed (2026-08-15, PR #102); still needs the `Get-AccountKeyMap` resolver + CD pipeline wiring before it can run against live Dataverse; policies mapping deferred pending a status-value mapping decision.
+- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping, `crmshow_seedkey` schema, and the `Get-AccountKeyMap` resolver are all done (2026-08-14/15, PRs #101/#102/#103) — code-complete end-to-end; still needs CD pipeline wiring plus at least one DEV account with a populated `crmshow_seedkey` before it runs live; policies mapping deferred pending a status-value mapping decision.
 - [ ] MDA app "Advisor Cockpit" + custom pages (#64) — both controls wrapped as real PCF + build-verified (2026-08-14); app module/sitemap + the 2 custom pages (Maker-Portal-only step) still pending.
 - [ ] E2E DEV→TEST evidence (#65).


### PR DESCRIPTION
## Summary

Docs-only fix. `sprint.md` and `STATUS.md` both described `Get-AccountKeyMap` as "still not done"/"still needs a resolver" even after **PR #103** (which implements exactly that) merged as `10d2546`.

**Root cause:** the reconciliation pass documenting PR #103's own changes was written *before* the resolver code, in the same working session, and never revisited afterward — so the PR shipped with a self-contradicting doc (implementing the very thing its own docs said was still pending).

## Changes

- Updated both files' stream-table rows and narrative text: the claims-seeding path is now **code-complete end-to-end** (PRs #101/#102/#103 all merged). What remains is **data**, not code — no live DEV account has a `crmshow_seedkey` value yet — plus separately-deferred work (policies.json mapping, CD pipeline wiring).
- Appended a new dated `STATUS.md` entry (rather than rewriting the prior one) per the file's append-only run-log convention, and noted the staleness bug itself as a lesson for next time.

No code changes.

Refs #60. Not self-merging.