### PR TITLE
docs(sprint-ops): anchor DEV+TEST evidence as a required sprint-closing policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint-charter.md
+++ b/.github/ISSUE_TEMPLATE/sprint-charter.md
@@ -22,3 +22,10 @@ labels: sprint-charter
 
 - [ ] All streams merged to main via PR
 - [ ] Evidence captured in the sprint STATUS.md
+- [ ] DEV evidence: authoring/convergence pipeline green against live DEV,
+      linked run + offline test pass/fail counts, in `STATUS.md` under
+      `## Live DEV + TEST evidence`
+- [ ] TEST evidence: promoted to TEST, linked run + step-by-step result table
+      + TEST-side test/smoke counts — **or**, if this sprint's scope does not
+      reach TEST, an explicit stated reason (never a silent omission)
+      — see [Sprint Operating Model — "Sprint closing"](../../docs/superpowers/SPRINT-OPERATING-MODEL.md#sprint-closing--required-dev--test-evidence)

--- a/docs/superpowers/SPRINT-OPERATING-MODEL.md
+++ b/docs/superpowers/SPRINT-OPERATING-MODEL.md
@@ -170,6 +170,39 @@ topic A# -> use case -> ADR -> design spec (trunk)
 Every packet, branch, PR and `STATUS.md` row carries `#S` / `#N`, so a whole
 delegated run is auditable end to end.
 
+## Sprint closing — required DEV + TEST evidence
+
+*Anchored 2026-08-15, prompted mid-sprint-003 while its seed-pipeline stream
+was in review (PRs #101–#106).* Grounds
+[ADR-0017](../adr/ADR-0017-alm-everything-through-the-pipeline.md)'s "rollback
+must be demonstrable, not described" in a concrete, checkable requirement for
+every sprint charter, not just sprint-002's promotion-themed one.
+
+**A sprint is not closed on "the code merged to `main`" alone.** Its charter's
+Definition of Done must show, in the sprint's own `STATUS.md`, under a
+`## Live DEV + TEST evidence` heading:
+
+1. **DEV evidence** — the authoring/convergence pipeline (e.g. `cd-solution-dev.yml`)
+   run **green against live DEV**, linked by run URL, with the **offline test
+   suite's pass/fail counts** quoted alongside it (not just "CI is green" as a
+   bare claim — the actual numbers, e.g. "385 passed, 0 failed, 2 skipped").
+2. **TEST evidence** — the same change **promoted to TEST**, linked by run
+   URL, with a step-by-step result table (mirroring
+   [sprint-002's "Live promotion evidence"](./sprints/sprint-002-insurance-foundation-promotion/STATUS.md)
+   — one row per pipeline step, ✅/❌/⚠️, defects found and fixed called out
+   explicitly) and the TEST-side smoke/Pester result counts.
+3. **If a sprint's scope genuinely does not reach TEST** (e.g. a
+   documentation-only or research sprint), its Definition of Done must say so
+   **explicitly, with a reason** — never a silent omission. A missing DEV or
+   TEST evidence line reads as *not done*, not as *not applicable*.
+
+This is a closing-time requirement, not a per-PR one: individual stream PRs
+keep following their own `gate1` + evidence-in-PR convention as before: this
+section is what the **sprint charter's own Definition of Done** checks against
+before anyone calls the sprint closed. See
+[the sprint-charter issue template](../../.github/ISSUE_TEMPLATE/sprint-charter.md)
+for the checklist wording every new sprint charter now carries.
+
 ## The scripts
 
 | Script | Responsibility |

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -14,7 +14,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | foundation-choices | #56 | EXECUTION-ONLY | feat/sprint-003-foundation-choices | #75 | ✅ merged | +5 cockpit choices (nbastatus/nbachannel/productline/region/metrictype) in 4 languages; contract 1.1.0; authored in DEV by the CD pipeline (2026-08-12) |
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
-| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, cd-seed-wiring PR open | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
+| seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, #106 ✅ merged | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
 | mda-app | #64 | DESIGN-SENSITIVE | — | #100 (docs) | ⏳ in progress (attended) | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); app module + custom pages + sitemap not yet authored |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
@@ -537,3 +537,43 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     `crmshow_accountcontactrole` junction (fixture "role" field), a
     separate increment; (4) MDA app "Advisor Cockpit" + the 2 custom pages
     (#64, Maker-Portal-attended step); (5) E2E DEV→TEST evidence (#65).
+
+- **2026-08-15 (PR #106 merged as `5f3c9dc` — the pipeline-wiring PR the
+  "Live DEV + TEST evidence" section below anticipated) -** Confirmed merged
+  while rebasing PR #107 (this policy-anchor PR) onto the updated `main` to
+  resolve the STATUS.md conflict the two PRs' parallel appends created (as
+  flagged before either merged). Updated the paragraph below to stop saying
+  "once #106 merges" now that it has.
+
+## Live DEV + TEST evidence
+
+Required by the [Sprint Operating Model's "Sprint closing" policy](../../SPRINT-OPERATING-MODEL.md#sprint-closing--required-dev--test-evidence)
+(anchored 2026-08-15, mid-sprint, while PR #106 was in review) before this
+sprint can be called closed. Mirrors the structure of
+[sprint-002's "Live promotion evidence"](../sprint-002-insurance-foundation-promotion/STATUS.md#live-promotion-evidence)
+— one row per pipeline step, run links, and actual test-count evidence, not
+bare claims.
+
+**DEV evidence — stale, a fresh run is needed.** The most recent
+confirmed-green live DEV run is
+[31805085480](https://github.com/urruegg/CRMShowcase/actions/runs/31805085480)
+(2026-08-14, before the seed-pipeline PRs in this document): `validate`
+12m22s, `author` 9m13s, full offline suite green. That run predates
+PRs #101–#106 (claims/`crmshow_seedkey`/`Get-AccountKeyMap`/account
+upserts/seed+smoke pipeline steps), all of which are now merged to `main` —
+**a new dispatch is needed** to author anything still pending intake-export
+and to produce the first live evidence of the seed + smoke steps actually
+running (including observing the documented two-pass-convergence behavior).
+Not yet done.
+
+**TEST evidence — not started.** No promotion of this sprint's schema/data to
+TEST has been attempted. Sequentially blocked behind #64 (MDA app + custom
+pages) per this sprint's own dependency chain — TEST evidence only makes
+sense once there is a complete, DEV-verified surface to promote. Tracked as
+stream `e2e-verify` (#65) in the table above.
+
+**Reason TEST has not yet been reached (explicit, per the anchored policy —
+not a silent omission):** sprint-003's own remaining path is
+schema/seed-pipeline (this document) → MDA app + PCF ALM wrap (#64) → *then*
+DEV→TEST promotion (#65). TEST evidence is intentionally sequenced last, not
+skipped.

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/sprint.md
@@ -43,7 +43,7 @@ DESIGN-SENSITIVE streams run **attended**; EXECUTION-ONLY may run headless.
 | cockpit-tables (nba + provenance) | 3 | #58 | EXECUTION-ONLY | ✅ DEV-authored (2026-08-14, run 31805085480); source not yet intake-exported |
 | seed-pipeline wiring | 5.3 | #60 (follow-up) | EXECUTION-ONLY | ✅ code-complete (2026-08-14/15) — claims mapping, `crmshow_seedkey`, the `Get-AccountKeyMap` resolver, account upserts, and the CD-DEV pipeline step all done; not yet verified live; contacts/roles and policies deferred |
 | mda-app + custom pages | 9 | #64 | DESIGN-SENSITIVE | ⏳ in progress (attended) |
-| e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated |
+| e2e DEV→TEST verify | 10 | #65 | EXECUTION-ONLY | ⏳ DEV-gated — must produce a `## Live DEV + TEST evidence` section per the newly-anchored [Sprint Operating Model policy](../../SPRINT-OPERATING-MODEL.md#sprint-closing--required-dev--test-evidence) (2026-08-15) |
 | nba-agent (Copilot Studio) | 6 | #61 | DESIGN-SENSITIVE | ⏸ deferred (out of sprint) |
 
 #56 (foundation-choices, base + addendum) and #57/#58 (foundational + cockpit
@@ -249,4 +249,4 @@ expected to then seed claims successfully.
 - [x] #56 addendum choices + foundational/cockpit tables authored in DEV (#57/#58, run 31805085480, 2026-08-14) — intake-export into source control still pending.
 - [x] Seed wired into the CD pipeline with smoke (#60 follow-up / 5.3) — claims mapping, `crmshow_seedkey` schema, the `Get-AccountKeyMap` resolver, account upserts, and the CD-DEV pipeline step are all done (2026-08-14/15) — code-complete end-to-end; not yet verified against a live dispatch (expected to need 2 runs to fully converge a fresh environment, see above); contact/role seeding and policies mapping (status-value decision) remain separately deferred.
 - [ ] MDA app "Advisor Cockpit" + custom pages (#64) — both controls wrapped as real PCF + build-verified (2026-08-14); app module/sitemap + the 2 custom pages (Maker-Portal-only step) still pending.
-- [ ] E2E DEV→TEST evidence (#65).
+- [ ] E2E DEV→TEST evidence (#65) — per the [Sprint Operating Model's "Sprint closing"](../../SPRINT-OPERATING-MODEL.md#sprint-closing--required-dev--test-evidence) policy (anchored 2026-08-15): needs a `## Live DEV + TEST evidence` section in STATUS.md with (a) DEV run link + offline test pass/fail counts, and (b) a TEST promotion run link + step-by-step result table + TEST-side test/smoke counts, mirroring [sprint-002's promotion evidence](../sprint-002-insurance-foundation-promotion/STATUS.md). Not started — sequentially blocked behind #64 (MDA app).


### PR DESCRIPTION
## Summary

Prompted mid-sprint-003, while the seed-pipeline stream (PRs #101-#106) was in review: anchors DEV + TEST deployment evidence, with real test-result counts, as a required part of every sprint's closing - not just something sprint-002 happened to do once.

## What this adds

- New section in `docs/superpowers/SPRINT-OPERATING-MODEL.md`: "Sprint closing - required DEV + TEST evidence." Grounds this in ADR-0017's existing "rollback must be demonstrable, not described" position. Requires every sprint's `STATUS.md` to carry a `## Live DEV + TEST evidence` section with:
  1. DEV evidence - pipeline run link + offline test pass/fail counts (the actual numbers, not a bare "CI is green" claim).
  2. TEST evidence - promotion run link + step-by-step result table (mirroring sprint-002's "Live promotion evidence") + TEST-side test/smoke counts.
  3. If a sprint genuinely doesn't reach TEST, an explicit stated reason - never a silent omission.
- Updated `.github/ISSUE_TEMPLATE/sprint-charter.md`'s Definition of Done checklist so every new sprint charter carries this from creation, rather than relying on someone remembering to add it.
- Applied the anchor to sprint-003 itself (the sprint in flight when this was raised): strengthened the `#65` (E2E DEV to TEST verify) DoD line and stream-table row to reference the new policy explicitly, and added a `## Live DEV + TEST evidence` section to its `STATUS.md` with current, honest state:
  - DEV evidence: partial/stale (most recent green run predates PRs #101-#106; a fresh dispatch is needed once #106 merges).
  - TEST evidence: not started, explicitly sequenced behind `#64` (MDA app) per the sprint's own dependency chain - stated as a reason, not left as a silent gap.

## Scope note

Deliberately kept on a separate branch from the still-open PR #106 (pipeline wiring) rather than bundling them - different concerns (policy documentation vs. pipeline code), and this PR only touches `sprint.md`/`STATUS.md` lines that #106 does not touch (the `#65` stream, not the `#60`/5.3 stream), so there's no merge-order conflict risk either way.

No code changes. Not self-merging.