### PR TITLE
feat(sprint-003): extend cd-solution-test.yml to promote crmshow_Sales (#64, #65)

### DIFF
--- a/.github/workflows/cd-solution-test.yml
+++ b/.github/workflows/cd-solution-test.yml
@@ -58,8 +58,10 @@ jobs:
         run: |
           $out = Join-Path $env:RUNNER_TEMP 'promote'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
-          ./scripts/solution/Export-Solution.ps1 -SolutionName crmshow_Foundation -OutFile (Join-Path $out 'crmshow_Foundation_managed.zip') -Managed
-          ./scripts/solution/Export-Solution.ps1 -SolutionName crmshow_DataModel  -OutFile (Join-Path $out 'crmshow_DataModel_managed.zip')  -Managed
+          ./scripts/solution/Export-Solution.ps1 -SolutionName crmshow_Foundation  -OutFile (Join-Path $out 'crmshow_Foundation_managed.zip')  -Managed
+          ./scripts/solution/Export-Solution.ps1 -SolutionName crmshow_DataModel   -OutFile (Join-Path $out 'crmshow_DataModel_managed.zip')   -Managed
+          ./scripts/solution/Export-Solution.ps1 -SolutionName crmshow_Integration -OutFile (Join-Path $out 'crmshow_Integration_managed.zip') -Managed
+          ./scripts/solution/Export-Solution.ps1 -SolutionName crmshow_Sales       -OutFile (Join-Path $out 'crmshow_Sales_managed.zip')       -Managed
       - name: Assert excluded components are absent from the package
         shell: pwsh
         run: |
@@ -117,12 +119,15 @@ jobs:
         run: |
           & ./infra/scripts/Set-DataverseLanguages.ps1 -EnvironmentUrl $env:POWER_PLATFORM_ENV_URL -LocaleId 1033,1031,1036,1040
           if ($LASTEXITCODE -ne 0) { throw 'TEST language preflight failed.' }
-      - name: Import managed (Foundation then DataModel)
+      - name: Import managed (Foundation, DataModel, Integration, Sales)
         shell: pwsh
         run: |
+          # Import order follows solution/manifest.json dependsOn: Foundation <- DataModel/Integration <- Sales.
           $out = Join-Path $env:RUNNER_TEMP 'promote'
-          ./scripts/solution/Import-Solution.ps1 -ZipFile (Join-Path $out 'crmshow_Foundation_managed.zip') -Mode ${{ inputs.mode }} -PublishChanges
-          ./scripts/solution/Import-Solution.ps1 -ZipFile (Join-Path $out 'crmshow_DataModel_managed.zip')  -Mode ${{ inputs.mode }} -PublishChanges
+          ./scripts/solution/Import-Solution.ps1 -ZipFile (Join-Path $out 'crmshow_Foundation_managed.zip')  -Mode ${{ inputs.mode }} -PublishChanges
+          ./scripts/solution/Import-Solution.ps1 -ZipFile (Join-Path $out 'crmshow_DataModel_managed.zip')   -Mode ${{ inputs.mode }} -PublishChanges
+          ./scripts/solution/Import-Solution.ps1 -ZipFile (Join-Path $out 'crmshow_Integration_managed.zip') -Mode ${{ inputs.mode }} -PublishChanges
+          ./scripts/solution/Import-Solution.ps1 -ZipFile (Join-Path $out 'crmshow_Sales_managed.zip')       -Mode ${{ inputs.mode }} -PublishChanges
       - name: Smoke evidence
         shell: pwsh
         run: |


### PR DESCRIPTION
## What
Extends the `cd-solution-test.yml` DEV->TEST promotion pipeline to also promote `crmshow_Integration` and `crmshow_Sales`, not just `crmshow_Foundation`/`crmshow_DataModel`.

## Why
Per [solution/manifest.json](solution/manifest.json), `crmshow_Sales` (Advisor Cockpit MDA app + both PCF controls) `dependsOn` `crmshow_Foundation`, `crmshow_DataModel`, **and** `crmshow_Integration`. Only the first two were wired into the TEST promotion pipeline, so a TEST dispatch today would promote zero evidence of this sprint's actual surface. This was discovered while starting stream `e2e-verify` (#65), now that `mda-app` (#64) is complete.

## Changes
- `export-from-dev` job: export `crmshow_Integration` and `crmshow_Sales` (managed) alongside the existing two, reusing `Export-Solution.ps1` unchanged.
- `import-to-test` job: import all four in manifest `dependsOn` order (Foundation -> DataModel -> Integration -> Sales), reusing `Import-Solution.ps1` unchanged.
- No changes to the effective-date exclusion-contract check (Foundation/DataModel-specific; does not apply to Integration/Sales).
- No PowerShell script/test changes — this is a workflow-YAML-only change reusing existing generic scripts. Validated with a plain YAML parse.

## Story / traceability
US-story: #65 (e2e-verify), sprint-003 (#55). Builds on #64 (merged).

## Risk / rollout note
Not yet dispatched against live TEST. Per [docs/superpowers/plans/2026-08-11-advisor-cockpit.md](docs/superpowers/plans/2026-08-11-advisor-cockpit.md), dispatching this workflow requires approving the protected `test` GitHub Environment before the import job runs.