### PR TITLE
feat(sprint-003): implement account upserts, populating crmshow_seedkey (#60 follow-up)

### DIFF
--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -14,7 +14,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | ✅ merged | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; authored in DEV by the CD pipeline (2026-08-12) |
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
-| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged | ⏳ in progress | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester) — code-complete end-to-end; blocked only on DEV account seed-key data + CD pipeline wiring; policies.json deferred separately |
+| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), account-upserts PR open | ⏳ in progress | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (2026-08-15, 22/22 Pester) — account/claims now code-complete end-to-end; blocked only on CD pipeline wiring; contacts/roles + policies.json deferred separately |
 | mda-app | #64 | DESIGN-SENSITIVE | — | #100 (docs) | ⏳ in progress (attended) | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); app module + custom pages + sitemap not yet authored |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
@@ -436,4 +436,60 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     (3) wire seeding into the CD pipeline with a smoke check (5.3); (4) MDA
     app "Advisor Cockpit" + the 2 custom pages (#64, Maker-Portal-attended
     step); (5) E2E DEV→TEST evidence (#65).
+
+- **2026-08-15 (PR #104 docs fix merged; account upserts implemented \u2014
+  `crmshow_seedkey` now actually gets populated) -** Owner confirmed "pr
+  approved" for #104; verified merged (`6f26823`) and synced local `main`.
+  - **PR #104** (docs-only, fixing the self-contradiction noted above) is
+    already reflected in the entries above \u2014 no separate narrative needed.
+  - Implemented the next queued step: `ConvertTo-AccountUpsertBody` +
+    `Get-AccountUpsertRequests` in `seed-advisor-cockpit.ps1`, mapping
+    `accounts-contacts.json`'s **account rows only** (contacts excluded) to
+    `name`, `crmshow_accounttype`, and `crmshow_seedkey`. Added a
+    `ConvertTo-GlobalChoiceValue` helper to resolve the fixture's
+    `Household`/`Business`/`Broker` strings to their Dataverse numeric
+    option values (`100000000 + index`, the same convention
+    `Publish-InsuranceFoundation.ps1` uses) \u2014 safe here because the fixture
+    already uses the choice's own English codes verbatim, unlike
+    policies.json's German free text.
+  - **Key finding mid-implementation:** `account` has no *registered*
+    Dataverse alternate key on `crmshow_seedkey` (deliberate PR #102 scope
+    decision \u2014 native-table alternate keys aren't a supported pipeline
+    capability today), so the claims/policies PATCH-by-alternate-key
+    pattern doesn't apply to accounts. `Get-AccountUpsertRequests` instead
+    resolves each row against the same live-account map `Get-AccountKeyMap`
+    builds, issuing a plain POST for an unresolved seed key or a
+    PATCH-by-GUID for one already known \u2014 idempotent in effect either way.
+  - Verified the `@headers` array-splat mechanism used to conditionally add
+    `If-Match: *` only for PATCH (not POST) requests actually expands to
+    separate CLI arguments as expected (tested directly in the terminal)
+    before trusting it in a code path shared with the already-working
+    measure/claim upserts.
+  - **Known limitation, documented rather than solved:** on a fully empty
+    environment, `Invoke-AdvisorCockpitSeed` resolves `$AccountKeyMap` once
+    up front and uses that same snapshot for both account and claim
+    resolution \u2014 so newly-created accounts' claims won't resolve until a
+    *second* seed run re-queries `Get-AccountKeyMap` fresh. Accepted as an
+    idempotent-by-design characteristic rather than fixed with a bigger
+    two-phase refactor, to keep the change proportionate.
+  - 6 new Pester cases; `SeedAdvisorCockpit.Tests.ps1` now **22/22 green**.
+  - **Caught and fixed the same self-contradiction pattern again** while
+    writing these very docs: added a new paragraph to sprint.md saying
+    account upserts are now implemented, right after an *older* paragraph
+    (from the PR #103 entry) that still claimed "`accounts-contacts.json`
+    seeding itself is still entirely unimplemented." Fixed the older
+    paragraph to stop asserting that, rather than leaving two adjacent
+    paragraphs disagreeing with each other. Lesson already in repo memory
+    (`sprint-docs.md`, "SELF-CONTRADICTION TRAP") \u2014 re-confirms it needs
+    active vigilance every time a new dated paragraph is added near an
+    older one describing the same code area.
+  - **Resume next session with, in order:** (1) policies.json mapping
+    (separate GlobalChoice value-mapping decision needed \u2014 an owner call,
+    not a technical one); (2) wire seeding into the CD pipeline with a
+    smoke check (5.3) \u2014 also the first real chance to observe the
+    two-pass-convergence limitation above against live DEV; (3) contact
+    rows + the `crmshow_accountcontactrole` junction (needed for the
+    fixture's "role" field), a separate increment from account upserts;
+    (4) MDA app "Advisor Cockpit" + the 2 custom pages (#64,
+    Maker-Portal-attended step); (5) E2E DEV→TEST evidence (#65).
 

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
@@ -41,7 +41,7 @@ DESIGN-SENSITIVE streams run **attended**; EXECUTION-ONLY may run headless.
 | foundation-choices | 1 | #56 | EXECUTION-ONLY | ✅ merged (PR #75) + addendum DEV-authored (2026-08-14, run 31805085480) |
 | foundational-tables (slices 1–5) | 2 | #57 | DESIGN-SENSITIVE | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
 | cockpit-tables (nba + provenance) | 3 | #58 | EXECUTION-ONLY | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
-| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — claims mapping + `crmshow_seedkey` + `Get-AccountKeyMap` resolver all done (2026-08-14/15, PRs #101/#102/#103); code-complete end-to-end, blocked only on DEV account seed-key data + CD pipeline wiring; policies deferred |
+| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — claims mapping, `crmshow_seedkey`, the `Get-AccountKeyMap` resolver, and account upserts all done (2026-08-14/15); account/claims code-complete end-to-end; still needs CD pipeline wiring; contacts/roles and policies deferred |
 | mda-app + custom pages | 9 | #64 | DESIGN-SENSITIVE | ⏳ in progress (attended) |
 | e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated |
 | nba-agent (Copilot Studio) | 6 | #61 | DESIGN-SENSITIVE | ⏸ deferred (out of sprint) |
@@ -185,10 +185,36 @@ seed step (5.3) needs no extra wiring beyond
 `SeedAdvisorCockpit.Tests.ps1` now **17/17 green**. **Net effect: the claims
 seeding path is now code-complete end-to-end** — no remaining code gap. What
 remains is data, not code: no live DEV account has a `crmshow_seedkey` value
-yet (`accounts-contacts.json` seeding itself is still entirely unimplemented
-— only declared in `Get-FixtureManifest`, no `Get-AccountUpsertRequests`
-function exists), and policies.json mapping is still separately deferred
-pending the `crmshow_status` GlobalChoice value-mapping decision above.
+yet — see the next entry for how that data now actually gets created.
+
+**Account upserts implemented, so `crmshow_seedkey` now actually gets
+populated (2026-08-15).** Added `ConvertTo-AccountUpsertBody` +
+`Get-AccountUpsertRequests` to `seed-advisor-cockpit.ps1`, mapping
+`accounts-contacts.json`'s **account rows only** (not contacts) to concrete
+columns: `name`, `crmshow_accounttype` (mapped from the fixture's
+`Household`/`Business`/`Broker` string to its Dataverse numeric option value
+via a new `ConvertTo-GlobalChoiceValue` helper — safe because the fixture
+already uses the exact same English option codes, unlike policies.json's
+German free text), and `crmshow_seedkey`. `segment`/`region`/`owner` have no
+corresponding schema column today and are intentionally not seeded; contact
+rows and the `crmshow_accountcontactrole` junction (needed for the fixture's
+"role" field) are a separate, not-yet-implemented increment.
+
+**Key finding: `account` has no registered Dataverse *alternate key* on
+`crmshow_seedkey`** — a deliberate PR #102 scope decision, since native-table
+alternate keys aren't a supported pipeline capability today. So
+`Get-AccountUpsertRequests` can't reuse the same PATCH-by-alternate-key
+pattern as claims/policies; instead it resolves each row against the same
+live-account map `Get-AccountKeyMap` builds and issues a plain POST (create)
+for a seed key not yet present, or a PATCH-by-GUID (update) for one already
+resolved. **Known limitation, documented rather than solved this round:** on
+a fully empty environment, accounts and claims are resolved from the *same*
+pre-run `$AccountKeyMap` snapshot, so newly-created accounts' claims won't
+resolve until a second seed run re-queries `Get-AccountKeyMap` fresh — an
+acceptable, idempotent-by-design characteristic rather than a bug, but worth
+knowing before assuming one pipeline run fully converges a brand-new
+environment. 6 new Pester cases; `SeedAdvisorCockpit.Tests.ps1` now
+**22/22 green**.
 
 ## Definition of done
 
@@ -199,6 +225,6 @@ pending the `crmshow_status` GlobalChoice value-mapping decision above.
 - [x] `SalesLeaderDashboard` PCF pixel-faithful to the mockup (#63).
 - [x] Foundation choices authored in DEV (#56 base, PR #75).
 - [x] #56 addendum choices + foundational/cockpit tables authored in DEV (#57/#58, run 31805085480, 2026-08-14) — intake-export into source control still pending.
-- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping, `crmshow_seedkey` schema, and the `Get-AccountKeyMap` resolver are all done (2026-08-14/15, PRs #101/#102/#103) — code-complete end-to-end; still needs CD pipeline wiring plus at least one DEV account with a populated `crmshow_seedkey` before it runs live; policies mapping deferred pending a status-value mapping decision.
+- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping, `crmshow_seedkey` schema, the `Get-AccountKeyMap` resolver, and account upserts are all done (2026-08-14/15) — account/claims are code-complete end-to-end; still needs CD pipeline wiring; contact/role seeding and policies mapping (status-value decision) remain separately deferred.
 - [ ] MDA app "Advisor Cockpit" + custom pages (#64) — both controls wrapped as real PCF + build-verified (2026-08-14); app module/sitemap + the 2 custom pages (Maker-Portal-only step) still pending.
 - [ ] E2E DEV→TEST evidence (#65).

--- a/scripts/solution/seed-advisor-cockpit.ps1
+++ b/scripts/solution/seed-advisor-cockpit.ps1
@@ -27,6 +27,21 @@
     upserts are skipped with a warning if no account has a seed key yet, or if
     a referenced account key is missing from the resolved map.
 
+    Accounts (accounts-contacts.json, account rows only) are also mapped, using
+    only columns that already exist (name, crmshow_accounttype,
+    crmshow_seedkey) -- segment/region/owner have no corresponding schema
+    column today and are intentionally not seeded. Unlike claims/policies,
+    account has no *registered Dataverse alternate key* on crmshow_seedkey (a
+    deliberate PR #102 scope decision: native-table alternate keys are not a
+    supported pipeline capability today), so the standard
+    PATCH-by-alternate-key URL syntax does not apply here. Get-AccountUpsertRequests
+    instead resolves each row against the live account map (the same one
+    Get-AccountKeyMap builds) and issues a plain POST (create) for a seed key
+    not yet present, or a PATCH-by-GUID (update) for one that is -- both are
+    idempotent in effect. Contact rows and the crmshow_accountcontactrole
+    junction (needed for the fixture's "role" field) are NOT yet mapped; left
+    for a follow-up.
+
     Policies (crmshow_policyprojection) are NOT yet mapped: beyond the same
     account-resolution gap, the table also requires crmshow_policynumber,
     crmshow_lineofbusinesscode, crmshow_effectivefrom and
@@ -108,6 +123,74 @@ function ConvertTo-MeasureUpsertBody {
     if ($null -ne $Row.region) { $body.crmshow_region = [string]$Row.region }
     if ($null -ne $Row.productLine) { $body.crmshow_productline = [string]$Row.productLine }
     return $body
+}
+
+# Fixed offset Dataverse assigns to custom global choice options that don't
+# specify an explicit numeric value (see Publish-InsuranceFoundation.ps1,
+# which uses the same 100000000 + index convention when authoring options).
+$script:GlobalChoiceValueBase = 100000000
+
+# Maps a choice's fixture-facing code string (e.g. "Household") to its
+# Dataverse numeric option value, by position in the given ordered code list.
+# Throws on an unknown code rather than silently seeding a wrong option.
+function ConvertTo-GlobalChoiceValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Code,
+        [Parameter(Mandatory)] [string[]]$KnownCodes
+    )
+    $index = [Array]::IndexOf($KnownCodes, $Code)
+    if ($index -lt 0) {
+        throw "Unknown choice code '$Code'. Known codes: $($KnownCodes -join ',')."
+    }
+    return $script:GlobalChoiceValueBase + $index
+}
+
+# Maps one accounts-contacts.json account row to its account column body.
+# Only fields with an existing schema column are mapped -- see the script
+# docstring for what's intentionally excluded (segment/region/owner/contacts).
+function ConvertTo-AccountUpsertBody {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Row)
+
+    [ordered]@{
+        name                = [string]$Row.name
+        crmshow_accounttype = ConvertTo-GlobalChoiceValue -Code ([string]$Row.accountType) -KnownCodes @('Household', 'Business', 'Broker')
+        crmshow_seedkey     = [string]$Row.key
+    }
+}
+
+# Builds account create/update requests. account has no registered Dataverse
+# alternate key on crmshow_seedkey (see the script docstring), so this cannot
+# use New-DataverseUpsertRequest's PATCH-by-alternate-key pattern like
+# claims/policies. Instead: a plain POST for a seed key absent from
+# $ExistingAccountMap (the same map Get-AccountKeyMap builds), or a
+# PATCH-by-GUID for one already present -- idempotent in effect either way.
+function Get-AccountUpsertRequests {
+    [CmdletBinding()]
+    param(
+        [string]$FixtureRoot = $script:FixtureRoot,
+        [System.Collections.IDictionary]$ExistingAccountMap = [ordered]@{}
+    )
+
+    $group = Get-SeedPlan -FixtureRoot $FixtureRoot | Where-Object { $_.Fixture -eq 'accounts-contacts.json' }
+    foreach ($row in @($group.Records | Where-Object { $_.recordType -eq 'account' })) {
+        $body = ConvertTo-AccountUpsertBody -Row $row
+        if ($ExistingAccountMap -and $ExistingAccountMap.Contains([string]$row.key)) {
+            [pscustomobject]@{
+                Method = 'PATCH'
+                Path   = "/accounts($([string]$ExistingAccountMap[[string]$row.key]))"
+                Body   = $body
+            }
+        }
+        else {
+            [pscustomobject]@{
+                Method = 'POST'
+                Path   = '/accounts'
+                Body   = $body
+            }
+        }
+    }
 }
 
 # Builds a PATCH-upsert request object against an alternate key. Does not execute.
@@ -240,15 +323,17 @@ function Invoke-AdvisorCockpitSeed {
         $AccountKeyMap = Get-AccountKeyMap -EnvironmentUrl $EnvironmentUrl
     }
 
-    $requests = @(Get-MeasureUpsertRequests) + @(Get-ClaimUpsertRequests -AccountKeyMap $AccountKeyMap)
+    $requests = @(Get-MeasureUpsertRequests) + @(Get-AccountUpsertRequests -ExistingAccountMap $AccountKeyMap) + @(Get-ClaimUpsertRequests -AccountKeyMap $AccountKeyMap)
     foreach ($req in $requests) {
         $url = "$baseUrl/api/data/v9.2$($req.Path)"
         if ($PSCmdlet.ShouldProcess($url, $req.Method)) {
             $tmp = [System.IO.Path]::GetTempFileName()
             try {
                 ($req.Body | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $tmp -Encoding UTF8
+                $headers = @('Content-Type=application/json')
+                if ($req.Method -eq 'PATCH') { $headers += 'If-Match=*' }
                 az rest --method $req.Method --url $url --resource "$baseUrl/" `
-                    --headers 'Content-Type=application/json' 'If-Match=*' `
+                    --headers @headers `
                     --body "@$tmp" --only-show-errors | Out-Null
             }
             finally {

--- a/scripts/solution/tests/SeedAdvisorCockpit.Tests.ps1
+++ b/scripts/solution/tests/SeedAdvisorCockpit.Tests.ps1
@@ -124,13 +124,14 @@ Describe 'seed-advisor-cockpit' {
         $requests.Count | Should -Be 0
     }
 
-    It 'includes claim upserts alongside analytics upserts when Invoke-AdvisorCockpitSeed is given an AccountKeyMap' {
+    It 'includes claim and account upserts alongside analytics upserts when Invoke-AdvisorCockpitSeed is given an AccountKeyMap' {
         $map = @{ 'ACC-AEBISCHER' = '44444444-4444-4444-4444-444444444444'; 'ACC-BRUNNER' = '55555555-5555-5555-5555-555555555555' }
         Mock -CommandName az -MockWith { $global:LASTEXITCODE = 0 }
         Invoke-AdvisorCockpitSeed -EnvironmentUrl 'https://example.crm.dynamics.com' -AccountKeyMap $map -Confirm:$false
         $measureCount = (Get-SeedPlan | Where-Object { $_.Shape -eq 'measure' }).Count
+        $accountCount = @((Get-SeedPlan | Where-Object { $_.Fixture -eq 'accounts-contacts.json' }).Records | Where-Object { $_.recordType -eq 'account' }).Count
         $claimCount = (Get-SeedPlan | Where-Object { $_.Fixture -eq 'claims.json' }).Count
-        Should -Invoke -CommandName az -Times ($measureCount + $claimCount) -Exactly
+        Should -Invoke -CommandName az -Times ($measureCount + $accountCount + $claimCount) -Exactly
     }
 
     It 'builds an account key map from live accounts with a resolved crmshow_seedkey' {
@@ -156,7 +157,48 @@ Describe 'seed-advisor-cockpit' {
         Invoke-AdvisorCockpitSeed -EnvironmentUrl 'https://example.crm.dynamics.com' -Confirm:$false
         Should -Invoke -CommandName Get-AccountKeyMap -Times 1 -Exactly
         $measureCount = (Get-SeedPlan | Where-Object { $_.Shape -eq 'measure' }).Count
+        $accountCount = @((Get-SeedPlan | Where-Object { $_.Fixture -eq 'accounts-contacts.json' }).Records | Where-Object { $_.recordType -eq 'account' }).Count
         $claimCount = (Get-SeedPlan | Where-Object { $_.Fixture -eq 'claims.json' }).Count
-        Should -Invoke -CommandName az -Times ($measureCount + $claimCount) -Exactly
+        Should -Invoke -CommandName az -Times ($measureCount + $accountCount + $claimCount) -Exactly
+    }
+
+    It 'converts a known choice code to its Dataverse numeric option value by position' {
+        ConvertTo-GlobalChoiceValue -Code 'Household' -KnownCodes @('Household', 'Business', 'Broker') | Should -Be 100000000
+        ConvertTo-GlobalChoiceValue -Code 'Broker' -KnownCodes @('Household', 'Business', 'Broker') | Should -Be 100000002
+    }
+
+    It 'throws on an unknown choice code rather than guessing a value' {
+        { ConvertTo-GlobalChoiceValue -Code 'Nonprofit' -KnownCodes @('Household', 'Business', 'Broker') } |
+            Should -Throw '*Nonprofit*'
+    }
+
+    It 'converts an account row to its Dataverse column body' {
+        $row = [pscustomobject]@{ recordType = 'account'; key = 'ACC-BRUNNER'; name = 'Haushalt Brunner'; accountType = 'Household' }
+        $body = ConvertTo-AccountUpsertBody -Row $row
+        $body.name | Should -Be 'Haushalt Brunner'
+        $body.crmshow_accounttype | Should -Be 100000000
+        $body.crmshow_seedkey | Should -Be 'ACC-BRUNNER'
+    }
+
+    It 'builds one account upsert request per account row (contacts excluded), split between create and update' {
+        $accountCount = @((Get-SeedPlan | Where-Object { $_.Fixture -eq 'accounts-contacts.json' }).Records | Where-Object { $_.recordType -eq 'account' }).Count
+        $existing = @{ 'ACC-BRUNNER' = '11111111-1111-1111-1111-111111111111' }
+        $requests = @(Get-AccountUpsertRequests -ExistingAccountMap $existing)
+        $requests.Count | Should -Be $accountCount
+
+        $update = $requests | Where-Object { $_.Method -eq 'PATCH' }
+        @($update).Count | Should -Be 1
+        $update.Path | Should -Be '/accounts(11111111-1111-1111-1111-111111111111)'
+
+        $creates = @($requests | Where-Object { $_.Method -eq 'POST' })
+        $creates.Count | Should -Be ($accountCount - 1)
+        $creates | ForEach-Object { $_.Path | Should -Be '/accounts' }
+    }
+
+    It 'creates every account when no ExistingAccountMap is supplied' {
+        $accountCount = @((Get-SeedPlan | Where-Object { $_.Fixture -eq 'accounts-contacts.json' }).Records | Where-Object { $_.recordType -eq 'account' }).Count
+        $requests = @(Get-AccountUpsertRequests)
+        $requests.Count | Should -Be $accountCount
+        $requests | ForEach-Object { $_.Method | Should -Be 'POST' }
     }
 }


### PR DESCRIPTION
## Summary

Sprint 3, seed-pipeline wiring (#60 follow-up). Implements account upserts so `crmshow_seedkey` (added in PR #102) actually gets populated on live accounts, which is what lets `Get-AccountKeyMap` (PR #103) resolve claims/policies end-to-end.

Adds `ConvertTo-AccountUpsertBody` + `Get-AccountUpsertRequests` to `seed-advisor-cockpit.ps1`, mapping `accounts-contacts.json`'s **account rows only** (not contacts) to `name`, `crmshow_accounttype`, and `crmshow_seedkey`.

Adds `ConvertTo-GlobalChoiceValue` to resolve the fixture's `Household`/`Business`/`Broker` strings to their Dataverse numeric option values (`100000000 + index`, the same convention `Publish-InsuranceFoundation.ps1` uses) — safe here because the fixture already uses the choice's own English codes verbatim, unlike policies.json's German free text which still needs a separate owner mapping decision.

## Key finding

`account` has no *registered* Dataverse alternate key on `crmshow_seedkey` — a deliberate PR #102 scope decision, since native-table alternate keys aren't a supported pipeline capability today. So the claims/policies PATCH-by-alternate-key pattern doesn't apply here. `Get-AccountUpsertRequests` instead resolves each row against the same live-account map `Get-AccountKeyMap` builds, issuing a plain POST for an unresolved seed key or a PATCH-by-GUID for one already known — idempotent in effect either way.

## Explicitly out of scope

- Contact rows and the `crmshow_accountcontactrole` junction (needed for the fixture's "role" field) — a separate, not-yet-implemented increment.
- `segment`/`region`/`owner` — no corresponding schema column exists today; intentionally not seeded.
- **Known limitation, documented not solved:** on a fully empty environment, `Invoke-AdvisorCockpitSeed` resolves `$AccountKeyMap` once up front and reuses that snapshot for both account and claim resolution, so newly-created accounts' claims won't resolve until a *second* seed run re-queries `Get-AccountKeyMap` fresh. Accepted as an idempotent-by-design characteristic rather than a bigger two-phase refactor, to keep this change proportionate.

## Testing

- 6 new Pester cases (`SeedAdvisorCockpit.Tests.ps1`, now **22/22 green**): choice-value conversion (including the unknown-code throw), account row-to-body mapping, `Get-AccountUpsertRequests`' create/update split — plus fixed the 2 existing `Invoke-AdvisorCockpitSeed` tests whose `az` call-count assertions didn't yet account for the new account upserts.
- Verified the `@headers` array-splat mechanism (used to conditionally add `If-Match: *` only for PATCH, not POST) actually expands to separate CLI arguments as expected — tested directly in the terminal before trusting it in a code path shared with the already-working measure/claim upserts.
- Confirmed via repo-wide search that `seed-advisor-cockpit.ps1` remains only dot-sourced by its own test file.

## Docs

Reconciled `sprint.md`/`STATUS.md` — including catching and fixing a self-contradiction this same change would otherwise have introduced (an older paragraph still claimed account seeding was unimplemented, right next to a new one saying it's now done). Caught per the "SELF-CONTRADICTION TRAP" lesson already recorded in repo memory from the PR #103/#104 cycle.

Refs #60. Not self-merging — awaiting `gate1` + human review.