### PR TITLE
feat(sprint-003): Advisor Cockpit MDA app publisher (#64)

### DIFF
--- a/.github/workflows/cd-solution-dev.yml
+++ b/.github/workflows/cd-solution-dev.yml
@@ -171,6 +171,18 @@ jobs:
           }
           Write-Output 'Smoke check passed: measure-snapshot records present.'
 
+      - name: Publish Advisor Cockpit app
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          . (Join-Path $root 'scripts/solution/publish-advisor-cockpit-app.ps1')
+          $publisherId = (az rest --method GET --url "$env:POWER_PLATFORM_ENV_URL/api/data/v9.2/publishers?`$select=publisherid&`$filter=uniquename eq 'urruegg'" --resource "$env:POWER_PLATFORM_ENV_URL/" --only-show-errors | ConvertFrom-Json).value[0].publisherid
+          $roleId = (az rest --method GET --url "$env:POWER_PLATFORM_ENV_URL/api/data/v9.2/roles?`$select=roleid&`$filter=name eq 'CRM Showcase Insurance Reader'" --resource "$env:POWER_PLATFORM_ENV_URL/" --only-show-errors | ConvertFrom-Json).value[0].roleid
+          if (-not $publisherId) { throw "Publisher 'urruegg' not found in $env:POWER_PLATFORM_ENV_URL -- cannot resolve appmodule.publisherid@odata.bind." }
+          if (-not $roleId) { throw "Security role 'CRM Showcase Insurance Reader' not found in $env:POWER_PLATFORM_ENV_URL -- cannot associate it with the app." }
+          Invoke-AdvisorCockpitAppPublish -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL -PublisherId $publisherId -RoleIds @{ 'CRM Showcase Insurance Reader' = $roleId } -Confirm:$false
+          if ($LASTEXITCODE -ne 0) { throw 'Advisor Cockpit app publish failed.' }
+
       - name: Export managed and unmanaged solutions
         shell: pwsh
         run: |

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -583,6 +583,29 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     marker is left in the test file itself at the point of the fixture).
   - 6/6 Pester green on `PublishAdvisorCockpitApp.Tests.ps1`. Continuing
     with Tasks 6–10 next.
+  - **Tasks 6, 7, 8** (component-type lookup + `Get-CustomPageIdMap`;
+    idempotent `AddAppComponents` builder; idempotent role-association
+    builder) done and reviewed, no deviations — plan matched cleanly.
+    10/10 → 13/13 → 16/16 Pester green.
+  - **Task 9** (`Invoke-AdvisorCockpitAppRequest` wrapper +
+    `Invoke-AdvisorCockpitAppPublish` orchestrator) done, with the same
+    contract-placeholder deviation as Task 5 (mocks
+    `Get-AdvisorCockpitAppContract` itself, substituting only
+    `clientType`/`formFactor` test doubles, to exercise the real
+    orchestration call sequence ahead of Task 1 landing). Code review
+    independently confirmed (Microsoft Learn fetches, not just asserted)
+    **two real Web API protocol bugs copied from the plan's own example
+    code**, both fixed same-session: (1) `If-Match: *` on the upsert PATCH
+    calls forces update-only semantics — would 404 instead of create on a
+    fresh environment's first run, defeating the script's whole idempotent-
+    upsert purpose; removed. (2) `Get-AppRoleAssociationRequests`'s
+    `@odata.id` was a bare relative segment (`roles(...)`) — Dataverse
+    requires an absolute URL for any associate/`$ref` body; added a
+    `-BaseUrl` parameter and tightened the test assertion from a loose
+    `-Match` to an exact `-Be`. Both bugs were invisible to the mocked
+    Pester suite by design (it never talks to a real server) — recorded in
+    repo memory as a general Dataverse Web API lesson. 20/20 → 21/21
+    Pester green.
 
 ## Live DEV + TEST evidence
 

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -545,6 +545,45 @@ Live status for the Advisor Cockpit (charter **#55**). See the
   flagged before either merged). Updated the paragraph below to stop saying
   "once #106 merges" now that it has.
 
+- **2026-08-15 (MDA app publisher, Tasks 1–5 of the implementation plan;
+  `feat/s3-mda-app-publish`, not yet pushed/PR'd) -** Executing
+  [PR #109's plan](../../plans/2026-08-15-advisor-cockpit-mda-app.md) via the
+  subagent-driven-development workflow (implementer → spec-reviewer →
+  code-quality-reviewer per task).
+  - **Task 1 (live Dataverse research spike): blocked, deferred.** `az rest`
+    against `crmshowdev` fails with `Unauthorized`/"Interactive
+    authentication is needed" even after a fresh
+    `az login --use-device-code` re-auth (confirmed correct tenant/account
+    via `az account show`) — `pac org who` connects fine, isolating the
+    problem to how `az` (not `pac`) authenticates against this specific
+    Dataverse resource, not a simple stale-token issue. Root cause not
+    found; not re-attempting further login variations without new
+    information.
+  - **Task 2** (`Get-AdvisorCockpitAppContract` + contract JSON) and
+    **Task 4** (`ConvertTo-SitemapUpsertBody`, including an XML-escaping bug
+    the plan's own example code had — found via spec review, fixed with
+    `[System.Security.SecurityElement]::Escape()` + an adversarial test)
+    are done and reviewed.
+  - **Task 5** (`ConvertTo-AppModuleUpsertBody`) is done and reviewed, with
+    one deliberate, reviewed deviation from the plan's literal test: the
+    contract's `appModule.clientType`/`appModule.formFactor` are still the
+    `"<CONFIRM-IN-TASK-1>"` placeholder (Task 1 above is blocked), and these
+    two values are **not** inline-documented in the public Web API
+    reference the way e.g. `navigationtype` is (confirmed by checking the
+    `appmodule` EntityType page directly), so they cannot be resolved
+    without either live introspection or guessing — and per this repo's
+    "never invent a number" rule, guessing was not an option. `[int]"<CONFIRM-IN-TASK-1>"`
+    throws a cast exception, so the test now uses a synthetic
+    `[pscustomobject]` fixture (arbitrary `clientType`/`formFactor` test
+    doubles, clearly commented as such) instead of the real contract, to
+    exercise the mapping logic without depending on Task 1's still-unknown
+    values. **Follow-up, not yet done:** once Task 1 unblocks and the real
+    values are confirmed, swap this test back to consuming
+    `Get-AdvisorCockpitAppContract`'s real `appModule` output (a `TODO`
+    marker is left in the test file itself at the point of the fixture).
+  - 6/6 Pester green on `PublishAdvisorCockpitApp.Tests.ps1`. Continuing
+    with Tasks 6–10 next.
+
 ## Live DEV + TEST evidence
 
 Required by the [Sprint Operating Model's "Sprint closing" policy](../../SPRINT-OPERATING-MODEL.md#sprint-closing--required-dev--test-evidence)

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -15,7 +15,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, #106 ✅ merged | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
-| mda-app | #64 | DESIGN-SENSITIVE | — | #100 (docs) | ⏳ in progress (attended) | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); app module + custom pages + sitemap not yet authored |
+| mda-app | #64 | DESIGN-SENSITIVE | feat/s3-mda-app-publish | #100 (docs), PR pending | ⏳ code-complete, PR pending | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); `publish-advisor-cockpit-app.ps1` now implements the sitemap/app-module/component/role reconciliation end to end (10/10 plan tasks, 21/21 Pester) and is wired into `cd-solution-dev.yml` — not yet merged, not yet live-dispatched; blocked on Task 1's `clientType`/`formFactor`/`CustomPage`-componenttype placeholders (az Dataverse auth issue) and the 2 custom pages' Maker-Portal creation |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
 
@@ -606,6 +606,33 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     Pester suite by design (it never talks to a real server) — recorded in
     repo memory as a general Dataverse Web API lesson. 20/20 → 21/21
     Pester green.
+  - **Task 10** (wire into `cd-solution-dev.yml`) done — a "Publish Advisor
+    Cockpit app" step added between "Smoke-check seeded demo data" and
+    "Export managed and unmanaged solutions", resolving the publisher
+    (`urruegg`) and security-role (`CRM Showcase Insurance Reader`) ids via
+    two ad-hoc `az rest` lookups, with explicit not-found guards (beyond
+    the plan's literal text) before calling `Invoke-AdvisorCockpitAppPublish`
+    — no new secrets/permissions, reuses the job's existing OIDC session.
+    **All 10 plan tasks are now code-complete** on `feat/s3-mda-app-publish`.
+  - **Final whole-branch review** (independent of the per-task reviews
+    above): 21/21 on this stream's own tests + full repo suite 359/359
+    passed, 0 failed, 2 skipped (the one known-hanging file,
+    `Test-InsuranceFoundationConvergence.Tests.ps1`, was run separately per
+    its own documented characteristic — confirmed untouched by this
+    branch's diff, zero incremental risk). No secrets, no injection risk,
+    scope clean (5 files, all stream-relevant). Verdict
+    APPROVED_WITH_FOLLOWUPS; non-blocking follow-ups noted for a future
+    pass: `ConvertTo-ComponentTypeValue`/`$script:ComponentTypeValues` is
+    dead code (superseded by `Get-ComponentODataEntity` in Task 7 — zero
+    runtime risk, just vestigial), the orchestrator function lacks the
+    file's otherwise-universal leading rationale comment, and the two new
+    ad-hoc `az rest` lookups in the YAML step don't `TrimEnd('/')` the env
+    URL like the neighboring smoke-check step does (low risk — the
+    orchestrator itself still normalizes this internally).
+  - **Not yet done:** pushing this branch and opening a PR (next step);
+    Task 1's live research spike remains blocked on the unresolved `az`
+    Dataverse auth issue; no live dispatch of the updated pipeline has been
+    attempted.
 
 ## Live DEV + TEST evidence
 

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -15,7 +15,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | foundational-tables | #57 | DESIGN-SENSITIVE | — | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | 5 tables incl. `crmshow_leadcluster`/`crmshow_claimprojection` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, #106 ✅ merged | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
-| mda-app | #64 | DESIGN-SENSITIVE | feat/s3-mda-app-publish | #100 (docs), PR pending | ⏳ code-complete, PR pending | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); `publish-advisor-cockpit-app.ps1` now implements the sitemap/app-module/component/role reconciliation end to end (10/10 plan tasks, 21/21 Pester) and is wired into `cd-solution-dev.yml` — not yet merged, not yet live-dispatched; blocked on Task 1's `clientType`/`formFactor`/`CustomPage`-componenttype placeholders (az Dataverse auth issue) and the 2 custom pages' Maker-Portal creation |
+| mda-app | #64 | DESIGN-SENSITIVE | feat/s3-mda-app-publish | #100 (docs), #110 | ⏳ #110 open, awaiting review | both PCF controls wrapped as real, build-verified PCF projects (AdvisorCockpit 259s/8.1MiB, SalesLeaderDashboard 74s/3.97MiB); `publish-advisor-cockpit-app.ps1` now implements the sitemap/app-module/component/role reconciliation end to end (10/10 plan tasks, 21/21 Pester) and is wired into `cd-solution-dev.yml` — not yet merged, not yet live-dispatched; blocked on Task 1's `clientType`/`formFactor`/`CustomPage`-componenttype placeholders (az Dataverse auth issue) and the 2 custom pages' Maker-Portal creation |
 | e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
 
@@ -633,6 +633,15 @@ Live status for the Advisor Cockpit (charter **#55**). See the
     Task 1's live research spike remains blocked on the unresolved `az`
     Dataverse auth issue; no live dispatch of the updated pipeline has been
     attempted.
+
+- **2026-08-15 (branch pushed, PR #110 opened) -** Rebased cleanly onto
+  `origin/main` (PR #109 had merged in the meantime; no conflicts — it only
+  added the plan doc, which this branch doesn't touch). Applied the
+  STATUS.md staleness fix the final review recommended (this paragraph +
+  the `mda-app` row above), then pushed `feat/s3-mda-app-publish` and
+  opened **PR #110**, with the two protocol-bug fixes, the known Task-1
+  limitations, and the non-blocking follow-ups all called out explicitly in
+  the PR description. Not self-merged — awaiting `gate1` CI + human review.
 
 ## Live DEV + TEST evidence
 

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -83,6 +83,28 @@ function ConvertTo-SitemapUpsertBody {
     }
 }
 
+# Maps the contract's appModule section to an appmodule upsert body.
+# PublisherId is resolved by the caller (a live lookup, not part of the
+# contract) since the publisher already exists for every other solution
+# component in this repo -- see Get-PublisherId.
+function ConvertTo-AppModuleUpsertBody {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $AppModule,
+        [Parameter(Mandatory)] [string]$PublisherId
+    )
+
+    [ordered]@{
+        name                        = [string]$AppModule.name
+        uniquename                  = [string]$AppModule.uniqueName
+        description                 = [string]$AppModule.description
+        clienttype                  = [int]$AppModule.clientType
+        formfactor                  = [int]$AppModule.formFactor
+        navigationtype              = [int]$AppModule.navigationType
+        'publisherid@odata.bind'    = "/publishers($PublisherId)"
+    }
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
         Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -217,7 +217,8 @@ function Get-AppRoleAssociationRequests {
         [Parameter(Mandatory)] [string[]]$SecurityRoles,
         [Parameter(Mandatory)] [System.Collections.IDictionary]$RoleIds,
         [string[]]$ExistingRoleIds = @(),
-        [Parameter(Mandatory)] [string]$AppId
+        [Parameter(Mandatory)] [string]$AppId,
+        [Parameter(Mandatory)] [string]$BaseUrl
     )
 
     foreach ($roleName in $SecurityRoles) {
@@ -231,7 +232,7 @@ function Get-AppRoleAssociationRequests {
         [pscustomobject]@{
             Method = 'POST'
             Path   = "/appmodules($AppId)/appmoduleroles_association/`$ref"
-            Body   = @{ '@odata.id' = "roles($roleId)" }
+            Body   = @{ '@odata.id' = "$BaseUrl/api/data/v9.2/roles($roleId)" }
         }
     }
 }
@@ -262,7 +263,6 @@ function Invoke-AdvisorCockpitAppRequest {
     try {
         ($Body | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $tmp -Encoding UTF8
         $headers = @('Content-Type=application/json')
-        if ($Method -eq 'PATCH') { $headers += 'If-Match=*' }
         az rest --method $Method --url $url --resource "$BaseUrl/" `
             --headers @headers --body "@$tmp" --only-show-errors | Out-Null
     }
@@ -309,7 +309,7 @@ function Invoke-AdvisorCockpitAppPublish {
     $existingRoles = (Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'GET' -Path "/appmodules($appId)/appmoduleroles_association?`$select=roleid").value
     $existingRoleIds = @($existingRoles | ForEach-Object { [string]$_.roleid })
 
-    foreach ($roleReq in @(Get-AppRoleAssociationRequests -SecurityRoles $contract.securityRoles -RoleIds $RoleIds -ExistingRoleIds $existingRoleIds -AppId $appId)) {
+    foreach ($roleReq in @(Get-AppRoleAssociationRequests -SecurityRoles $contract.securityRoles -RoleIds $RoleIds -ExistingRoleIds $existingRoleIds -AppId $appId -BaseUrl $baseUrl)) {
         Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method $roleReq.Method -Path $roleReq.Path -Body $roleReq.Body | Out-Null
     }
 

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -207,6 +207,35 @@ function Get-AppComponentAddRequests {
     }
 }
 
+# Builds one $ref associate request per contract security role not already
+# associated with the app. Uses the appmoduleroles_association navigation
+# property directly (POST .../$ref), the standard Web API pattern for
+# adding one member to an existing many-to-many relationship.
+function Get-AppRoleAssociationRequests {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string[]]$SecurityRoles,
+        [Parameter(Mandatory)] [System.Collections.IDictionary]$RoleIds,
+        [string[]]$ExistingRoleIds = @(),
+        [Parameter(Mandatory)] [string]$AppId
+    )
+
+    foreach ($roleName in $SecurityRoles) {
+        if (-not $RoleIds.Contains($roleName)) {
+            throw "No resolved role id for security role '$roleName'."
+        }
+        $roleId = $RoleIds[$roleName]
+        if ($ExistingRoleIds -contains $roleId) {
+            continue
+        }
+        [pscustomobject]@{
+            Method = 'POST'
+            Path   = "/appmodules($AppId)/appmoduleroles_association/`$ref"
+            Body   = @{ '@odata.id' = "roles($roleId)" }
+        }
+    }
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
         Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -56,11 +56,18 @@ function ConvertTo-SitemapUpsertBody {
     $areasXml = foreach ($area in @($Sitemap.areas)) {
         $groupsXml = foreach ($group in @($area.groups)) {
             $subAreasXml = foreach ($sub in @($group.subAreas)) {
-                "<SubArea Id=`"$($sub.id)`" Title=`"$($sub.title)`" Url=`"/main.aspx?pagetype=custom&name=$($sub.pageUniqueName)`" />"
+                $subId = [System.Security.SecurityElement]::Escape([string]$sub.id)
+                $subTitle = [System.Security.SecurityElement]::Escape([string]$sub.title)
+                $subPageUniqueName = [System.Security.SecurityElement]::Escape([string]$sub.pageUniqueName)
+                "<SubArea Id=`"$subId`" Title=`"$subTitle`" Url=`"/main.aspx?pagetype=custom&amp;name=$subPageUniqueName`" />"
             }
-            "<Group Id=`"$($group.id)`" Title=`"$($group.title)`">$($subAreasXml -join '')</Group>"
+            $groupId = [System.Security.SecurityElement]::Escape([string]$group.id)
+            $groupTitle = [System.Security.SecurityElement]::Escape([string]$group.title)
+            "<Group Id=`"$groupId`" Title=`"$groupTitle`">$($subAreasXml -join '')</Group>"
         }
-        "<Area Id=`"$($area.id)`" Title=`"$($area.title)`">$($groupsXml -join '')</Area>"
+        $areaId = [System.Security.SecurityElement]::Escape([string]$area.id)
+        $areaTitle = [System.Security.SecurityElement]::Escape([string]$area.title)
+        "<Area Id=`"$areaId`" Title=`"$areaTitle`">$($groupsXml -join '')</Area>"
     }
     $sitemapXml = "<SiteMap>$($areasXml -join '')</SiteMap>"
 

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -46,6 +46,36 @@ function Get-AdvisorCockpitAppContract {
     return $contract
 }
 
+# Maps the contract's sitemap section to a sitemap upsert body, generating
+# the raw Site Map XML from the structured areas/groups/subAreas -- so the
+# XML itself is never hand-maintained as a giant string in the contract.
+function ConvertTo-SitemapUpsertBody {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Sitemap)
+
+    $areasXml = foreach ($area in @($Sitemap.areas)) {
+        $groupsXml = foreach ($group in @($area.groups)) {
+            $subAreasXml = foreach ($sub in @($group.subAreas)) {
+                "<SubArea Id=`"$($sub.id)`" Title=`"$($sub.title)`" Url=`"/main.aspx?pagetype=custom&name=$($sub.pageUniqueName)`" />"
+            }
+            "<Group Id=`"$($group.id)`" Title=`"$($group.title)`">$($subAreasXml -join '')</Group>"
+        }
+        "<Area Id=`"$($area.id)`" Title=`"$($area.title)`">$($groupsXml -join '')</Area>"
+    }
+    $sitemapXml = "<SiteMap>$($areasXml -join '')</SiteMap>"
+
+    [ordered]@{
+        sitemapname             = [string]$Sitemap.name
+        sitemapnameunique       = [string]$Sitemap.uniqueName
+        sitemapxml              = $sitemapXml
+        isappaware              = [bool]$Sitemap.isAppAware
+        showhome                = [bool]$Sitemap.showHome
+        showpinned              = [bool]$Sitemap.showPinned
+        showrecents             = [bool]$Sitemap.showRecents
+        enablecollapsiblegroups = [bool]$Sitemap.enableCollapsibleGroups
+    }
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
         Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -105,6 +105,57 @@ function ConvertTo-AppModuleUpsertBody {
     }
 }
 
+# Confirmed appmodulecomponent.componenttype values (Microsoft Learn,
+# fetched 2026-08-15). CustomPage's value is filled in from Task 1's
+# empirical finding -- update the number below once confirmed; every other
+# value here is already documentation-confirmed.
+$script:ComponentTypeValues = @{
+    Entities = 1
+    Views    = 26
+    Forms    = 60
+    Sitemap  = 62
+    CustomPage = -1  # <CONFIRM-IN-TASK-1> -- replace -1 with the real value.
+}
+
+function ConvertTo-ComponentTypeValue {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Type)
+
+    if (-not $script:ComponentTypeValues.ContainsKey($Type)) {
+        throw "Unknown component type '$Type'. Known types: $($script:ComponentTypeValues.Keys -join ',')."
+    }
+    return $script:ComponentTypeValues[$Type]
+}
+
+# Resolves each of the given custom-page uniquenames to its live canvasapp
+# GUID. Throws immediately naming the missing page rather than silently
+# building an incomplete map -- a missing custom page means the Maker
+# Portal step (Task 1 Step 3 / design doc) has not happened yet for that
+# page, which the caller needs to know about explicitly.
+function Get-CustomPageIdMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$EnvironmentUrl,
+        [Parameter(Mandatory)] [string[]]$PageUniqueNames
+    )
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $filter = ($PageUniqueNames | ForEach-Object { "name eq '$_'" }) -join ' or '
+    $url = "$baseUrl/api/data/v9.2/canvasapps?`$select=canvasappid,name&`$filter=$filter"
+    $response = az rest --method GET --url $url --resource "$baseUrl/" --only-show-errors | ConvertFrom-Json
+
+    $map = [ordered]@{}
+    foreach ($page in @($response.value)) {
+        $map[[string]$page.name] = [string]$page.canvasappid
+    }
+    foreach ($expected in $PageUniqueNames) {
+        if (-not $map.Contains($expected)) {
+            throw "Custom page '$expected' does not exist yet in $EnvironmentUrl -- create it in the Maker Portal first (see the design doc's Approach A)."
+        }
+    }
+    return $map
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
         Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -272,9 +272,56 @@ function Invoke-AdvisorCockpitAppRequest {
     return $null
 }
 
+function Invoke-AdvisorCockpitAppPublish {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)] [string]$EnvironmentUrl,
+        [Parameter(Mandatory)] [string]$PublisherId,
+        [Parameter(Mandatory)] [System.Collections.IDictionary]$RoleIds
+    )
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $contract = Get-AdvisorCockpitAppContract -Path $script:ContractPath
+
+    $pageNames = @($contract.components | Where-Object { $_.referenceKind -eq 'pageUniqueName' } | ForEach-Object { $_.reference })
+    $pageIds = Get-CustomPageIdMap -EnvironmentUrl $baseUrl -PageUniqueNames $pageNames
+
+    $sitemapBody = ConvertTo-SitemapUpsertBody -Sitemap $contract.sitemap
+    Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'PATCH' -Path "/sitemaps(sitemapnameunique='$($contract.sitemap.uniqueName)')" -Body $sitemapBody | Out-Null
+
+    $appModuleBody = ConvertTo-AppModuleUpsertBody -AppModule $contract.appModule -PublisherId $PublisherId
+    Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'PATCH' -Path "/appmodules(uniquename='$($contract.appModule.uniqueName)')" -Body $appModuleBody | Out-Null
+
+    $appId = (Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'GET' -Path "/appmodules(uniquename='$($contract.appModule.uniqueName)')?`$select=appmoduleid").appmoduleid
+    $sitemapId = (Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'GET' -Path "/sitemaps(sitemapnameunique='$($contract.sitemap.uniqueName)')?`$select=sitemapid").sitemapid
+
+    $resolvedIds = [ordered]@{ $contract.sitemap.uniqueName = $sitemapId }
+    foreach ($key in $pageIds.Keys) { $resolvedIds[$key] = $pageIds[$key] }
+
+    $existingComponents = (Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'GET' -Path "/appmodulecomponents?`$select=objectid&`$filter=_appmoduleidunique_value eq $appId").value
+    $existingObjectIds = @($existingComponents | ForEach-Object { [string]$_.objectid })
+
+    $addRequest = Get-AppComponentAddRequests -Components $contract.components -ResolvedIds $resolvedIds -ExistingObjectIds $existingObjectIds -AppId $appId
+    if ($addRequest) {
+        Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'POST' -Path '/AddAppComponents' -Body $addRequest | Out-Null
+    }
+
+    $existingRoles = (Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'GET' -Path "/appmodules($appId)/appmoduleroles_association?`$select=roleid").value
+    $existingRoleIds = @($existingRoles | ForEach-Object { [string]$_.roleid })
+
+    foreach ($roleReq in @(Get-AppRoleAssociationRequests -SecurityRoles $contract.securityRoles -RoleIds $RoleIds -ExistingRoleIds $existingRoleIds -AppId $appId)) {
+        Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method $roleReq.Method -Path $roleReq.Path -Body $roleReq.Body | Out-Null
+    }
+
+    Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'POST' -Path "/appmodules($appId)/Microsoft.Dynamics.CRM.ValidateApp" -Body @{} | Out-Null
+    Invoke-AdvisorCockpitAppRequest -BaseUrl $baseUrl -Method 'POST' -Path '/PublishAllXml' -Body @{} | Out-Null
+
+    Write-Output "Advisor Cockpit app published: appmoduleid=$appId"
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
-        Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'
+        Write-Output 'Invoke-AdvisorCockpitAppPublish requires -PublisherId and -RoleIds; call it directly once those are resolved for your environment.'
     }
     else {
         $contract = Get-AdvisorCockpitAppContract -Path $script:ContractPath

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -156,6 +156,57 @@ function Get-CustomPageIdMap {
     return $map
 }
 
+# Maps a contract component to its @odata.type + id property name, since
+# the AddAppComponents payload shape differs per entity type.
+function Get-ComponentODataEntity {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Type)
+
+    switch ($Type) {
+        'Sitemap'    { return @{ ODataType = 'Microsoft.Dynamics.CRM.sitemap'; IdProperty = 'sitemapid' } }
+        'CustomPage' { return @{ ODataType = 'Microsoft.Dynamics.CRM.canvasapp'; IdProperty = 'canvasappid' } }
+        default      { throw "No AddAppComponents entity mapping for component type '$Type'." }
+    }
+}
+
+# Builds the AddAppComponents request body for every contract component not
+# already present in $ExistingObjectIds (idempotent -- re-running this after
+# a partial success only adds what's missing). Returns $null when there is
+# nothing left to add, so the caller can skip the Web API call entirely.
+function Get-AppComponentAddRequests {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Components,
+        [Parameter(Mandatory)] [System.Collections.IDictionary]$ResolvedIds,
+        [string[]]$ExistingObjectIds = @(),
+        [Parameter(Mandatory)] [string]$AppId
+    )
+
+    $entries = foreach ($component in @($Components)) {
+        $resolvedId = $ResolvedIds[[string]$component.reference]
+        if (-not $resolvedId) {
+            throw "No resolved id for component reference '$($component.reference)' (referenceKind '$($component.referenceKind)')."
+        }
+        if ($ExistingObjectIds -contains $resolvedId) {
+            continue
+        }
+        $entity = Get-ComponentODataEntity -Type $component.type
+        [ordered]@{
+            '@odata.type'    = $entity.ODataType
+            $entity.IdProperty = $resolvedId
+        }
+    }
+
+    if (@($entries).Count -eq 0) {
+        return $null
+    }
+
+    [pscustomobject]@{
+        AppId      = $AppId
+        Components = @($entries)
+    }
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
         Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -236,6 +236,42 @@ function Get-AppRoleAssociationRequests {
     }
 }
 
+# The only function that calls az directly. GET requests return the parsed
+# JSON response; mutating requests (PATCH/POST) write the body to a temp
+# file (avoids command-line length limits / quoting issues) and return
+# null. This single choke point is what every test in this file mocks,
+# instead of mocking az itself for each differently-shaped call.
+function Invoke-AdvisorCockpitAppRequest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)] [string]$BaseUrl,
+        [Parameter(Mandatory)] [string]$Method,
+        [Parameter(Mandatory)] [string]$Path,
+        $Body
+    )
+
+    $url = "$BaseUrl/api/data/v9.2$Path"
+    if ($Method -eq 'GET') {
+        $response = az rest --method GET --url $url --resource "$BaseUrl/" --only-show-errors
+        if ([string]::IsNullOrWhiteSpace($response)) { return $null }
+        return ($response | ConvertFrom-Json)
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($url, $Method)) { return $null }
+    $tmp = [System.IO.Path]::GetTempFileName()
+    try {
+        ($Body | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $tmp -Encoding UTF8
+        $headers = @('Content-Type=application/json')
+        if ($Method -eq 'PATCH') { $headers += 'If-Match=*' }
+        az rest --method $Method --url $url --resource "$BaseUrl/" `
+            --headers @headers --body "@$tmp" --only-show-errors | Out-Null
+    }
+    finally {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+    return $null
+}
+
 if ($MyInvocation.InvocationName -ne '.') {
     if ($EnvironmentUrl) {
         Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'

--- a/scripts/solution/publish-advisor-cockpit-app.ps1
+++ b/scripts/solution/publish-advisor-cockpit-app.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+    Authors the Advisor Cockpit Model-Driven App into a Dataverse environment.
+.DESCRIPTION
+    Reads solution/schema/advisor-cockpit-app.json and idempotently reconciles
+    the sitemap, app module, component attachments and security-role
+    association via the Dataverse Web API (az rest). Authentication is
+    acquired at runtime by `az rest` -- no connection strings.
+
+    The two custom pages this app hosts (crmshow_advisorcockpitpage,
+    crmshow_salesleaderdashboardpage) must already exist -- their canvas
+    content has no Web API/CLI authoring path (Maker Portal only, confirmed
+    Sprint 3). This script resolves them by uniquename via a live query
+    (Get-CustomPageIdMap), the same idiom already used for account
+    resolution in seed-advisor-cockpit.ps1.
+
+    Safe to dot-source for testing: the top-level parameters are
+    non-mandatory and the publish action runs only when the script is
+    invoked directly with an -EnvironmentUrl.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$EnvironmentUrl,
+    [string]$ContractPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $ContractPath) {
+    $ContractPath = (Resolve-Path (Join-Path $PSScriptRoot '../../solution/schema/advisor-cockpit-app.json')).Path
+}
+$script:ContractPath = $ContractPath
+
+# Loads the contract and throws a clear error naming the missing key, rather
+# than a generic PowerShell null-reference failure deeper in the script.
+function Get-AdvisorCockpitAppContract {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Path)
+
+    $contract = (Get-Content -LiteralPath $Path -Raw -Encoding UTF8) | ConvertFrom-Json
+    foreach ($required in @('sitemap', 'appModule', 'components', 'securityRoles')) {
+        if (-not $contract.PSObject.Properties.Name.Contains($required)) {
+            throw "Advisor Cockpit app contract is missing required key '$required'."
+        }
+    }
+    return $contract
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    if ($EnvironmentUrl) {
+        Write-Output 'Dry run scaffold -- publish orchestration lands in a later task.'
+    }
+    else {
+        $contract = Get-AdvisorCockpitAppContract -Path $script:ContractPath
+        Write-Output ("Contract loaded: app '{0}', {1} components, {2} security role(s)." -f $contract.appModule.name, @($contract.components).Count, @($contract.securityRoles).Count)
+    }
+}

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -106,4 +106,39 @@ Describe 'publish-advisor-cockpit-app' {
         { Get-CustomPageIdMap -EnvironmentUrl 'https://example.crm.dynamics.com' -PageUniqueNames @('crmshow_missingpage') } |
             Should -Throw '*crmshow_missingpage*'
     }
+
+    It 'builds an AddAppComponents request for every contract component not already attached' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $resolvedIds = @{
+            'crmshow_advisorcockpitsitemap'      = '44444444-4444-4444-4444-444444444444'
+            'crmshow_advisorcockpitpage'         = '22222222-2222-2222-2222-222222222222'
+            'crmshow_salesleaderdashboardpage'   = '33333333-3333-3333-3333-333333333333'
+        }
+        $req = Get-AppComponentAddRequests -Components $contract.components -ResolvedIds $resolvedIds -ExistingObjectIds @() -AppId '55555555-5555-5555-5555-555555555555'
+        $req.AppId | Should -Be '55555555-5555-5555-5555-555555555555'
+        @($req.Components).Count | Should -Be 3
+        ($req.Components | Where-Object { $_.sitemapid -eq '44444444-4444-4444-4444-444444444444' }).'@odata.type' | Should -Be 'Microsoft.Dynamics.CRM.sitemap'
+    }
+
+    It 'excludes components already attached to the app' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $resolvedIds = @{
+            'crmshow_advisorcockpitsitemap'      = '44444444-4444-4444-4444-444444444444'
+            'crmshow_advisorcockpitpage'         = '22222222-2222-2222-2222-222222222222'
+            'crmshow_salesleaderdashboardpage'   = '33333333-3333-3333-3333-333333333333'
+        }
+        $req = Get-AppComponentAddRequests -Components $contract.components -ResolvedIds $resolvedIds -ExistingObjectIds @('44444444-4444-4444-4444-444444444444') -AppId '55555555-5555-5555-5555-555555555555'
+        @($req.Components).Count | Should -Be 2
+    }
+
+    It 'returns a null AddAppComponents request when every component is already attached' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $resolvedIds = @{
+            'crmshow_advisorcockpitsitemap'      = '44444444-4444-4444-4444-444444444444'
+            'crmshow_advisorcockpitpage'         = '22222222-2222-2222-2222-222222222222'
+            'crmshow_salesleaderdashboardpage'   = '33333333-3333-3333-3333-333333333333'
+        }
+        $req = Get-AppComponentAddRequests -Components $contract.components -ResolvedIds $resolvedIds -ExistingObjectIds @('44444444-4444-4444-4444-444444444444', '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333') -AppId '55555555-5555-5555-5555-555555555555'
+        $req | Should -BeNullOrEmpty
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -141,4 +141,23 @@ Describe 'publish-advisor-cockpit-app' {
         $req = Get-AppComponentAddRequests -Components $contract.components -ResolvedIds $resolvedIds -ExistingObjectIds @('44444444-4444-4444-4444-444444444444', '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333') -AppId '55555555-5555-5555-5555-555555555555'
         $req | Should -BeNullOrEmpty
     }
+
+    It 'builds an associate request for each contract security role not already associated' {
+        $roleIds = @{ 'CRM Showcase Insurance Reader' = '66666666-6666-6666-6666-666666666666' }
+        $reqs = @(Get-AppRoleAssociationRequests -SecurityRoles @('CRM Showcase Insurance Reader') -RoleIds $roleIds -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555')
+        $reqs.Count | Should -Be 1
+        $reqs[0].Path | Should -Be "/appmodules(55555555-5555-5555-5555-555555555555)/appmoduleroles_association/`$ref"
+        $reqs[0].Body.'@odata.id' | Should -Match 'roles\(66666666-6666-6666-6666-666666666666\)'
+    }
+
+    It 'skips a role that is already associated' {
+        $roleIds = @{ 'CRM Showcase Insurance Reader' = '66666666-6666-6666-6666-666666666666' }
+        $reqs = @(Get-AppRoleAssociationRequests -SecurityRoles @('CRM Showcase Insurance Reader') -RoleIds $roleIds -ExistingRoleIds @('66666666-6666-6666-6666-666666666666') -AppId '55555555-5555-5555-5555-555555555555')
+        $reqs.Count | Should -Be 0
+    }
+
+    It 'throws when a contract security role does not resolve to a live role id' {
+        { Get-AppRoleAssociationRequests -SecurityRoles @('Unknown Role') -RoleIds @{} -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555' } |
+            Should -Throw '*Unknown Role*'
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -160,4 +160,17 @@ Describe 'publish-advisor-cockpit-app' {
         { Get-AppRoleAssociationRequests -SecurityRoles @('Unknown Role') -RoleIds @{} -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555' } |
             Should -Throw '*Unknown Role*'
     }
+
+    It 'issues a GET and returns the parsed JSON response' {
+        Mock -CommandName az -MockWith { '{"appmoduleid":"55555555-5555-5555-5555-555555555555"}' }
+        $result = Invoke-AdvisorCockpitAppRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'GET' -Path "/appmodules(uniquename='crmshow_advisorcockpitapp')?`$select=appmoduleid"
+        $result.appmoduleid | Should -Be '55555555-5555-5555-5555-555555555555'
+    }
+
+    It 'issues a PATCH with a body and returns null' {
+        Mock -CommandName az -MockWith { $global:LASTEXITCODE = 0 }
+        $result = Invoke-AdvisorCockpitAppRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'PATCH' -Path "/sitemaps(sitemapnameunique='x')" -Body @{ sitemapname = 'x' }
+        $result | Should -BeNullOrEmpty
+        Should -Invoke -CommandName az -Times 1 -Exactly
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -144,20 +144,20 @@ Describe 'publish-advisor-cockpit-app' {
 
     It 'builds an associate request for each contract security role not already associated' {
         $roleIds = @{ 'CRM Showcase Insurance Reader' = '66666666-6666-6666-6666-666666666666' }
-        $reqs = @(Get-AppRoleAssociationRequests -SecurityRoles @('CRM Showcase Insurance Reader') -RoleIds $roleIds -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555')
+        $reqs = @(Get-AppRoleAssociationRequests -SecurityRoles @('CRM Showcase Insurance Reader') -RoleIds $roleIds -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555' -BaseUrl 'https://example.crm.dynamics.com')
         $reqs.Count | Should -Be 1
         $reqs[0].Path | Should -Be "/appmodules(55555555-5555-5555-5555-555555555555)/appmoduleroles_association/`$ref"
-        $reqs[0].Body.'@odata.id' | Should -Match 'roles\(66666666-6666-6666-6666-666666666666\)'
+        $reqs[0].Body.'@odata.id' | Should -Be 'https://example.crm.dynamics.com/api/data/v9.2/roles(66666666-6666-6666-6666-666666666666)'
     }
 
     It 'skips a role that is already associated' {
         $roleIds = @{ 'CRM Showcase Insurance Reader' = '66666666-6666-6666-6666-666666666666' }
-        $reqs = @(Get-AppRoleAssociationRequests -SecurityRoles @('CRM Showcase Insurance Reader') -RoleIds $roleIds -ExistingRoleIds @('66666666-6666-6666-6666-666666666666') -AppId '55555555-5555-5555-5555-555555555555')
+        $reqs = @(Get-AppRoleAssociationRequests -SecurityRoles @('CRM Showcase Insurance Reader') -RoleIds $roleIds -ExistingRoleIds @('66666666-6666-6666-6666-666666666666') -AppId '55555555-5555-5555-5555-555555555555' -BaseUrl 'https://example.crm.dynamics.com')
         $reqs.Count | Should -Be 0
     }
 
     It 'throws when a contract security role does not resolve to a live role id' {
-        { Get-AppRoleAssociationRequests -SecurityRoles @('Unknown Role') -RoleIds @{} -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555' } |
+        { Get-AppRoleAssociationRequests -SecurityRoles @('Unknown Role') -RoleIds @{} -ExistingRoleIds @() -AppId '55555555-5555-5555-5555-555555555555' -BaseUrl 'https://example.crm.dynamics.com' } |
             Should -Throw '*Unknown Role*'
     }
 
@@ -172,6 +172,16 @@ Describe 'publish-advisor-cockpit-app' {
         $result = Invoke-AdvisorCockpitAppRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'PATCH' -Path "/sitemaps(sitemapnameunique='x')" -Body @{ sitemapname = 'x' }
         $result | Should -BeNullOrEmpty
         Should -Invoke -CommandName az -Times 1 -Exactly
+    }
+
+    It 'does not send an If-Match header on PATCH, so upserts can still create a new record' {
+        # If-Match: * on an upsert PATCH forces Dataverse to reject creates with a
+        # 404 (Microsoft Learn, "Perform conditional operations using the Web API").
+        Mock -CommandName az -MockWith { $global:LASTEXITCODE = 0 }
+        Invoke-AdvisorCockpitAppRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'PATCH' -Path "/sitemaps(sitemapnameunique='x')" -Body @{ sitemapname = 'x' } | Out-Null
+        Should -Invoke -CommandName az -Times 1 -Exactly -ParameterFilter {
+            ($args -join ' ') -notmatch 'If-Match'
+        }
     }
 
     It 'publishes the sitemap, app module, components and role association end to end' {

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -31,4 +31,10 @@ Describe 'publish-advisor-cockpit-app' {
         $body.sitemapxml | Should -Match 'crmshow_salesleaderdashboardpage'
         $body.sitemapxml | Should -Match '<SiteMap>'
     }
+
+    It 'produces well-formed XML that a strict XML parser can load' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $body = ConvertTo-SitemapUpsertBody -Sitemap $contract.sitemap
+        { [xml]$body.sitemapxml } | Should -Not -Throw
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -173,4 +173,77 @@ Describe 'publish-advisor-cockpit-app' {
         $result | Should -BeNullOrEmpty
         Should -Invoke -CommandName az -Times 1 -Exactly
     }
+
+    It 'publishes the sitemap, app module, components and role association end to end' {
+        Mock -CommandName Get-AdvisorCockpitAppContract -MockWith {
+            # appModule.clientType/formFactor are still Task 1's unresolved
+            # "<CONFIRM-IN-TASK-1>" placeholders in the real contract file (the
+            # same known gap the ConvertTo-AppModuleUpsertBody test above works
+            # around with a synthetic fixture) -- read the real contract
+            # directly (not via the function under mock, to avoid recursing
+            # into this same mock) and substitute test doubles for just those
+            # two fields so the orchestrator can be exercised end to end ahead
+            # of Task 1 landing.
+            $contract = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+            $contract.appModule.clientType = 0
+            $contract.appModule.formFactor = 1
+            return $contract
+        }
+        Mock -CommandName Get-CustomPageIdMap -MockWith {
+            @{
+                'crmshow_advisorcockpitpage'       = '22222222-2222-2222-2222-222222222222'
+                'crmshow_salesleaderdashboardpage' = '33333333-3333-3333-3333-333333333333'
+            }
+        }
+        Mock -CommandName Invoke-AdvisorCockpitAppRequest -MockWith {
+            switch -Regex ($Path) {
+                "appmodules\(uniquename=" { return [pscustomobject]@{ appmoduleid = '55555555-5555-5555-5555-555555555555' } }
+                "sitemaps\(sitemapnameunique=" { return [pscustomobject]@{ sitemapid = '44444444-4444-4444-4444-444444444444' } }
+                '/appmodulecomponents'         { return [pscustomobject]@{ value = @() } }
+                'appmoduleroles_association'   { return [pscustomobject]@{ value = @() } }
+                default                        { return $null }
+            }
+        }
+
+        Invoke-AdvisorCockpitAppPublish -EnvironmentUrl 'https://example.crm.dynamics.com' -PublisherId '11111111-1111-1111-1111-111111111111' -RoleIds @{ 'CRM Showcase Insurance Reader' = '66666666-6666-6666-6666-666666666666' } -Confirm:$false
+
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Method -eq 'PATCH' -and $Path -match 'sitemaps' } -Times 1 -Exactly
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Method -eq 'PATCH' -and $Path -match 'appmodules' } -Times 1 -Exactly
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Method -eq 'POST' -and $Path -eq '/AddAppComponents' } -Times 1 -Exactly
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Method -eq 'POST' -and $Path -match 'appmoduleroles_association' } -Times 1 -Exactly
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Path -match 'ValidateApp' } -Times 1 -Exactly
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Path -eq '/PublishAllXml' } -Times 1 -Exactly
+    }
+
+    It 'skips AddAppComponents entirely when every component is already attached' {
+        Mock -CommandName Get-AdvisorCockpitAppContract -MockWith {
+            # See the previous test's comment: substitutes real-value test
+            # doubles for the still-unresolved Task 1 clientType/formFactor
+            # placeholders only; everything else comes from the real contract.
+            $contract = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+            $contract.appModule.clientType = 0
+            $contract.appModule.formFactor = 1
+            return $contract
+        }
+        Mock -CommandName Get-CustomPageIdMap -MockWith {
+            @{
+                'crmshow_advisorcockpitpage'       = '22222222-2222-2222-2222-222222222222'
+                'crmshow_salesleaderdashboardpage' = '33333333-3333-3333-3333-333333333333'
+            }
+        }
+        Mock -CommandName Invoke-AdvisorCockpitAppRequest -MockWith {
+            switch -Regex ($Path) {
+                "appmodules\(uniquename=" { return [pscustomobject]@{ appmoduleid = '55555555-5555-5555-5555-555555555555' } }
+                "sitemaps\(sitemapnameunique=" { return [pscustomobject]@{ sitemapid = '44444444-4444-4444-4444-444444444444' } }
+                '/appmodulecomponents'         { return [pscustomobject]@{ value = @(@{ objectid = '44444444-4444-4444-4444-444444444444' }, @{ objectid = '22222222-2222-2222-2222-222222222222' }, @{ objectid = '33333333-3333-3333-3333-333333333333' }) } }
+                'appmoduleroles_association'   { return [pscustomobject]@{ value = @(@{ roleid = '66666666-6666-6666-6666-666666666666' }) } }
+                default                        { return $null }
+            }
+        }
+
+        Invoke-AdvisorCockpitAppPublish -EnvironmentUrl 'https://example.crm.dynamics.com' -PublisherId '11111111-1111-1111-1111-111111111111' -RoleIds @{ 'CRM Showcase Insurance Reader' = '66666666-6666-6666-6666-666666666666' } -Confirm:$false
+
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Path -eq '/AddAppComponents' } -Times 0 -Exactly
+        Should -Invoke -CommandName Invoke-AdvisorCockpitAppRequest -ParameterFilter { $Method -eq 'POST' -and $Path -match 'appmoduleroles_association' } -Times 0 -Exactly
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -54,4 +54,28 @@ Describe 'publish-advisor-cockpit-app' {
         { [xml]$body.sitemapxml } | Should -Not -Throw
         $body.sitemapxml | Should -Match 'R&amp;D &lt;Ops&gt;'
     }
+
+    It 'converts an appModule object to an appmodule upsert body' {
+        # Synthetic fixture -- clientType/formFactor are arbitrary test doubles
+        # here, NOT confirmed real Dataverse values (those remain unresolved
+        # pending the blocked Task 1 research spike). The real contract still
+        # carries the "<CONFIRM-IN-TASK-1>" placeholder for both fields by
+        # design, so it cannot be used as this test's input.
+        $syntheticAppModule = [pscustomobject]@{
+            name           = 'Advisor Cockpit'
+            uniqueName     = 'crmshow_advisorcockpitapp'
+            description    = 'Sales advisory cockpit and leader dashboard for the CRM Showcase.'
+            clientType     = 0
+            formFactor     = 1
+            navigationType = 0
+        }
+        $body = ConvertTo-AppModuleUpsertBody -AppModule $syntheticAppModule -PublisherId '11111111-1111-1111-1111-111111111111'
+        $body.name | Should -Be 'Advisor Cockpit'
+        $body.uniquename | Should -Be 'crmshow_advisorcockpitapp'
+        $body.description | Should -Be 'Sales advisory cockpit and leader dashboard for the CRM Showcase.'
+        $body.clienttype | Should -Be 0
+        $body.formfactor | Should -Be 1
+        $body.navigationtype | Should -Be 0
+        $body.'publisherid@odata.bind' | Should -Be '/publishers(11111111-1111-1111-1111-111111111111)'
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -1,0 +1,23 @@
+# Pester tests for the Advisor Cockpit MDA app publisher (Sprint 3, #64).
+# The script is dot-sourced (non-mandatory params, auto-invoke guard), so no
+# Dataverse environment is touched by these tests.
+
+BeforeAll {
+    . "$PSScriptRoot/../publish-advisor-cockpit-app.ps1"
+}
+
+Describe 'publish-advisor-cockpit-app' {
+    It 'loads the contract and validates required top-level keys are present' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $contract.sitemap | Should -Not -BeNullOrEmpty
+        $contract.appModule | Should -Not -BeNullOrEmpty
+        $contract.components | Should -Not -BeNullOrEmpty
+        $contract.securityRoles | Should -Not -BeNullOrEmpty
+    }
+
+    It 'throws a clear error when a required top-level key is missing' {
+        $tmp = Join-Path $TestDrive 'bad-contract.json'
+        '{"sitemap": {}}' | Set-Content -LiteralPath $tmp -Encoding UTF8
+        { Get-AdvisorCockpitAppContract -Path $tmp } | Should -Throw '*appModule*'
+    }
+}

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -37,4 +37,21 @@ Describe 'publish-advisor-cockpit-app' {
         $body = ConvertTo-SitemapUpsertBody -Sitemap $contract.sitemap
         { [xml]$body.sitemapxml } | Should -Not -Throw
     }
+
+    It 'escapes XML-significant characters in dynamic sitemap values' {
+        $sitemap = [pscustomobject]@{
+            name = 'Test'; uniqueName = 'test'; isAppAware = $true
+            showHome = $false; showPinned = $false; showRecents = $false; enableCollapsibleGroups = $false
+            areas = @([pscustomobject]@{
+                id = 'a1'; title = 'R&D <Ops>'
+                groups = @([pscustomobject]@{
+                    id = 'g1'; title = 'Group "One"'
+                    subAreas = @([pscustomobject]@{ id = 's1'; title = "O'Brien"; pageUniqueName = 'pg1' })
+                })
+            })
+        }
+        $body = ConvertTo-SitemapUpsertBody -Sitemap $sitemap
+        { [xml]$body.sitemapxml } | Should -Not -Throw
+        $body.sitemapxml | Should -Match 'R&amp;D &lt;Ops&gt;'
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -61,6 +61,11 @@ Describe 'publish-advisor-cockpit-app' {
         # pending the blocked Task 1 research spike). The real contract still
         # carries the "<CONFIRM-IN-TASK-1>" placeholder for both fields by
         # design, so it cannot be used as this test's input.
+        # TODO(Task 1): once clientType/formFactor are confirmed and the
+        # placeholders in solution/schema/advisor-cockpit-app.json are
+        # replaced with real values, switch this test back to loading
+        # $contract.appModule via Get-AdvisorCockpitAppContract (see the
+        # sitemap tests above for the pattern) instead of this fixture.
         $syntheticAppModule = [pscustomobject]@{
             name           = 'Advisor Cockpit'
             uniqueName     = 'crmshow_advisorcockpitapp'

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -20,4 +20,15 @@ Describe 'publish-advisor-cockpit-app' {
         '{"sitemap": {}}' | Set-Content -LiteralPath $tmp -Encoding UTF8
         { Get-AdvisorCockpitAppContract -Path $tmp } | Should -Throw '*appModule*'
     }
+
+    It 'converts the contract sitemap section to a sitemapxml payload referencing both custom pages' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $body = ConvertTo-SitemapUpsertBody -Sitemap $contract.sitemap
+        $body.sitemapname | Should -Be 'Advisor Cockpit Sitemap'
+        $body.sitemapnameunique | Should -Be 'crmshow_advisorcockpitsitemap'
+        $body.isappaware | Should -BeTrue
+        $body.sitemapxml | Should -Match 'crmshow_advisorcockpitpage'
+        $body.sitemapxml | Should -Match 'crmshow_salesleaderdashboardpage'
+        $body.sitemapxml | Should -Match '<SiteMap>'
+    }
 }

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -83,4 +83,27 @@ Describe 'publish-advisor-cockpit-app' {
         $body.navigationtype | Should -Be 0
         $body.'publisherid@odata.bind' | Should -Be '/publishers(11111111-1111-1111-1111-111111111111)'
     }
+
+    It 'resolves a known component type label to its Dataverse numeric value' {
+        ConvertTo-ComponentTypeValue -Type 'Sitemap' | Should -Be 62
+    }
+
+    It 'throws on an unknown component type rather than guessing a value' {
+        { ConvertTo-ComponentTypeValue -Type 'Dashboard' } | Should -Throw '*Dashboard*'
+    }
+
+    It 'builds a custom-page uniquename to GUID map from a live canvasapps query' {
+        Mock -CommandName az -MockWith {
+            '{"value":[{"canvasappid":"22222222-2222-2222-2222-222222222222","name":"crmshow_advisorcockpitpage"},{"canvasappid":"33333333-3333-3333-3333-333333333333","name":"crmshow_salesleaderdashboardpage"}]}'
+        }
+        $map = Get-CustomPageIdMap -EnvironmentUrl 'https://example.crm.dynamics.com' -PageUniqueNames @('crmshow_advisorcockpitpage', 'crmshow_salesleaderdashboardpage')
+        $map['crmshow_advisorcockpitpage'] | Should -Be '22222222-2222-2222-2222-222222222222'
+        $map['crmshow_salesleaderdashboardpage'] | Should -Be '33333333-3333-3333-3333-333333333333'
+    }
+
+    It 'throws when a referenced custom page does not exist yet in the environment' {
+        Mock -CommandName az -MockWith { '{"value":[]}' }
+        { Get-CustomPageIdMap -EnvironmentUrl 'https://example.crm.dynamics.com' -PageUniqueNames @('crmshow_missingpage') } |
+            Should -Throw '*crmshow_missingpage*'
+    }
 }

--- a/solution/schema/advisor-cockpit-app.json
+++ b/solution/schema/advisor-cockpit-app.json
@@ -1,0 +1,46 @@
+{
+  "contractId": "crmshow.advisor-cockpit-app",
+  "version": "1.0.0",
+  "publisherUniqueName": "urruegg",
+  "sitemap": {
+    "uniqueName": "crmshow_advisorcockpitsitemap",
+    "name": "Advisor Cockpit Sitemap",
+    "isAppAware": true,
+    "showHome": false,
+    "showPinned": false,
+    "showRecents": false,
+    "enableCollapsibleGroups": false,
+    "areas": [
+      {
+        "id": "area_advisorcockpit",
+        "title": "Advisor Cockpit",
+        "groups": [
+          {
+            "id": "group_cockpit",
+            "title": "Cockpit",
+            "subAreas": [
+              { "id": "sub_advisorcockpit", "title": "Beratercockpit", "pageUniqueName": "crmshow_advisorcockpitpage" },
+              { "id": "sub_salesleaderdashboard", "title": "F\u00fchrungsdashboard", "pageUniqueName": "crmshow_salesleaderdashboardpage" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "appModule": {
+    "uniqueName": "crmshow_advisorcockpitapp",
+    "name": "Advisor Cockpit",
+    "description": "Sales advisory cockpit and leader dashboard for the CRM Showcase.",
+    "clientType": "<CONFIRM-IN-TASK-1>",
+    "formFactor": "<CONFIRM-IN-TASK-1>",
+    "navigationType": 0
+  },
+  "components": [
+    { "type": "Sitemap", "referenceKind": "sitemapUniqueName", "reference": "crmshow_advisorcockpitsitemap" },
+    { "type": "CustomPage", "referenceKind": "pageUniqueName", "reference": "crmshow_advisorcockpitpage" },
+    { "type": "CustomPage", "referenceKind": "pageUniqueName", "reference": "crmshow_salesleaderdashboardpage" }
+  ],
+  "securityRoles": [
+    "CRM Showcase Insurance Reader"
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the Advisor Cockpit MDA app publisher (stream #64) per the plan in PR #109: `scripts/solution/publish-advisor-cockpit-app.ps1` idempotently reconciles the sitemap, app module, component attachments, and security-role association for the Advisor Cockpit model-driven app via the Dataverse Web API, and wires it into `cd-solution-dev.yml`.

All 10 plan tasks are code-complete, built via the subagent-driven-development workflow (implementer -> spec-reviewer -> code-quality-reviewer per task), plus a final whole-branch review.

## What changed

- `solution/schema/advisor-cockpit-app.json` (new): contract describing the sitemap, app module, components (1 sitemap + 2 custom pages), and security role.
- `scripts/solution/publish-advisor-cockpit-app.ps1` (new): contract loader, sitemap/app-module upsert body builders, component-type lookup + live custom-page GUID resolver, idempotent `AddAppComponents`/role-association request builders, a single Dataverse request wrapper (`Invoke-AdvisorCockpitAppRequest`, the only function that calls `az`), and the `Invoke-AdvisorCockpitAppPublish` orchestrator.
- `scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1` (new): 21 Pester tests, all green.
- `.github/workflows/cd-solution-dev.yml`: new "Publish Advisor Cockpit app" step between the existing seed and export steps. No new secrets/permissions -- reuses the job's existing OIDC session.
- `docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md`: run-log + stream-table updates.

## Two real bugs found and fixed during review (not just style nits)

Both were copied from the plan's own example code, confirmed independently against Microsoft Learn (not just asserted), and are covered by regression tests:

1. **`If-Match: *` on upsert PATCH** would force update-only semantics (404 instead of create) on a fresh environment's first run -- defeating the script's whole idempotent-upsert purpose. Removed.
2. **Relative `@odata.id`** in the role-association `$ref` body (`roles(...)` instead of an absolute URL) -- Dataverse requires an absolute URL for any associate/`$ref` body. Fixed by adding a `-BaseUrl` parameter; tightened the test from a loose `-Match` to an exact `-Be`.

## Known, deliberate limitations

1. **Task 1 (live Dataverse research spike) remains blocked.** `az rest` auth against `crmshowdev` fails with `Unauthorized` even after a fresh `az login --use-device-code` re-auth (confirmed correct tenant/account) -- `pac org who` connects fine, isolating the problem to how `az` (not `pac`) authenticates against this specific resource. Root cause not found. As a result:
   - `appModule.clientType`/`appModule.formFactor` in `advisor-cockpit-app.json` remain explicit `"<CONFIRM-IN-TASK-1>"` placeholders (never guessed -- these aren't inline-documented in the public Web API reference the way e.g. `navigationtype` is).
   - The `CustomPage` entry in `$script:ComponentTypeValues` remains an explicit `-1` placeholder (currently dead code -- superseded by `Get-ComponentODataEntity`, zero runtime risk).
   - Two tests use a synthetic/mocked contract fixture instead of the real (placeholder-containing) one, clearly commented as such, with a `TODO` to swap back once Task 1 unblocks.
2. **No live dispatch has been attempted.** The new CD-DEV step has never run against real DEV. The two custom pages (`crmshow_advisorcockpitpage`, `crmshow_salesleaderdashboardpage`) must already exist via the Maker Portal (no Web API/CLI authoring path for canvas content) before a live run can succeed.

## Test evidence

- `PublishAdvisorCockpitApp.Tests.ps1`: **21/21 passed**.
- Full repo suite (`scripts/solution/tests`, 22 of 23 files -- the one known-slow/hanging file was run separately per its own documented characteristic and confirmed untouched by this diff): **359/359 passed, 0 failed, 2 skipped**.

## Non-blocking follow-ups (optional, not scoped by the plan)

- Remove or wire in the now-dead `ConvertTo-ComponentTypeValue`/`$script:ComponentTypeValues`.
- Add a leading rationale comment to `Invoke-AdvisorCockpitAppPublish` (the one function in the file without one).
- `TrimEnd('/')` the two new ad-hoc `az rest` lookup URLs in the YAML step, matching the neighboring smoke-check step's convention.

Not self-merging -- awaiting `gate1` CI + human review.