### PR TITLE
feat(sprint-003): solution-version sync + Advisor Cockpit app reconciliation (#64)

### DIFF
--- a/.github/workflows/cd-solution-dev.yml
+++ b/.github/workflows/cd-solution-dev.yml
@@ -183,6 +183,16 @@ jobs:
           Invoke-AdvisorCockpitAppPublish -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL -PublisherId $publisherId -RoleIds @{ 'CRM Showcase Insurance Reader' = $roleId } -Confirm:$false
           if ($LASTEXITCODE -ne 0) { throw 'Advisor Cockpit app publish failed.' }
 
+      - name: Sync solution versions to manifest.json
+        shell: pwsh
+        run: |
+          $root = $env:GITHUB_WORKSPACE
+          & (Join-Path $root 'scripts/solution/Set-SolutionVersions.ps1') `
+            -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL `
+            -Build $env:GITHUB_RUN_NUMBER `
+            -Confirm:$false
+          if ($LASTEXITCODE -ne 0) { throw 'Solution version sync failed.' }
+
       - name: Export managed and unmanaged solutions
         shell: pwsh
         run: |

--- a/docs/superpowers/specs/2026-08-15-generative-custom-page-captured-source.tsx
+++ b/docs/superpowers/specs/2026-08-15-generative-custom-page-captured-source.tsx
@@ -1,0 +1,174 @@
+// Captured 2026-08-15 from the "Code" tab of the AI-generated ("Describe your
+// page") Custom Page created for the Advisor Cockpit app in CRM Showcase - DEV
+// (environment 36c1c7c2-e090-e6a4-96e1-dd02ae894e0e, crmshow_Sales solution).
+// Prompt used: "advisorcockpitpage blank to be ready for github copilot to add
+// the PCF Control advisorcockpit".
+//
+// Preserved as primary evidence for the "Approach B" research question raised
+// in docs/superpowers/specs/2026-08-15-solution-versioning-and-mda-app-live-resolution-design.md
+// -- i.e. whether a Custom Page's content can be authored/deployed as source
+// (not just assembled via the Studio's Insert-component picker). NOT yet
+// verified whether this "Code" view is a two-way editable/exportable source
+// format or a read-only generated preview -- that remains the open question.
+//
+// Notable observations:
+// - Plain functional React component using @fluentui/react-components (the
+//   same Fluent v9 library this repo's own PCF controls already use).
+// - Uses Xrm.Utility.getGlobalContext() for language/RTL detection -- genuine
+//   model-driven-app client API integration, not a sandboxed preview.
+// - Uses a `dataApi.retrieveRow(...)` call (a code-custom-page-specific data
+//   API, distinct from a PCF control's own context.webAPI).
+// - The AI correctly left a blank content area for the PCF control rather
+//   than inventing unrelated business logic, per the prompt's intent.
+
+import React from "react";
+import { Text, makeStyles, mergeClasses, tokens } from "@fluentui/react-components";
+
+// Language map (module-level constant)
+const langMap: Record<number, { code: string; name: string; isRtl: boolean }> = {
+  1033: { code: "en-US", name: "English (United States)", isRtl: false },
+  1031: { code: "de-DE", name: "German (Germany)", isRtl: false },
+  1036: { code: "fr-FR", name: "French (France)", isRtl: false },
+  1040: { code: "it-IT", name: "Italian (Italy)", isRtl: false },
+};
+
+// Translations dictionary (module-level constant)
+const translations: Record<string, Record<string, string>> = {
+  "en-US": {
+    title: "Advisor Cockpit Page",
+    description: "This page is ready for GitHub Copilot to add the PCF Control advisorcockpit.",
+  },
+  "de-DE": {
+    title: "Berater Cockpit Seite",
+    description: "Diese Seite ist bereit für GitHub Copilot, um das PCF Control advisorcockpit hinzuzufügen.",
+  },
+  "fr-FR": {
+    title: "Page Cockpit Conseiller",
+    description: "Cette page est prête pour que GitHub Copilot ajoute le contrôle PCF advisorcockpit.",
+  },
+  "it-IT": {
+    title: "Pagina Cockpit Consulente",
+    description: "Questa pagina è pronta per GitHub Copilot per aggiungere il controllo PCF advisorcockpit.",
+  },
+};
+
+// Styling
+const useStyles = makeStyles({
+  root: {
+    flexGrow: 1,
+    alignSelf: "stretch",
+    width: "100%",
+    height: "100%",
+    minHeight: 0,
+    minWidth: 0,
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "column",
+    backgroundColor: tokens.colorNeutralBackground1,
+    padding: tokens.spacingVerticalXL,
+    gap: tokens.spacingVerticalL,
+  },
+  header: {
+    textAlign: "start",
+    marginBottom: tokens.spacingVerticalL,
+  },
+  description: {
+    color: tokens.colorNeutralForeground2,
+    fontSize: tokens.fontSizeBase400,
+    marginBottom: tokens.spacingVerticalL,
+  },
+  content: {
+    flex: 1,
+    minHeight: 0,
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRadius: tokens.borderRadiusLarge,
+    boxShadow: tokens.shadow4,
+    // Blank content area for PCF control
+  },
+});
+
+const GeneratedComponent = () => {
+  // Language detection
+  const language = React.useMemo(() => {
+    const uiLanguageId =
+      (typeof Xrm !== "undefined" &&
+        Xrm.Utility?.getGlobalContext()?.userSettings?.languageId) ||
+      1033;
+    return langMap[uiLanguageId]?.code || "en-US";
+  }, []);
+
+  // RTL detection
+  const isRTL = React.useMemo(() => {
+    const uiLanguageId =
+      (typeof Xrm !== "undefined" &&
+        Xrm.Utility?.getGlobalContext()?.userSettings?.languageId) ||
+      1033;
+    return langMap[uiLanguageId]?.isRtl || false;
+  }, []);
+
+  // Translation helper
+  const t = (key: string): string =>
+    translations[language]?.[key] || translations["en-US"]?.[key] || key;
+
+  // User settings fetch (for future formatting needs)
+  const [userSettings, setUserSettings] = React.useState<any>(null);
+  React.useEffect(() => {
+    const fetchUserSettings = async () => {
+      try {
+        const currentUserId =
+          (typeof Xrm !== "undefined" &&
+            Xrm.Utility?.getGlobalContext()?.userSettings?.userId)
+            ?.replace("{", "")
+            .replace("}", "");
+        if (!currentUserId) return;
+        // @ts-ignore dataApi is not available in blank page, but hook is ready for future use
+        if (typeof dataApi !== "undefined" && dataApi?.retrieveRow) {
+          const settings = await dataApi.retrieveRow("usersettings", {
+            id: currentUserId,
+            select: [
+              "uilanguageid",
+              "localeid",
+              "decimalsymbol",
+              "numberseparator",
+              "currencysymbol",
+              "dateformatstring",
+              "dateseparator",
+            ],
+          });
+          setUserSettings(settings);
+        }
+      } catch {
+        // Ignore errors in blank page
+      }
+    };
+    fetchUserSettings();
+  }, []);
+
+  const styles = useStyles();
+
+  return (
+    <div
+      dir={isRTL ? "rtl" : "ltr"}
+      style={{ direction: isRTL ? "rtl" : "ltr", height: "100%", width: "100%" }}
+      className={styles.root}
+    >
+      <header className={styles.header}>
+        <Text as="h1" size={700} weight="semibold" block>
+          {t("title")}
+        </Text>
+        <Text as="p" className={styles.description} block>
+          {t("description")}
+        </Text>
+      </header>
+      <main className={styles.content} aria-label={t("title")}>
+        {/* Blank content area for PCF Control advisorcockpit */}
+      </main>
+    </div>
+  );
+};
+
+export default GeneratedComponent;

--- a/docs/superpowers/specs/2026-08-15-solution-versioning-and-mda-app-live-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-15-solution-versioning-and-mda-app-live-resolution-design.md
@@ -1,0 +1,257 @@
+# Solution versioning sync + Advisor Cockpit app live-authoring resolution
+
+| Field | Value |
+| --- | --- |
+| **Status** | Draft — brainstormed live with the repo owner (real-time Q&A, not autonomous). Scope confirmed: both parts, in one pass. Owner confirmed comfortable with live CD-DEV dispatches as part of resolving this. |
+| **Date** | 2026-08-15 |
+| **Deciders** | Repo owner |
+| **Related** | [2026-08-15-advisor-cockpit-mda-app-design.md](./2026-08-15-advisor-cockpit-mda-app-design.md) (open question #3 already flagged the `clienttype`/`formfactor` research gap resolved here) · [2026-08-15-advisor-cockpit-mda-app.md](../plans/2026-08-15-advisor-cockpit-mda-app.md) (implementation plan, Task 1) · [sprint-003 charter](../sprints/sprint-003-advisor-cockpit/sprint.md) (stream `mda-app`, issue #64) · [ADR-0017](../../adr/ADR-0017-alm-everything-through-the-pipeline.md) |
+| **Licence** | 🧩 configuration / own build |
+| **Upgrade impact** | Additive — a new version-sync step + a contract data fix. No existing schema or component is renamed/removed. |
+| **Maturity** | Design only. No code changes in this document. |
+
+## Why this document exists
+
+The owner opened the DEV environment's Power Apps page and did not see the
+Advisor Cockpit app — despite PR #110 (the full 10-task MDA app publisher
+implementation) having merged to `main` earlier the same day. Asked to check
+the evidence and plan the resolution end to end.
+
+Investigation surfaced two distinct, confirmed problems — one explains the
+immediate symptom, the other is a separate, systemic gap the owner flagged as
+**critical** once found.
+
+## Evidence (gathered empirically, not inferred)
+
+### (A) Why the app isn't there
+
+- `gh run list --workflow cd-solution-dev.yml`: the most recent run is
+  `31805085480`, dated **2026-08-14** — before PR #110 merged
+  (**2026-08-15**). The pipeline has not run since the new "Publish Advisor
+  Cockpit app" step was added.
+- `pac solution export --name crmshow_Sales` (live DEV, `pac` auth confirmed
+  working via `pac org who` — this environment is `36c1c7c2-e090-e6a4-96e1-dd02ae894e0e`
+  / `crmshowdev.crm.dynamics.com`, the same one the owner linked): the
+  exported `customizations.xml` is completely empty — `<Entities></Entities>`,
+  no `AppModules` node at all.
+- **Conclusion: not a bug.** The code is correct and merged; it has simply
+  never been executed against DEV.
+
+### (B) Solution versions never reach Dataverse (owner: "this is critical")
+
+- `solution/manifest.json` declares `crmshow_Foundation` 1.1.0.0,
+  `crmshow_DataModel` 1.2.0.0, `crmshow_Sales` 1.1.0.0.
+- `pac solution list` (live DEV) shows **all three still at 1.0.0.0** —
+  confirmed independently via the exported `crmshow_Sales/solution.xml`'s
+  `<Version>1.0.0.0</Version>`.
+- `scripts/solution/Bump-Version.ps1` exists, has correct semver math, has
+  its own passing Pester suite — but a repo-wide grep shows it is **only
+  ever referenced by its own test file**. Neither `Publish-InsuranceFoundation.ps1`
+  nor `Export-InsuranceFoundationPackages.ps1` nor any GitHub Actions
+  workflow calls it, or touches a live solution's `version` attribute at all.
+- `solution/manifest.json`'s own `"versioning"` section already documents
+  the intended scheme: `"BUILD": "GitHub Actions run number
+  ($env:GITHUB_RUN_NUMBER); source of uniqueness"` — i.e. this was already
+  designed, just never wired into the pipeline.
+
+### A key unlock discovered while reasoning through the fix
+
+My **local** `az` CLI session has been broken all sprint (documented
+blocker on Task 1 of the MDA app plan). But CD-DEV's `author` job
+authenticates via a **completely different mechanism** — GitHub Actions OIDC
+via `azure/login` — which has been working reliably all sprint (it is what
+successfully authored tables, choices, and seed data live). **Task 1's
+remaining research does not require fixing my local `az` at all** — it can
+be resolved by a live CD-DEV-context query instead.
+
+### Also discovered: one of Task 1's two placeholders was never a real blocker
+
+The final code review of PR #110 already found that
+`ConvertTo-ComponentTypeValue` / `$script:ComponentTypeValues` (which holds
+the `CustomPage = -1` placeholder) is **dead code** — the real orchestrator
+resolves component attachment via `Get-ComponentODataEntity`, which maps
+`CustomPage` to an `@odata.type` string (`Microsoft.Dynamics.CRM.canvasapp`),
+never a numeric `componenttype`. So the **only** genuine remaining blocker
+for `Invoke-AdvisorCockpitAppPublish` to run without throwing is
+`appModule.clientType` / `appModule.formFactor` in
+`solution/schema/advisor-cockpit-app.json`.
+
+## Part B — Solution versioning sync
+
+### Approaches considered
+
+**Approach B1 — New standalone script, wired near the end of `cd-solution-dev.yml`'s `author` job (recommended)**
+
+A new `scripts/solution/Set-SolutionVersions.ps1`:
+
+1. Loads `solution/manifest.json` via the existing `Get-Manifest` function
+   (already validates shape/version format — no new parsing logic needed).
+2. For each declared solution: `GET /solutions?$select=solutionid,version&$filter=uniquename eq '<name>'`.
+3. Computes the target version via the existing `Bump-Version -Current <manifest version> -Kind build -Build $env:GITHUB_RUN_NUMBER` (keeps the PR author's declared MAJOR.MINOR.PATCH, stamps BUILD with the real CI run number — exactly what the manifest's own schema already documents as intended).
+4. `PATCH /solutions(id)` with the new version **only if it differs** from
+   the live value (idempotent, safe to run every time).
+5. Runs for **all 6 solutions** in the manifest, not just Sales — this is a
+   repo-wide gap, not an Advisor-Cockpit-specific one.
+
+Wired as a new step **right before** "Export managed and unmanaged
+solutions" — so it only fires once all authoring steps in that run have
+already succeeded (a version bump should mean "this run's changes are
+confirmed live", not "we attempted to apply changes"), and the exported
+package picks up the correct, current version.
+
+Testable offline via Pester using this repo's own established one-wrapper-
+function mocking pattern (a new, small `Invoke-DataverseRequest`-style
+wrapper local to this script, mocked in tests the same way
+`Publish-InsuranceFoundation.Tests.ps1` and `PublishAdvisorCockpitApp.Tests.ps1`
+already do).
+
+**Approach B2 — Fold version-sync into `Publish-InsuranceFoundation.ps1`**
+
+Trade-off: reuses that script's existing `Invoke-DataverseRequest` wrapper
+directly (no new wrapper needed) — but that script is scoped to the
+Foundation/DataModel domain (owner `AG-E-08`); versions for `Sales`/
+`Service`/`Marketing`/`Integration` (owned by `AG-E-01`/`AG-E-09`) don't
+naturally belong there. Would create an awkward cross-domain dependency.
+**Not recommended** for that reason.
+
+**Approach B3 — Stamp version only at export/package time, not authoring time**
+
+Post-process the exported zip's `solution.xml` during
+"Export managed and unmanaged solutions" instead of PATCHing the live
+solution first. Trade-off: fixes what the *exported artifact* claims, but
+**doesn't fix what the owner is actually looking at** — the live Maker
+Portal / `pac solution list` would still show 1.0.0.0. Given the concern is
+specifically about not being able to trust what's live, this alone doesn't
+address it. **Not recommended as the primary fix**, though it's worth
+confirming B1's live version bump is also reflected in exports (it will be,
+since export happens after B1's step in the same job).
+
+### Recommendation
+
+**B1.** Small, standalone, reuses two already-correct-and-tested building
+blocks (`Get-Manifest`, `Bump-Version`) that were simply never connected to
+anything, fixes the problem where the owner is actually looking (live
+Dataverse), and follows this repo's own established wrapper-function testing
+pattern.
+
+## Part A — Getting the Advisor Cockpit app live
+
+### Approaches considered
+
+**Approach A1 — Throwaway diagnostic dispatch, never merged (recommended)**
+
+A minimal workflow file on a throwaway branch (copy the `author` job's
+existing auth steps — `azure/login` + Power Platform CLI — from
+`cd-solution-dev.yml`, replace the actual authoring steps with 1-2 read-only
+`az rest` GETs against an existing app module, e.g. the native Sales Hub,
+for real `clienttype`/`formfactor` values). Dispatch once via
+`gh workflow run --ref <throwaway-branch>`, read the values from the job
+log, then discard the branch entirely. Zero permanent footprint in `main`.
+Mirrors this repo's own established practice of using throwaway,
+never-committed scripts for one-off empirical verification.
+
+**Approach A2 — Small, permanent diagnostic step**
+
+Same queries, but committed as a reusable (always-available, manually
+invoked) diagnostic step/script. Trade-off: slightly more permanent surface
+area for a one-time need; **not recommended** unless we expect to need this
+kind of live introspection again soon.
+
+**Approach A3 — Ask the owner to check Maker Portal UI manually**
+
+Since the owner already has the Apps page open, they could open an existing
+app (Sales Hub) and read its Client Type / Form Factor from the UI
+directly. Trade-off: zero engineering effort, but relies on the owner's own
+time and the UI may not expose the raw numeric values as cleanly as the Web
+API does. Offered as a fallback if A1 hits an unexpected snag.
+
+### Recommendation
+
+**A1**, with A3 as a fallback if the throwaway-dispatch approach runs into
+trouble. **Superseded in practice:** the owner manually created the app
+module directly (browser-shared session), giving real `clientType=4`/
+`formFactor=1` values without needing either A1 or A3 — see the Update log
+at the bottom of this document.
+
+### Addendum — code-based Custom Pages (captured evidence, not yet actioned)
+
+While verifying the custom page for this app, the owner used the "Describe
+your page" AI-assisted flow, which produced a genuine, readable React
+functional component (not a black-box artifact) using
+`@fluentui/react-components` — the same Fluent v9 library this repo's PCF
+controls already use — plus `Xrm.Utility.getGlobalContext()` and a
+`dataApi.retrieveRow(...)` call. Captured verbatim at
+[2026-08-15-generative-custom-page-captured-source.tsx](./2026-08-15-generative-custom-page-captured-source.tsx)
+as primary evidence for a **separate, later-stage research question**: can a
+Custom Page's content be authored/deployed as source (via GitHub Copilot,
+outside the browser Studio), rather than only assembled through the Insert-
+component picker? **Not yet verified** whether the "Code" tab is a two-way
+editable/exportable format or a read-only generated preview. Explicitly
+**not** pursued as part of closing out #64 — brainstormed and deliberately
+deferred as its own future spike, since #64's own path (embedding the
+already-built PCF control via the GA "Code components in custom pages"
+mechanism) is proven and nearly complete.
+
+### End-to-end sequence
+
+1. Implement + Pester-test Part B (`Set-SolutionVersions.ps1` + wiring).
+2. Dispatch the A1 throwaway diagnostic workflow; read confirmed
+   `clientType`/`formFactor` values from the job log.
+3. Update `solution/schema/advisor-cockpit-app.json`, replacing both
+   `"<CONFIRM-IN-TASK-1>"` placeholders with the confirmed values.
+4. Remove the now-confirmed-dead `ConvertTo-ComponentTypeValue` /
+   `$script:ComponentTypeValues` (`CustomPage = -1`) code and its two tests
+   from `publish-advisor-cockpit-app.ps1` — closes that follow-up from
+   PR #110's final review cleanly, since it's confirmed unreachable from the
+   real orchestrator path.
+5. Commit both fixes together (or as two small PRs — TBD in the
+   implementation plan), open PR(s), merge after review (never self-merge).
+6. Dispatch `cd-solution-dev.yml` against DEV for real.
+   - **If the 2 custom pages don't exist yet**: the run fails cleanly inside
+     `Get-CustomPageIdMap`, naming exactly which page is missing — this is
+     the one already-known, unavoidable manual step (Maker Portal has no
+     Web API/CLI path for canvas-page content). Owner creates them, then we
+     dispatch again.
+   - **If they already exist**: the app should be authored, versions synced,
+     done.
+7. Verify via a fresh `pac solution export` (or the Maker Portal Apps page
+   directly) that the app now appears and all 6 solution versions match
+   their manifest-declared values (build-stamped).
+
+## Non-negotiables carried into implementation
+
+- Never self-merge; `gate1` CI + human review, per the Sprint Operating
+  Model.
+- The throwaway diagnostic workflow (A1) is read-only (GET only) and is
+  never merged to `main`.
+- No number gets invented — `clientType`/`formFactor` come from a live,
+  confirmed query, not a guess; if the diagnostic query is inconclusive,
+  fall back to A3 (ask the owner) rather than guessing.
+- Version-sync (B1) never *decreases* a live version — the manifest is
+  always treated as the source of truth going forward for MAJOR.MINOR.PATCH.
+
+## Open questions
+
+1. **Does Part B need its own tracking issue?** It's a repo-wide ALM gap
+   discovered while investigating #64, not originally scoped to any
+   existing issue. Recommend opening a new issue (e.g. "Solution versions
+   never sync to live Dataverse") once this design is approved, rather than
+   overloading #64 with unrelated scope.
+2. **Should B1's version-sync step run unconditionally every CD-DEV run, or
+   only when something changed?** Recommendation in this doc is
+   unconditional (idempotent PATCH, no change-detection complexity) — flag
+   if a lighter-touch approach is preferred.
+
+## Definition of done for this design (not the implementation)
+
+- [x] Evidence gathered empirically (GitHub Actions run history, live
+      solution export, repo-wide grep for version-sync logic).
+- [x] Two problems clearly separated, scope confirmed live with the owner
+      ("both, in one pass").
+- [x] Live-dispatch comfort confirmed live with the owner ("yes please").
+- [x] Proposed approaches with trade-offs and a recommendation for both
+      parts.
+- [x] Key blocker re-assessed (`CustomPage` placeholder confirmed dead code,
+      not a real blocker) rather than left stale.
+- [ ] **Owner review of this document** — required before invoking
+      `writing-plans`, per the brainstorming skill's hard gate.

--- a/scripts/solution/Set-SolutionVersions.ps1
+++ b/scripts/solution/Set-SolutionVersions.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    Syncs each Dataverse solution declared in solution/manifest.json to its
+    manifest-declared version.
+.DESCRIPTION
+    Manifest.json declares a semver-four-part version per solution, but
+    nothing previously pushed that version to the live Dataverse solution
+    record -- every solution stayed at 1.0.0.0 regardless of what the
+    manifest said. This script closes that gap: for each declared solution,
+    it computes the target version as the manifest's MAJOR.MINOR.PATCH with
+    BUILD stamped from the live CI run number (Bump-Version -Kind build),
+    matching the convention manifest.json's own "versioning" section already
+    documents, and PATCHes the live solution only when the version differs.
+
+    Safe to dot-source for testing: the top-level parameters are
+    non-mandatory and the sync action runs only when the script is invoked
+    directly with an -EnvironmentUrl and -Build.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$EnvironmentUrl,
+    [string]$ManifestPath,
+    [int]$Build
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $ManifestPath) {
+    $ManifestPath = (Resolve-Path (Join-Path $PSScriptRoot '../../solution/manifest.json')).Path
+}
+$script:ManifestPath = $ManifestPath
+
+. (Join-Path $PSScriptRoot 'Get-Manifest.ps1')
+. (Join-Path $PSScriptRoot 'Bump-Version.ps1')
+
+# Pure function: given the manifest's declared solutions and a map of their
+# live { Id; Version }, returns only the solutions whose live version
+# doesn't already match the manifest-derived target -- so the caller can
+# skip a PATCH entirely when nothing changed. Throws immediately naming any
+# manifest-declared solution missing from $LiveSolutions, rather than
+# silently skipping it (a missing solution means something is fundamentally
+# wrong with the environment, not a "nothing to do" case).
+function Get-SolutionVersionUpdates {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Solutions,
+        [Parameter(Mandatory)] [System.Collections.IDictionary]$LiveSolutions,
+        [Parameter(Mandatory)] [int]$Build
+    )
+
+    foreach ($solution in @($Solutions)) {
+        $live = $LiveSolutions[[string]$solution.uniqueName]
+        if (-not $live) {
+            throw "Solution '$($solution.uniqueName)' not found live -- cannot sync its version."
+        }
+        $target = Bump-Version -Current $solution.version -Kind 'build' -Build $Build
+        if ($target -ne $live.Version) {
+            [pscustomobject]@{
+                UniqueName    = [string]$solution.uniqueName
+                SolutionId    = [string]$live.Id
+                TargetVersion = $target
+            }
+        }
+    }
+}
+
+# The only function that calls az directly. GET requests return the parsed
+# JSON response; mutating requests (PATCH) write the body to a temp file and
+# return null. This single choke point is what every test in this file
+# mocks, instead of mocking az itself for each differently-shaped call.
+function Invoke-SolutionVersionRequest {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)] [string]$BaseUrl,
+        [Parameter(Mandatory)] [string]$Method,
+        [Parameter(Mandatory)] [string]$Path,
+        $Body
+    )
+
+    $url = "$BaseUrl/api/data/v9.2$Path"
+    if ($Method -eq 'GET') {
+        $response = az rest --method GET --url $url --resource "$BaseUrl/" --only-show-errors
+        if ([string]::IsNullOrWhiteSpace($response)) { return $null }
+        return ($response | ConvertFrom-Json)
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($url, $Method)) { return $null }
+    $tmp = [System.IO.Path]::GetTempFileName()
+    try {
+        ($Body | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $tmp -Encoding UTF8
+        # No If-Match header -- this is a plain update (the solution always
+        # already exists), not an upsert that needs create/update guarding.
+        az rest --method $Method --url $url --resource "$BaseUrl/" `
+            --headers 'Content-Type=application/json' --body "@$tmp" --only-show-errors | Out-Null
+    }
+    finally {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+    return $null
+}
+
+function Invoke-SolutionVersionSync {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)] [string]$EnvironmentUrl,
+        [Parameter(Mandatory)] [int]$Build
+    )
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $manifest = Get-Manifest -Path $script:ManifestPath -Validate
+
+    $liveSolutions = [ordered]@{}
+    foreach ($solution in $manifest.solutions) {
+        $response = Invoke-SolutionVersionRequest -BaseUrl $baseUrl -Method 'GET' -Path "/solutions?`$select=solutionid,version,uniquename&`$filter=uniquename eq '$($solution.uniqueName)'"
+        if (@($response.value).Count -lt 1) {
+            throw "Solution '$($solution.uniqueName)' not found in $EnvironmentUrl -- cannot sync its version."
+        }
+        $record = $response.value[0]
+        $liveSolutions[[string]$solution.uniqueName] = @{ Id = [string]$record.solutionid; Version = [string]$record.version }
+    }
+
+    $updates = @(Get-SolutionVersionUpdates -Solutions $manifest.solutions -LiveSolutions $liveSolutions -Build $Build)
+    foreach ($update in $updates) {
+        Invoke-SolutionVersionRequest -BaseUrl $baseUrl -Method 'PATCH' -Path "/solutions($($update.SolutionId))" -Body @{ version = $update.TargetVersion } | Out-Null
+        Write-Output "Synced $($update.UniqueName): $($update.TargetVersion)"
+    }
+    if (@($updates).Count -eq 0) {
+        Write-Output 'All solution versions already match the manifest.'
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    if ($EnvironmentUrl -and $PSBoundParameters.ContainsKey('Build')) {
+        Invoke-SolutionVersionSync -EnvironmentUrl $EnvironmentUrl -Build $Build
+    }
+    else {
+        $manifest = Get-Manifest -Path $script:ManifestPath -Validate
+        Write-Output ("Manifest loaded: {0} solution(s) declared." -f @($manifest.solutions).Count)
+    }
+}

--- a/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+++ b/scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'publish-advisor-cockpit-app' {
         $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
         $body = ConvertTo-SitemapUpsertBody -Sitemap $contract.sitemap
         $body.sitemapname | Should -Be 'Advisor Cockpit Sitemap'
-        $body.sitemapnameunique | Should -Be 'crmshow_advisorcockpitsitemap'
+        $body.sitemapnameunique | Should -Be 'crmshow_AdvisorCockpit'
         $body.isappaware | Should -BeTrue
         $body.sitemapxml | Should -Match 'crmshow_advisorcockpitpage'
         $body.sitemapxml | Should -Match 'crmshow_salesleaderdashboardpage'
@@ -55,30 +55,13 @@ Describe 'publish-advisor-cockpit-app' {
         $body.sitemapxml | Should -Match 'R&amp;D &lt;Ops&gt;'
     }
 
-    It 'converts an appModule object to an appmodule upsert body' {
-        # Synthetic fixture -- clientType/formFactor are arbitrary test doubles
-        # here, NOT confirmed real Dataverse values (those remain unresolved
-        # pending the blocked Task 1 research spike). The real contract still
-        # carries the "<CONFIRM-IN-TASK-1>" placeholder for both fields by
-        # design, so it cannot be used as this test's input.
-        # TODO(Task 1): once clientType/formFactor are confirmed and the
-        # placeholders in solution/schema/advisor-cockpit-app.json are
-        # replaced with real values, switch this test back to loading
-        # $contract.appModule via Get-AdvisorCockpitAppContract (see the
-        # sitemap tests above for the pattern) instead of this fixture.
-        $syntheticAppModule = [pscustomobject]@{
-            name           = 'Advisor Cockpit'
-            uniqueName     = 'crmshow_advisorcockpitapp'
-            description    = 'Sales advisory cockpit and leader dashboard for the CRM Showcase.'
-            clientType     = 0
-            formFactor     = 1
-            navigationType = 0
-        }
-        $body = ConvertTo-AppModuleUpsertBody -AppModule $syntheticAppModule -PublisherId '11111111-1111-1111-1111-111111111111'
+    It 'converts the contract appModule section to an appmodule upsert body' {
+        $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
+        $body = ConvertTo-AppModuleUpsertBody -AppModule $contract.appModule -PublisherId '11111111-1111-1111-1111-111111111111'
         $body.name | Should -Be 'Advisor Cockpit'
-        $body.uniquename | Should -Be 'crmshow_advisorcockpitapp'
+        $body.uniquename | Should -Be 'crmshow_AdvisorCockpit'
         $body.description | Should -Be 'Sales advisory cockpit and leader dashboard for the CRM Showcase.'
-        $body.clienttype | Should -Be 0
+        $body.clienttype | Should -Be 4
         $body.formfactor | Should -Be 1
         $body.navigationtype | Should -Be 0
         $body.'publisherid@odata.bind' | Should -Be '/publishers(11111111-1111-1111-1111-111111111111)'
@@ -110,7 +93,7 @@ Describe 'publish-advisor-cockpit-app' {
     It 'builds an AddAppComponents request for every contract component not already attached' {
         $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
         $resolvedIds = @{
-            'crmshow_advisorcockpitsitemap'      = '44444444-4444-4444-4444-444444444444'
+            'crmshow_AdvisorCockpit'             = '44444444-4444-4444-4444-444444444444'
             'crmshow_advisorcockpitpage'         = '22222222-2222-2222-2222-222222222222'
             'crmshow_salesleaderdashboardpage'   = '33333333-3333-3333-3333-333333333333'
         }
@@ -123,7 +106,7 @@ Describe 'publish-advisor-cockpit-app' {
     It 'excludes components already attached to the app' {
         $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
         $resolvedIds = @{
-            'crmshow_advisorcockpitsitemap'      = '44444444-4444-4444-4444-444444444444'
+            'crmshow_AdvisorCockpit'             = '44444444-4444-4444-4444-444444444444'
             'crmshow_advisorcockpitpage'         = '22222222-2222-2222-2222-222222222222'
             'crmshow_salesleaderdashboardpage'   = '33333333-3333-3333-3333-333333333333'
         }
@@ -134,7 +117,7 @@ Describe 'publish-advisor-cockpit-app' {
     It 'returns a null AddAppComponents request when every component is already attached' {
         $contract = Get-AdvisorCockpitAppContract -Path (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json')
         $resolvedIds = @{
-            'crmshow_advisorcockpitsitemap'      = '44444444-4444-4444-4444-444444444444'
+            'crmshow_AdvisorCockpit'             = '44444444-4444-4444-4444-444444444444'
             'crmshow_advisorcockpitpage'         = '22222222-2222-2222-2222-222222222222'
             'crmshow_salesleaderdashboardpage'   = '33333333-3333-3333-3333-333333333333'
         }
@@ -185,20 +168,6 @@ Describe 'publish-advisor-cockpit-app' {
     }
 
     It 'publishes the sitemap, app module, components and role association end to end' {
-        Mock -CommandName Get-AdvisorCockpitAppContract -MockWith {
-            # appModule.clientType/formFactor are still Task 1's unresolved
-            # "<CONFIRM-IN-TASK-1>" placeholders in the real contract file (the
-            # same known gap the ConvertTo-AppModuleUpsertBody test above works
-            # around with a synthetic fixture) -- read the real contract
-            # directly (not via the function under mock, to avoid recursing
-            # into this same mock) and substitute test doubles for just those
-            # two fields so the orchestrator can be exercised end to end ahead
-            # of Task 1 landing.
-            $contract = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json') -Raw -Encoding UTF8 | ConvertFrom-Json
-            $contract.appModule.clientType = 0
-            $contract.appModule.formFactor = 1
-            return $contract
-        }
         Mock -CommandName Get-CustomPageIdMap -MockWith {
             @{
                 'crmshow_advisorcockpitpage'       = '22222222-2222-2222-2222-222222222222'
@@ -226,15 +195,6 @@ Describe 'publish-advisor-cockpit-app' {
     }
 
     It 'skips AddAppComponents entirely when every component is already attached' {
-        Mock -CommandName Get-AdvisorCockpitAppContract -MockWith {
-            # See the previous test's comment: substitutes real-value test
-            # doubles for the still-unresolved Task 1 clientType/formFactor
-            # placeholders only; everything else comes from the real contract.
-            $contract = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../../../solution/schema/advisor-cockpit-app.json') -Raw -Encoding UTF8 | ConvertFrom-Json
-            $contract.appModule.clientType = 0
-            $contract.appModule.formFactor = 1
-            return $contract
-        }
         Mock -CommandName Get-CustomPageIdMap -MockWith {
             @{
                 'crmshow_advisorcockpitpage'       = '22222222-2222-2222-2222-222222222222'

--- a/scripts/solution/tests/Set-SolutionVersions.Tests.ps1
+++ b/scripts/solution/tests/Set-SolutionVersions.Tests.ps1
@@ -1,0 +1,87 @@
+# Pester tests for the solution-version sync script (repo-wide ALM gap:
+# manifest.json declares versions that were never pushed to live Dataverse).
+# Dot-sourced (non-mandatory params, auto-invoke guard), so no Dataverse
+# environment is touched by these tests.
+
+BeforeAll {
+    . "$PSScriptRoot/../Set-SolutionVersions.ps1"
+}
+
+Describe 'Set-SolutionVersions' {
+    It 'loads the manifest and lists every declared solution' {
+        $manifest = Get-Manifest -Path (Join-Path $PSScriptRoot '../../../solution/manifest.json') -Validate
+        @($manifest.solutions).Count | Should -Be 6
+        ($manifest.solutions | Where-Object { $_.uniqueName -eq 'crmshow_Sales' }).version | Should -Be '1.1.0.0'
+    }
+
+    It 'computes target versions and only flags solutions whose live version differs' {
+        $solutions = @(
+            [pscustomobject]@{ uniqueName = 'crmshow_Foundation'; version = '1.1.0.0' }
+            [pscustomobject]@{ uniqueName = 'crmshow_Sales'; version = '1.1.0.0' }
+        )
+        $liveSolutions = @{
+            'crmshow_Foundation' = @{ Id = '11111111-1111-1111-1111-111111111111'; Version = '1.1.0.42' }
+            'crmshow_Sales'      = @{ Id = '22222222-2222-2222-2222-222222222222'; Version = '1.1.0.100' }
+        }
+        $updates = @(Get-SolutionVersionUpdates -Solutions $solutions -LiveSolutions $liveSolutions -Build 100)
+        @($updates).Count | Should -Be 1
+        $updates[0].UniqueName | Should -Be 'crmshow_Foundation'
+        $updates[0].SolutionId | Should -Be '11111111-1111-1111-1111-111111111111'
+        $updates[0].TargetVersion | Should -Be '1.1.0.100'
+    }
+
+    It 'returns no updates when every live version already matches the manifest-derived target' {
+        $solutions = @([pscustomobject]@{ uniqueName = 'crmshow_Sales'; version = '1.1.0.0' })
+        $liveSolutions = @{ 'crmshow_Sales' = @{ Id = '22222222-2222-2222-2222-222222222222'; Version = '1.1.0.100' } }
+        $updates = @(Get-SolutionVersionUpdates -Solutions $solutions -LiveSolutions $liveSolutions -Build 100)
+        $updates | Should -BeNullOrEmpty
+    }
+
+    It 'throws when a manifest-declared solution is not found live, rather than silently skipping it' {
+        $solutions = @([pscustomobject]@{ uniqueName = 'crmshow_Missing'; version = '1.0.0.0' })
+        { Get-SolutionVersionUpdates -Solutions $solutions -LiveSolutions @{} -Build 1 } | Should -Throw '*crmshow_Missing*'
+    }
+
+    It 'issues a GET and returns the parsed JSON response' {
+        Mock -CommandName az -MockWith { '{"value":[{"solutionid":"33333333-3333-3333-3333-333333333333","version":"1.0.0.0","uniquename":"crmshow_Sales"}]}' }
+        $result = Invoke-SolutionVersionRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'GET' -Path "/solutions?`$select=solutionid,version,uniquename&`$filter=uniquename eq 'crmshow_Sales'"
+        $result.value[0].solutionid | Should -Be '33333333-3333-3333-3333-333333333333'
+    }
+
+    It 'issues a PATCH with a body and returns null' {
+        Mock -CommandName az -MockWith { $global:LASTEXITCODE = 0 }
+        $result = Invoke-SolutionVersionRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'PATCH' -Path '/solutions(33333333-3333-3333-3333-333333333333)' -Body @{ version = '1.1.0.100' }
+        $result | Should -BeNullOrEmpty
+        Should -Invoke -CommandName az -Times 1 -Exactly
+    }
+
+    It 'does not send an If-Match header on PATCH, so the update is not accidentally blocked' {
+        Mock -CommandName az -MockWith { $global:LASTEXITCODE = 0 }
+        Invoke-SolutionVersionRequest -BaseUrl 'https://example.crm.dynamics.com' -Method 'PATCH' -Path '/solutions(33333333-3333-3333-3333-333333333333)' -Body @{ version = '1.1.0.100' } | Out-Null
+        Should -Invoke -CommandName az -Times 1 -Exactly -ParameterFilter {
+            ($args -join ' ') -notmatch 'If-Match'
+        }
+    }
+
+    It 'syncs every manifest solution end to end, updating only the ones that differ' {
+        Mock -CommandName Invoke-SolutionVersionRequest -MockWith {
+            switch -Regex ($Path) {
+                "uniquename eq 'crmshow_Foundation'"  { return [pscustomobject]@{ value = @(@{ solutionid = '11111111-1111-1111-1111-111111111111'; version = '1.0.9.5'; uniquename = 'crmshow_Foundation' }) } }
+                "uniquename eq 'crmshow_DataModel'"   { return [pscustomobject]@{ value = @(@{ solutionid = '22222222-2222-2222-2222-222222222222'; version = '1.2.0.100'; uniquename = 'crmshow_DataModel' }) } }
+                "uniquename eq 'crmshow_Integration'" { return [pscustomobject]@{ value = @(@{ solutionid = '33333333-3333-3333-3333-333333333333'; version = '1.0.0.0'; uniquename = 'crmshow_Integration' }) } }
+                "uniquename eq 'crmshow_Sales'"       { return [pscustomobject]@{ value = @(@{ solutionid = '44444444-4444-4444-4444-444444444444'; version = '1.0.0.0'; uniquename = 'crmshow_Sales' }) } }
+                "uniquename eq 'crmshow_Service'"     { return [pscustomobject]@{ value = @(@{ solutionid = '55555555-5555-5555-5555-555555555555'; version = '1.0.0.0'; uniquename = 'crmshow_Service' }) } }
+                "uniquename eq 'crmshow_Marketing'"   { return [pscustomobject]@{ value = @(@{ solutionid = '66666666-6666-6666-6666-666666666666'; version = '1.0.0.0'; uniquename = 'crmshow_Marketing' }) } }
+                default                                { return $null }
+            }
+        }
+
+        Invoke-SolutionVersionSync -EnvironmentUrl 'https://example.crm.dynamics.com' -Build 100 -Confirm:$false
+
+        # crmshow_DataModel already matches 1.2.0.100 -> no PATCH expected for it.
+        Should -Invoke -CommandName Invoke-SolutionVersionRequest -ParameterFilter { $Method -eq 'PATCH' -and $Path -eq '/solutions(22222222-2222-2222-2222-222222222222)' } -Times 0 -Exactly
+        # Every other manifest solution's live version differs -> PATCH expected for each.
+        Should -Invoke -CommandName Invoke-SolutionVersionRequest -ParameterFilter { $Method -eq 'PATCH' -and $Path -eq '/solutions(11111111-1111-1111-1111-111111111111)' -and $Body.version -eq '1.1.0.100' } -Times 1 -Exactly
+        Should -Invoke -CommandName Invoke-SolutionVersionRequest -ParameterFilter { $Method -eq 'PATCH' -and $Path -eq '/solutions(44444444-4444-4444-4444-444444444444)' -and $Body.version -eq '1.1.0.100' } -Times 1 -Exactly
+    }
+}

--- a/solution/schema/advisor-cockpit-app.json
+++ b/solution/schema/advisor-cockpit-app.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "publisherUniqueName": "urruegg",
   "sitemap": {
-    "uniqueName": "crmshow_advisorcockpitsitemap",
+    "uniqueName": "crmshow_AdvisorCockpit",
     "name": "Advisor Cockpit Sitemap",
     "isAppAware": true,
     "showHome": false,
@@ -28,15 +28,15 @@
     ]
   },
   "appModule": {
-    "uniqueName": "crmshow_advisorcockpitapp",
+    "uniqueName": "crmshow_AdvisorCockpit",
     "name": "Advisor Cockpit",
     "description": "Sales advisory cockpit and leader dashboard for the CRM Showcase.",
-    "clientType": "<CONFIRM-IN-TASK-1>",
-    "formFactor": "<CONFIRM-IN-TASK-1>",
+    "clientType": 4,
+    "formFactor": 1,
     "navigationType": 0
   },
   "components": [
-    { "type": "Sitemap", "referenceKind": "sitemapUniqueName", "reference": "crmshow_advisorcockpitsitemap" },
+    { "type": "Sitemap", "referenceKind": "sitemapUniqueName", "reference": "crmshow_AdvisorCockpit" },
     { "type": "CustomPage", "referenceKind": "pageUniqueName", "reference": "crmshow_advisorcockpitpage" },
     { "type": "CustomPage", "referenceKind": "pageUniqueName", "reference": "crmshow_salesleaderdashboardpage" }
   ],


### PR DESCRIPTION
## Summary  Resolves why the Advisor Cockpit app wasn't showing up in DEV Power Apps despite PR #110 merging, and fixes a related, repo-wide ALM gap the investigation surfaced. Brainstormed live with the owner (real-time Q&A) -- design doc at [docs/superpowers/specs/2026-08-15-solution-versioning-and-mda-app-live-resolution-design.md](docs/superpowers/specs/2026-08-15-solution-versioning-and-mda-app-live-resolution-design.md).  ## What changed  1. **Design doc + captured evidence** -- the two-problem investigation (CD-DEV hadn't run since before PR #110; solution versions never sync to Dataverse), plus a captured `.tsx` reference file (real React source from a generative Custom Page) for a deliberately-deferred follow-up research question. 2. **Contract reconciliation** (`solution/schema/advisor-cockpit-app.json`) -- the owner manually created the app module + sitemap in DEV while investigating (both named `crmshow_AdvisorCockpit`). Reconciles the contract to match instead of creating a duplicate, and fills in the now-confirmed real `clientType=4`/`formFactor=1` (read directly from that live app module) -- resolving Task 1's placeholder blocker with real data, not a guess. Reverts the two documented TODO test workarounds now that real values exist. 3. **`Set-SolutionVersions.ps1`** (new) -- for each solution in `manifest.json`, computes the target version as the manifest's `MAJOR.MINOR.PATCH` with `BUILD` stamped from the live CI run number (`Bump-Version -Kind build`, already-existing, already-tested, just never wired in), and PATCHes the live solution only when it differs. Wired into `cd-solution-dev.yml` right before the export step.  ## Why the versioning gap mattered  `manifest.json` declared `crmshow_Sales` at 1.1.0.0, `crmshow_DataModel` at 1.2.0.0, etc., but `pac solution list` against live DEV showed **all solutions stuck at 1.0.0.0** -- confirmed via a direct `pac solution export`. `Bump-Version.ps1` existed with correct semver math and its own tests, but a repo-wide grep showed it was only ever referenced by its own test file. This is now closed for all 6 manifest-declared solutions, not just this one app.  ## Test evidence  - `Set-SolutionVersions.Tests.ps1`: **8/8 passed**. - `PublishAdvisorCockpitApp.Tests.ps1`: **21/21 passed** (after the contract reconciliation). - Full repo suite (`scripts/solution/tests`, 23 of 24 files -- the one known-slow file excluded per its own documented characteristic): **367/367 passed, 0 failed, 2 skipped**. - YAML validated (`python -c "import yaml; ..."`).  ## Known, deliberate limitations  - The custom page itself (hosting the PCF control) is still being finished by the owner directly in Maker Portal -- not yet confirmed attached to the app/solution via a fresh `pac solution export`. - The "Approach B" research question (can Custom Page content be authored/deployed as source, not just via the Insert-component picker) is explicitly deferred, not attempted here -- captured as reference evidence only.  Not self-merging -- awaiting `gate1` CI + human review.