### PR TITLE
feat(sprint-003): wire seed script + smoke check into cd-solution-dev.yml (#60 follow-up / 5.3)

### DIFF
--- a/.github/workflows/cd-solution-dev.yml
+++ b/.github/workflows/cd-solution-dev.yml
@@ -151,6 +151,26 @@ jobs:
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0) { throw 'Demo convergence validation failed.' }
 
+      - name: Seed Advisor Cockpit demo data
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          & (Join-Path $root 'scripts/solution/seed-advisor-cockpit.ps1') `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -Confirm:$false
+          if ($LASTEXITCODE -ne 0) { throw 'Advisor Cockpit demo data seeding failed.' }
+
+      - name: Smoke-check seeded demo data
+        shell: pwsh
+        run: |
+          $baseUrl = $env:POWER_PLATFORM_ENV_URL.TrimEnd('/')
+          $url = "$baseUrl/api/data/v9.2/crmshow_measuresnapshots?`$select=crmshow_measuresnapshotid&`$top=1"
+          $response = az rest --method GET --url $url --resource "$baseUrl/" --only-show-errors | ConvertFrom-Json
+          if (@($response.value).Count -lt 1) {
+            throw 'Smoke check failed: no crmshow_measuresnapshot records found after seeding.'
+          }
+          Write-Output 'Smoke check passed: measure-snapshot records present.'
+
       - name: Export managed and unmanaged solutions
         shell: pwsh
         run: |

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -14,7 +14,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | ✅ merged | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; authored in DEV by the CD pipeline (2026-08-12) |
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
-| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), account-upserts PR open | ⏳ in progress | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (2026-08-15, 22/22 Pester) — account/claims now code-complete end-to-end; blocked only on CD pipeline wiring; contacts/roles + policies.json deferred separately |
+| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, cd-seed-wiring PR open | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
 | mda-app | #64 | DESIGN-SENSITIVE | — | #100 (docs) | ⏳ in progress (attended) | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); app module + custom pages + sitemap not yet authored |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
@@ -492,4 +492,48 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     fixture's "role" field), a separate increment from account upserts;
     (4) MDA app "Advisor Cockpit" + the 2 custom pages (#64,
     Maker-Portal-attended step); (5) E2E DEV→TEST evidence (#65).
-
+- **2026-08-15 (PR #105 merged; seed step wired into `cd-solution-dev.yml`,
+  stream 5.3 now code-complete) -** Owner confirmed "pr approved" for #105;
+  verified merged (`5d12d10`) and synced local `main`.
+  - Added a "Seed Advisor Cockpit demo data" step to the `author` job in
+    `cd-solution-dev.yml`, right after "Validate complete demo convergence"
+    and before the solution-package export step: calls
+    `seed-advisor-cockpit.ps1 -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL -Confirm:$false`,
+    mirroring the exact invocation style of the neighboring "Reconcile
+    demo-safe metadata" step. No new authentication wiring needed — verified
+    by cross-checking `Publish-InsuranceFoundation.ps1`'s `Invoke-DataverseRequest`
+    uses the identical `az rest --resource $baseUrl/` pattern, so the job's
+    existing `azure/login` OIDC sign-in already covers it.
+  - Added a "Smoke-check seeded demo data" step right after it, querying
+    `crmshow_measuresnapshots` for at least one record and failing the job
+    if none exist — measures are unconditionally seeded every run (no
+    account-resolution dependency), so this is a stable smoke signal that
+    doesn't get tripped up by the two-pass-convergence nuance below.
+  - Verified the modified workflow YAML parses correctly with a Python
+    `yaml.safe_load` check (no native GitHub Actions linter available
+    locally). No PowerShell script logic changed, so no new Pester
+    coverage was needed for this specific change.
+  - **Not yet done: an actual live dispatch of the updated pipeline.** This
+    PR only adds the step — running it against live DEV is a separate,
+    deliberate action for a future turn, consistent with this session's
+    practice of never auto-dispatching CD-DEV without explicit
+    confirmation. Given the two-pass-convergence limitation from the prior
+    entry, the **first** live run against a fresh DEV is expected to create
+    accounts and skip claims (warning, not failure); a **second** dispatch
+    is expected to then seed claims successfully. This is the first real
+    opportunity to observe that behavior against a live environment rather
+    than mocked tests.
+  - `seed-pipeline` stream (5.3) is now **code-complete end-to-end** across
+    all its increments (#101/#102/#103/#105 + this pipeline-wiring PR).
+    Remaining work on this stream is either a live-verification step (not
+    yet run) or explicitly-deferred separate scope (contacts/roles,
+    policies.json).
+  - **Resume next session with, in order:** (1) dispatch `cd-solution-dev.yml`
+    against live DEV (twice, per the two-pass-convergence note) to get the
+    first live evidence of claims seeding actually working end-to-end —
+    this is a deliberate, explicit action, not something to do
+    automatically; (2) policies.json mapping (separate GlobalChoice
+    value-mapping decision needed — an owner call); (3) contact rows + the
+    `crmshow_accountcontactrole` junction (fixture "role" field), a
+    separate increment; (4) MDA app "Advisor Cockpit" + the 2 custom pages
+    (#64, Maker-Portal-attended step); (5) E2E DEV→TEST evidence (#65).

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
@@ -41,7 +41,7 @@ DESIGN-SENSITIVE streams run **attended**; EXECUTION-ONLY may run headless.
 | foundation-choices | 1 | #56 | EXECUTION-ONLY | ✅ merged (PR #75) + addendum DEV-authored (2026-08-14, run 31805085480) |
 | foundational-tables (slices 1–5) | 2 | #57 | DESIGN-SENSITIVE | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
 | cockpit-tables (nba + provenance) | 3 | #58 | EXECUTION-ONLY | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
-| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ⏳ in progress — claims mapping, `crmshow_seedkey`, the `Get-AccountKeyMap` resolver, and account upserts all done (2026-08-14/15); account/claims code-complete end-to-end; still needs CD pipeline wiring; contacts/roles and policies deferred |
+| seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ✅ code-complete (2026-08-14/15) — claims mapping, `crmshow_seedkey`, the `Get-AccountKeyMap` resolver, account upserts, and the CD-DEV pipeline step all done; not yet verified live; contacts/roles and policies deferred |
 | mda-app + custom pages | 9 | #64 | DESIGN-SENSITIVE | ⏳ in progress (attended) |
 | e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated |
 | nba-agent (Copilot Studio) | 6 | #61 | DESIGN-SENSITIVE | ⏸ deferred (out of sprint) |
@@ -216,6 +216,28 @@ knowing before assuming one pipeline run fully converges a brand-new
 environment. 6 new Pester cases; `SeedAdvisorCockpit.Tests.ps1` now
 **22/22 green**.
 
+**Seed wired into the CD-DEV pipeline (2026-08-15).** Added a "Seed Advisor
+Cockpit demo data" step to `cd-solution-dev.yml`'s `author` job, right after
+"Validate complete demo convergence" and before the solution-package export
+step, calling `seed-advisor-cockpit.ps1 -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL -Confirm:$false`
+— the same invocation style already used by the neighboring "Reconcile
+demo-safe metadata" step (no new auth wiring needed: `az rest` against
+Dataverse already works in this job via the existing `azure/login` OIDC
+sign-in, confirmed by cross-checking `Publish-InsuranceFoundation.ps1`'s
+identical `--resource` usage). A follow-up "Smoke-check seeded demo data"
+step queries `crmshow_measuresnapshots` for at least one record and fails
+the job if none exist — measures are unconditionally seeded every run (no
+account-resolution dependency), so this catches a silently-broken seed step
+without being brittle to the two-pass-convergence nuance below. YAML syntax
+verified with a Python `yaml` parse. **Not yet done: an actual live dispatch
+of the updated pipeline** — this PR only adds the steps; running it against
+live DEV is a separate, deliberate action for a future turn (per this
+session's established convention of never auto-dispatching CD-DEV without
+explicit confirmation). Given the two-pass-convergence limitation noted
+above, the **first** live run against a fresh DEV is expected to create
+accounts and skip claims (warning, not failure); a **second** dispatch is
+expected to then seed claims successfully.
+
 ## Definition of done
 
 - [x] Governance: ADR-0026/0027 + polish-loop pattern recorded (#66).
@@ -225,6 +247,6 @@ environment. 6 new Pester cases; `SeedAdvisorCockpit.Tests.ps1` now
 - [x] `SalesLeaderDashboard` PCF pixel-faithful to the mockup (#63).
 - [x] Foundation choices authored in DEV (#56 base, PR #75).
 - [x] #56 addendum choices + foundational/cockpit tables authored in DEV (#57/#58, run 31805085480, 2026-08-14) — intake-export into source control still pending.
-- [ ] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping, `crmshow_seedkey` schema, the `Get-AccountKeyMap` resolver, and account upserts are all done (2026-08-14/15) — account/claims are code-complete end-to-end; still needs CD pipeline wiring; contact/role seeding and policies mapping (status-value decision) remain separately deferred.
+- [x] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping, `crmshow_seedkey` schema, the `Get-AccountKeyMap` resolver, account upserts, and the CD-DEV pipeline step are all done (2026-08-14/15) — code-complete end-to-end; not yet verified against a live dispatch (expected to need 2 runs to fully converge a fresh environment, see above); contact/role seeding and policies mapping (status-value decision) remain separately deferred.
 - [ ] MDA app "Advisor Cockpit" + custom pages (#64) — both controls wrapped as real PCF + build-verified (2026-08-14); app module/sitemap + the 2 custom pages (Maker-Portal-only step) still pending.
 - [ ] E2E DEV→TEST evidence (#65).


### PR DESCRIPTION
## Summary

Sprint 3, seed-pipeline wiring (#60 follow-up / stream 5.3). Wires the standalone `seed-advisor-cockpit.ps1` (and its prerequisites from PRs #101/#102/#103/#105) into `cd-solution-dev.yml`.

Adds two steps to the `author` job, right after "Validate complete demo convergence" and before the solution-package export step:

- **"Seed Advisor Cockpit demo data"**: calls `seed-advisor-cockpit.ps1 -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL -Confirm:$false`, mirroring the exact invocation style of the neighboring "Reconcile demo-safe metadata" step.
- **"Smoke-check seeded demo data"**: queries `crmshow_measuresnapshots` for at least one record and fails the job if none exist. Measures are unconditionally seeded every run (no account-resolution dependency), so this is a stable signal that won't be tripped up by the two-pass-convergence nuance below.

No new authentication wiring needed — verified `Publish-InsuranceFoundation.ps1`'s `Invoke-DataverseRequest` uses the identical `az rest --resource $baseUrl/` pattern, so the job's existing `azure/login` OIDC sign-in already covers it.

## Not yet done

An actual **live dispatch** of the updated pipeline. This PR only adds the steps — running it against live DEV is a separate, deliberate action for a future turn, consistent with this session's practice of never auto-dispatching CD-DEV without explicit confirmation.

Given the two-pass-convergence limitation documented in PR #105 (`$AccountKeyMap` is resolved once per run and shared between account and claim building), the **first** live run against a fresh DEV is expected to create accounts and skip claims (warning, not failure); a **second** dispatch is expected to then seed claims successfully.

## Net effect

This closes out the seed-pipeline stream (5.3) as **code-complete** across all its increments (#101/#102/#103/#105 + this PR). Remaining stream work is either live verification (not yet run) or explicitly-deferred separate scope (contact/role seeding, policies.json mapping — the latter still needs an owner decision on GlobalChoice status-value mapping).

## Testing

- Verified the modified YAML parses correctly (`python -c "import yaml; yaml.safe_load(...)"`).
- No PowerShell script logic changed in this PR, so no new Pester coverage was needed.

## Docs

Reconciled `sprint.md`/`STATUS.md`, marking the stream's Definition-of-Done line complete with an explicit caveat that it's not yet verified live (did a full re-read pass of both files' relevant sections before committing, per the "self-contradiction trap" lesson from the last two PRs in this stream).

`.github/` is owned by `@urruegg` per CODEOWNERS (same reviewer as everything else in this repo) — no special extra review process beyond the standard gate.

Refs #60. Not self-merging — awaiting `gate1` + human review.