### PR TITLE
fix(sprint-003): shorten PCF control technical/display names (#64)

### DIFF
--- a/solution/apps/sales/Controls/AdvisorCockpit/pcf/AdvisorCockpit/ControlManifest.Input.xml
+++ b/solution/apps/sales/Controls/AdvisorCockpit/pcf/AdvisorCockpit/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="crmshow" constructor="AdvisorCockpit" version="1.0.1" display-name-key="AdvisorCockpit" description-key="Advisor Cockpit page-level dashboard (Sprint-003 #62/#64)" control-type="standard">
+  <control namespace="PCF" constructor="AdvisorCockpit" version="1.0.2" display-name-key="CRMShow_AdvisorCockpit" description-key="Advisor Cockpit page-level dashboard (Sprint-003 #62/#64)" control-type="standard">
     <!--
       Standard (not virtual) control-type: this control bundles its own React 18 +
       Fluent UI v9 runtime (see index.ts) instead of using the platform-provided

--- a/solution/apps/sales/Controls/SalesLeaderDashboard/pcf/SalesLeaderDashboard/ControlManifest.Input.xml
+++ b/solution/apps/sales/Controls/SalesLeaderDashboard/pcf/SalesLeaderDashboard/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="crmshow" constructor="SalesLeaderDashboard" version="1.0.0" display-name-key="SalesLeaderDashboard" description-key="Sales Leader Dashboard page-level dashboard (Sprint-003 #63/#64)" control-type="standard">
+  <control namespace="PCF" constructor="SalesLeaderDashboard" version="1.0.1" display-name-key="CRMShow_SalesLeaderDashboard" description-key="Sales Leader Dashboard page-level dashboard (Sprint-003 #63/#64)" control-type="standard">
     <!--
       Standard (not virtual) control-type: this control bundles its own React 18 +
       Fluent UI v9 runtime (see index.ts) instead of using the platform-provided


### PR DESCRIPTION
## Summary

Both `AdvisorCockpit` and `SalesLeaderDashboard` PCF controls had a redundant, hard-to-read technical name in Dataverse: `crmshow_crmshow.AdvisorCockpit` / `crmshow_crmshow.SalesLeaderDashboard`. This happened because each control's manifest `namespace` attribute was set to `crmshow`, duplicating the publisher's own customization prefix (also `crmshow`).

## What changed

Dataverse always names PCF controls as `<publisher-prefix>_<namespace>.<constructor>` — the dot between namespace and constructor is a hard platform constraint (confirmed via [Microsoft Learn](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/manifest-schema-reference/control) and empirical testing) and can't be changed to an underscore. The redundant `crmshow_crmshow` duplication, however, was avoidable.

Changed each manifest's `namespace` from `crmshow` to `PCF`:

| Before | After |
| --- | --- |
| `crmshow_crmshow.AdvisorCockpit` | `crmshow_PCF.AdvisorCockpit` |
| `crmshow_crmshow.SalesLeaderDashboard` | `crmshow_PCF.SalesLeaderDashboard` |

Also gave each control a distinct, readable **display name** (`CRMShow_AdvisorCockpit` / `CRMShow_SalesLeaderDashboard`, fully free-text and platform-unconstrained) instead of the bare constructor name, and bumped each manifest's patch version per the project's versioning convention for detecting control changes.

## Verification

- `pac pcf push --solution-unique-name crmshow_Sales` succeeded end-to-end for both controls (build → import → add-to-solution → publish, 0 errors).
- A fresh `pac solution export --name crmshow_Sales` confirms both new names are registered as real `<CustomControls>` components:
  ```xml
  <CustomControl>
    <Name>crmshow_PCF.SalesLeaderDashboard</Name>
  </CustomControl>
  <CustomControl>
    <Name>crmshow_PCF.AdvisorCockpit</Name>
  </CustomControl>
  ```

## Note — orphaned old controls

The old `crmshow_crmshow.AdvisorCockpit` / `crmshow_crmshow.SalesLeaderDashboard` custom controls remain in the DEV org as orphans — Dataverse treats a namespace change as a brand-new component, not a rename, so the old ones aren't automatically cleaned up. **Not removed in this PR** — deleting them from the live environment needs explicit confirmation first. Since neither control has been bound to any form/canvas app yet, this is low-risk to clean up whenever convenient.

## Related

- Sprint-003 #62/#64 (AdvisorCockpit), #63/#64 (SalesLeaderDashboard). Follows PR #114 (PCF import scaffolding fix).
