### PR TITLE
docs(sprint-003): record first TEST promotion evidence + Sales MCP-Server blocker (#65)

### DIFF
--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -43,17 +43,17 @@ Six principles keep the loop honest:
 | Principle | What it means for Contoso Insurance |
 | --- | --- |
 | Human-led | Advisors and named humans set direction, standards, priorities, and approvals ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md)). |
-| Agent-operated | Runtime and engineering agents handle analysis, structuring, proposals, drafts, and recurring operational work. |
+| Agent-operated | Runtime and engineering agents handle analysis, structuring, proposals, drafts, and recurring operational work (`AGENTS.md`). |
 | HITL-controlled | Critical steps stay under human control, with no exceptions ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md)). |
 | GitHub-driven | Every implementation-relevant requirement becomes traceable, versioned, and sprint-ready (`AGENTS.md` section 3). |
-| Dataverse-backed | Operational truth and outcome measurement live in Dataverse and Power Platform ([ADR-0008](../adr/ADR-0008-thin-crm-over-systems-of-record.md)). |
-| Teams/B2E-visible | Delivery status stays visible to employees through Teams and the B2E layer ([ADR-0033](../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md)). |
+| Dataverse-backed | Operational truth lives in Dataverse and Power Platform ([ADR-0008](../adr/ADR-0008-thin-crm-over-systems-of-record.md)). |
+| Teams/B2E-visible | Employees coordinate with customers, agents, and each other through Teams and the B2E UX layer ([ADR-0033](../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md)). |
 
 **Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 4 maps each loop stage onto this repo's existing traceability chain, mechanism by mechanism.
 
 ## 3. What the operating model must deliver
 
-Relevant insight about Contoso Insurance's customers, advisors, and processes is generated constantly - in Teams/B2E discussions, advisory notes, meeting transcripts, GitHub issues, sprint reviews, product usage, customer feedback, and operational Dataverse data. Without a standardized loop, that insight risks going uncaptured, unprioritized, never delivered, or never checked for impact after it ships.
+Relevant insight about Contoso Insurance's customers, advisors, and processes is generated constantly - in Teams/B2E discussions, advisory notes, meeting transcripts, GitHub issues, sprint reviews, product usage, customer feedback, and operational Dataverse data. Without a standardized loop, that insight risks going uncaptured, unprioritized, undelivered, or unmeasured.
 
 **Who this model is for**, mapped to this repo's real personas (`docs/PERSONAS-JOURNEY.md`) rather than generic role labels:
 
@@ -66,7 +66,7 @@ Relevant insight about Contoso Insurance's customers, advisors, and processes is
 
 - No fully autonomous prioritization without human sign-off.
 - No autonomous PROD deployment without review.
-- No unreviewed processing of sensitive customer data - health, financial exposure, or claims detail - by an arbitrary agent.
+- No unreviewed processing of sensitive customer data - health, financial exposure, or claims detail - by an arbitrary agent ([ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md)).
 - No wholesale replacement of existing advisory or engineering processes.
 - No autonomously issued binding recommendation, quote, or policy change - agents recommend, a named human decides, with no exception (`AGENTS.md`).
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -19,7 +19,7 @@ Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, h
 
 > **In this showcase:** Business/Teams, Agent/Copilot Agent Mesh, Engineering/GitHub, and Operational/Dataverse are **built**. Interaction/Work IQ is **documented only** - see `docs/FRONTIER-OPERATING-MODEL.md` section 8 for why, and how a real engagement would wire it up.
 
-## 3. A four-step establishment method
+## 8. A four-step establishment method
 
 Any insurer's EA/IT team can follow this method to stand up their own version:
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -226,7 +226,7 @@ This repo is the worked example of the method above, applied to the Contoso Insu
 
 ## Validate this live
 
-During the demo, open `docs/FRONTIER-OPERATING-MODEL.md` and walk section by section (section 5 control planes -> section 6 role mapping -> section 7 governance -> section 8 Work IQ pattern -> section 9 roadmap) to show this is a real, repo-grounded method, not a slide-only framework. Then open `docs/superpowers/sprints/` to show the requirement -> ADR -> design-pattern -> deployed-evidence loop this repo actually runs.
+During the demo, walk this document section by section first (section 2 vision -> section 3 requirements -> section 4 control planes -> section 5 agents -> section 6 governance -> section 7 roadmap -> section 8 method -> section 9 worked example) to deliver the full mental model in one pass. Then open `docs/FRONTIER-OPERATING-MODEL.md` for full depth on any section, walking it the same way (section 5 control planes -> section 6 role mapping -> section 7 governance -> section 8 Work IQ pattern -> section 9 roadmap) to show this is a real, repo-grounded method, not a slide-only framework. Then open `docs/superpowers/sprints/` to show the requirement -> ADR -> design-pattern -> deployed-evidence loop this repo actually runs.
 
 ## Decision
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -181,6 +181,27 @@ stateDiagram-v2
 
 **Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance).
 
+## 7. Roadmap, phased and status-tagged
+
+The same six phases `docs/FRONTIER-OPERATING-MODEL.md` section 9 defines, tagged so nobody mistakes narrative for delivered capability:
+
+```mermaid
+flowchart LR
+    classDef built fill:#d1fae5,stroke:#065f46,stroke-width:1px,color:#111111
+    classDef demoed fill:#fef3c7,stroke:#92400e,stroke-width:1px,color:#111111
+    classDef docOnly fill:#e5e5e5,stroke:#666666,stroke-width:1px,stroke-dasharray: 4 2,color:#111111
+
+    P0["Phase 0: Foundation"]:::built --> P1["Phase 1: Teams/B2E to GitHub transparency"]:::demoed
+    P1 --> P2["Phase 2: Work IQ agent intake"]:::docOnly
+    P2 --> P3["Phase 3: Sprint review to GitHub"]:::built
+    P3 --> P4["Phase 4: Release to outcome loop"]:::demoed
+    P4 --> P5["Phase 5: Agent mesh scaling"]:::demoed
+```
+
+*Legend: green = Built, amber = Demoed via docs, grey dashed = Documented-only - a deliberately different palette from the ownership colours in section 4, because this diagram encodes delivery status, not who owns each plane.*
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 9 for the full description of each phase's deliverables.
+
 ## 8. A four-step establishment method
 
 Any insurer's EA/IT team can follow this method to stand up their own version:

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -5,7 +5,70 @@
 
 ## 1. Why a Frontier Firm model for an insurer
 
-Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, human agency, and the opportunity for every organization, which makes the first insurance question an operating-model question, not an integration question. Before choosing any single API, UI, or data pattern, an insurer has to decide how customer-facing employees, copilots, approval points, engineering delivery, and the system of record will work together, because that is how a Frontier Company actually builds and operates a solution with Microsoft's current agentic stack. If that division of labor is unclear, every downstream pattern - Work IQ, GitHub, Dataverse, Copilot Studio, or core-system integration - will be implemented without a shared accountability model.
+Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, human agency, and the opportunity for every organization. That makes the first insurance question an operating-model question, not an integration question: before choosing any single API, UI, or data pattern, an insurer must decide how customer-facing employees, copilots, approval points, engineering delivery, and the system of record work together. That is how a Frontier Company actually builds and operates a solution with Microsoft's current agentic stack. Without that shared accountability model, every downstream pattern - Work IQ, GitHub, Dataverse, Copilot Studio, or core-system integration - gets implemented in isolation.
+
+Sections 2-7 below set out that operating model end to end: vision, requirements, architecture, agent roster, governance, and roadmap. Sections 8-9 then show how to establish it yourself and how Contoso Insurance did.
+
+## 2. Vision and the operating loop
+
+Contoso Insurance's Frontier Firm vision, adapted from the source idea doc's north star:
+
+> Every relevant interaction with a customer, employee, or system automatically strengthens Contoso Insurance's advice, product, and processes.
+
+Stated technically:
+
+> Contoso Insurance becomes a Human-led, Agent-operated advisory practice, in which the Business/Teams and B2E layer steers human-agent interaction, GitHub orchestrates the digital delivery, and Dataverse reflects the operational reality.
+
+This vision runs as a loop, not a one-off project:
+
+```mermaid
+flowchart LR
+    classDef stage fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+    I[Insight]:::stage --> D[Decision]:::stage --> DL[Delivery]:::stage --> O[Outcome]:::stage --> L[Learning]:::stage --> I
+
+    subgraph Sources["Where insight comes from"]
+        direction TB
+        S1[Advisory conversations]
+        S2[Service and claims cases]
+        S3[Teams / B2E reviews]
+        S4[Product usage]
+        S5[Customer feedback]
+        S6[Sprint reviews]
+    end
+    Sources --> I
+```
+
+Six principles keep the loop honest:
+
+| Principle | What it means for Contoso Insurance |
+| --- | --- |
+| Human-led | Advisors and named humans set direction, standards, priorities, and approvals ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md)). |
+| Agent-operated | Runtime and engineering agents handle analysis, structuring, proposals, drafts, and recurring operational work. |
+| HITL-controlled | Critical steps stay under human control, with no exceptions ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md)). |
+| GitHub-driven | Every implementation-relevant requirement becomes traceable, versioned, and sprint-ready (`AGENTS.md` section 3). |
+| Dataverse-backed | Operational truth and outcome measurement live in Dataverse and Power Platform ([ADR-0008](../adr/ADR-0008-thin-crm-over-systems-of-record.md)). |
+| Teams/B2E-visible | Delivery status stays visible to employees through Teams and the B2E layer ([ADR-0033](../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md)). |
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 4 maps each loop stage onto this repo's existing traceability chain, mechanism by mechanism.
+
+## 3. What the operating model must deliver
+
+Relevant insight about Contoso Insurance's customers, advisors, and processes is generated constantly - in Teams/B2E discussions, advisory notes, meeting transcripts, GitHub issues, sprint reviews, product usage, customer feedback, and operational Dataverse data. Without a standardized loop, that insight risks going uncaptured, unprioritized, never delivered, or never checked for impact after it ships.
+
+**Who this model is for**, mapped to this repo's real personas (`docs/PERSONAS-JOURNEY.md`) rather than generic role labels:
+
+| Audience | Personas | Role in the loop |
+| --- | --- | --- |
+| Primary - practitioners | P-01 Advisor (GA), P-02 General Agent lead, P-03 Assistance agent, P-04 Marketer, P-05 Broker manager | Generate Insight, consume Decision/Outcome status |
+| Secondary - build and govern | P-06 IT/Architect, P-07 Business owner/Data steward, plus the engineering agents (`AG-E-01` Product Owner and peers) | Turn Insight into Decision and Delivery, own Outcome measurement |
+
+**What this model is explicitly not**, for its first iteration:
+
+- No fully autonomous prioritization without human sign-off.
+- No autonomous PROD deployment without review.
+- No unreviewed processing of sensitive customer data - health, financial exposure, or claims detail - by an arbitrary agent.
+- No wholesale replacement of existing advisory or engineering processes.
+- No autonomously issued binding recommendation, quote, or policy change - agents recommend, a named human decides, with no exception (`AGENTS.md`).
 
 ## 4. The five control planes and how they connect
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -7,7 +7,7 @@
 
 Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, human agency, and the opportunity for every organization, which makes the first insurance question an operating-model question, not an integration question. Before choosing any single API, UI, or data pattern, an insurer has to decide how customer-facing employees, copilots, approval points, engineering delivery, and the system of record will work together, because that is how a Frontier Company actually builds and operates a solution with Microsoft's current agentic stack. If that division of labor is unclear, every downstream pattern - Work IQ, GitHub, Dataverse, Copilot Studio, or core-system integration - will be implemented without a shared accountability model.
 
-## 2. The five control planes, generically stated
+## 4. The five control planes and how they connect
 
 | Control plane | Generic insurance meaning |
 | --- | --- |
@@ -18,6 +18,29 @@ Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, h
 | Operational / Dataverse + Power Platform | The operational system-of-record layer where customer-relationship processes, governed actions, audit, events, security, and CRM workflow live. |
 
 > **In this showcase:** Business/Teams, Agent/Copilot Agent Mesh, Engineering/GitHub, and Operational/Dataverse are **built**. Interaction/Work IQ is **documented only** - see `docs/FRONTIER-OPERATING-MODEL.md` section 8 for why, and how a real engagement would wire it up.
+
+These five planes are not independent — each Insight/Decision/Delivery/Outcome cycle crosses all five in sequence:
+
+```mermaid
+flowchart TB
+    classDef msft fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+    classDef contoso fill:#fde8e8,stroke:#b91c1c,stroke-width:1px,color:#111111
+    classDef shared fill:#e5e5e5,stroke:#666666,stroke-width:1px,color:#111111
+
+    CE["Customers and Employees"]:::shared
+    BP["Business / Teams and B2E"]:::shared
+    IP["Interaction / Work IQ (documented only)"]:::msft
+    AP["Agent / Copilot Agent Mesh"]:::msft
+    EP["Engineering / GitHub"]:::msft
+    OP["Operational / Dataverse and Power Platform"]:::shared
+    TL["Teams / B2E transparency loop"]:::shared
+
+    CE --> BP --> IP --> AP --> EP --> OP --> TL --> BP
+```
+
+*Legend: white = Microsoft platform capability, red = a Contoso Insurance-owned system, grey = shared/jointly-owned — the same convention used in `docs/FRONTIER-OPERATING-MODEL.md`'s Solution Context diagrams.*
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 5 (adapted table with Built/Documented-only status per plane) and its Solution Context section for the full Contoso-specific architecture.
 
 ## 8. A four-step establishment method
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -198,7 +198,7 @@ flowchart LR
     P4 --> P5["Phase 5: Agent mesh scaling"]:::demoed
 ```
 
-*Legend: green = Built, amber = Demoed via docs, grey dashed = Documented-only - green and amber are new here, while grey deliberately reuses section 4's shared colour (documented-only work is also the least firmly owned), set apart by the dashed stroke rather than a new hue.*
+*Legend: green = Built, amber = Demoed via docs, grey dashed = Documented-only - green and amber are new here, while grey deliberately reuses section 4's shared colour, set apart by the dashed stroke rather than a new hue.*
 
 **Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 9 for the full description of each phase's deliverables.
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -82,7 +82,7 @@ Relevant insight about Contoso Insurance's customers, advisors, and processes is
 
 > **In this showcase:** Business/Teams, Agent/Copilot Agent Mesh, Engineering/GitHub, and Operational/Dataverse are **built**. Interaction/Work IQ is **documented only** - see `docs/FRONTIER-OPERATING-MODEL.md` section 8 for why, and how a real engagement would wire it up.
 
-These five planes are not independent — each Insight/Decision/Delivery/Outcome cycle crosses all five in sequence:
+These five planes are not independent - each Insight/Decision/Delivery/Outcome cycle crosses all five in sequence:
 
 ```mermaid
 flowchart TB
@@ -101,13 +101,13 @@ flowchart TB
     CE --> BP --> IP --> AP --> EP --> OP --> TL --> BP
 ```
 
-*Legend: white = Microsoft platform capability, red = a Contoso Insurance-owned system, grey = shared/jointly-owned — the same convention used in `docs/FRONTIER-OPERATING-MODEL.md`'s Solution Context diagrams.*
+*Legend: white = Microsoft platform capability, red = a Contoso Insurance-owned system, grey = shared/jointly-owned - the same convention used in `docs/FRONTIER-OPERATING-MODEL.md`'s Solution Context diagrams.*
 
 **Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 5 (adapted table with Built/Documented-only status per plane) and its Solution Context section for the full Contoso-specific architecture.
 
 ## 5. The agent roster behind the planes
 
-Every plane above runs on named agents, and every agent is advisory: it recommends, a human decides, with no exception ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md), `AGENTS.md`).
+Every plane above runs on named agents, and every agent is advisory: it recommends, a human decides, with no exception ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md), `AGENTS.md`). Agent IDs follow `AGENTS.md`'s two classes: `AG-F-##` are runtime/functional agents inside the showcase, and `AG-E-##` are engineering/build-time agents that build it.
 
 | Idea-doc role | Existing agent(s) | Notes |
 | --- | --- | --- |
@@ -179,7 +179,7 @@ stateDiagram-v2
     Rejected --> [*]
 ```
 
-**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance).
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance; the classification above is illustrative, pending ADR-0038's still-open option choice).
 
 ## 7. Roadmap, phased and status-tagged
 
@@ -198,7 +198,7 @@ flowchart LR
     P4 --> P5["Phase 5: Agent mesh scaling"]:::demoed
 ```
 
-*Legend: green = Built, amber = Demoed via docs, grey dashed = Documented-only - a deliberately different palette from the ownership colours in section 4, because this diagram encodes delivery status, not who owns each plane.*
+*Legend: green = Built, amber = Demoed via docs, grey dashed = Documented-only - green and amber are new here, while grey deliberately reuses section 4's shared colour (documented-only work is also the least firmly owned), set apart by the dashed stroke rather than a new hue.*
 
 **Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 9 for the full description of each phase's deliverables.
 
@@ -226,7 +226,7 @@ This repo is the worked example of the method above, applied to the Contoso Insu
 
 ## Validate this live
 
-During the demo, walk this document section by section first (section 2 vision -> section 3 requirements -> section 4 control planes -> section 5 agents -> section 6 governance -> section 7 roadmap -> section 8 method -> section 9 worked example) to deliver the full mental model in one pass. Then open `docs/FRONTIER-OPERATING-MODEL.md` for full depth on any section, walking it the same way (section 5 control planes -> section 6 role mapping -> section 7 governance -> section 8 Work IQ pattern -> section 9 roadmap) to show this is a real, repo-grounded method, not a slide-only framework. Then open `docs/superpowers/sprints/` to show the requirement -> ADR -> design-pattern -> deployed-evidence loop this repo actually runs.
+During the demo, first walk this document section by section (section 2 vision -> section 3 requirements -> section 4 control planes -> section 5 agents -> section 6 governance -> section 7 roadmap -> section 8 method -> section 9 worked example) to deliver the full mental model in one pass. For deeper detail on any topic, open `docs/FRONTIER-OPERATING-MODEL.md`, which covers the same ground at greater depth (its own section 5 control planes, section 6 role mapping, section 7 governance, section 8 Work IQ pattern, section 9 roadmap - note these section numbers refer to that document, not this one) to show this is a real, repo-grounded method, not a slide-only framework. Then open `docs/superpowers/sprints/` to show the requirement -> ADR -> design-pattern -> deployed-evidence loop this repo actually runs.
 
 ## Decision
 

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -105,6 +105,82 @@ flowchart TB
 
 **Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 5 (adapted table with Built/Documented-only status per plane) and its Solution Context section for the full Contoso-specific architecture.
 
+## 5. The agent roster behind the planes
+
+Every plane above runs on named agents, and every agent is advisory: it recommends, a human decides, with no exception ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md), `AGENTS.md`).
+
+| Idea-doc role | Existing agent(s) | Notes |
+| --- | --- | --- |
+| Voice of Customer | `AG-E-01` Product Owner (accountable intake), informed by `AG-F-04` Conversation Intelligence & Transcript Agent | Runtime signal feeds engineering backlog framing |
+| Product Discovery | `AG-E-01` Product Owner | - |
+| Architecture | `AG-E-03` Enterprise Architect, with `AG-E-08` Dataverse Modeler and `AG-E-09` Integration Engineer as specialists | Matches `AGENTS.md`'s non-delegable "Architecture approval" authority |
+| Delivery | `AG-E-02` Developer, with `AG-E-08` Dataverse Modeler and `AG-E-11` UX Designer | - |
+| Release | `AG-E-04` SecDevOps | Owns pipelines/environments per ADR-0039 |
+| Outcome | `AG-E-07` Data Engineer & Scientist (the Frontier Firm loop is explicit in their charter), fed by `AG-F-##` runtime telemetry | - |
+| Governance | `AG-E-06` Responsible-AI & Compliance Officer | Matches `AGENTS.md`'s non-delegable "RAI/compliance review" authority; ties to Purview (ADR-0038) |
+| Quality | Distributed - `AG-E-02` (tests), `AG-E-04` (pipeline gates), `AG-E-06` (RAI evals) | Shared by design, not force-fit to one owner |
+| *(cross-cutting)* | `AG-E-12` Frontier Firm Guide | Owns and maintains this operating model documentation itself |
+
+A signal only becomes a product change once a human has said so:
+
+```mermaid
+flowchart LR
+    classDef stage fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+    SIG["Customer / employee signal"]:::stage --> RUN["Runtime agent AG-F-## (advisory only)"]:::stage
+    RUN --> HUM{"Human decision: accept, edit, or dismiss"}
+    HUM -- "becomes a product change" --> ENG["Engineering agent AG-E-##"]:::stage
+    ENG --> GH["GitHub issue / PR"]:::stage
+    HUM -- "no change needed" --> DONE[No further action]
+```
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 6 for the complete role-mapping rationale, `AGENTS.md` for the full agent registry and its non-delegable-authority rules.
+
+## 6. HITL governance and data sensitivity
+
+Five principles govern every agent in the mesh:
+
+1. Agents produce proposals, not final decisions, in critical processes.
+2. Sensitive customer data is minimized or redacted before it reaches GitHub.
+3. Every relevant publication or handoff has a named owner.
+4. Every agent action is traceable.
+5. Automation may increase transparency; it never replaces accountability.
+
+Four data classes decide how a signal may be handled:
+
+| Class | Examples | Processing rule |
+| --- | --- | --- |
+| Public / non-critical | General feature requests, technical release notes, non-personal process notes | Agentic processing allowed; GitHub intake after standard review |
+| Internal business data | Internal priorities, roadmap topics, process issues, employee feedback | Authorized teams/GitHub areas only; no auto-publish without review |
+| Personal customer data (PII) | Name, contact details, advisory notes with personal reference | Redaction before GitHub, purpose limitation, human review |
+| Sensitive data | Health data (life/health lines), financial exposure, claims specifics | Highest protection class; no unreviewed GitHub handoff - only abstracted requirements or anonymized patterns |
+
+**Redaction in practice** - a raw signal never reaches GitHub as-is:
+
+- Raw: *"Customer Jane Doe mentioned during her claim follow-up that the online claim-status tracker is confusing."*
+- GitHub-safe: *"A customer mentioned during a claim follow-up that the online claim-status tracker is confusing."*
+- As a requirement: *"As a customer, I want to track my claim status with minimal steps, so that I don't need to call the service desk for updates."*
+
+Every proposal moves through the same approval states, end to end:
+
+```mermaid
+stateDiagram-v2
+    [*] --> DraftedByAgent
+    DraftedByAgent --> NeedsHumanReview
+    NeedsHumanReview --> Approved
+    NeedsHumanReview --> NeedsChanges
+    NeedsHumanReview --> Rejected
+    NeedsChanges --> NeedsHumanReview
+    Approved --> CreatedInGitHub
+    CreatedInGitHub --> InSprint
+    InSprint --> DeliveredToTest
+    DeliveredToTest --> DeliveredToProd
+    DeliveredToProd --> OutcomeReviewed
+    OutcomeReviewed --> [*]
+    Rejected --> [*]
+```
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance).
+
 ## 8. A four-step establishment method
 
 Any insurer's EA/IT team can follow this method to stand up their own version:

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -28,15 +28,17 @@ Any insurer's EA/IT team can follow this method to stand up their own version:
 3. **Phase your roadmap.** Tag each phase the way `docs/FRONTIER-OPERATING-MODEL.md` section 9 does: **[Built]**, **[Demoed via docs]**, or **[Documented-only]**. That forces honest sequencing and prevents a future-state narrative from being mistaken for a delivered capability.
 4. **Set HITL and governance guardrails before any agent is granted write access.** Use the same non-negotiable starting point expressed in `docs/FRONTIER-OPERATING-MODEL.md` section 7: agents recommend, a named human decides. Then bind that principle to concrete review authority, compliance controls, and approval points before any agent is allowed to mutate operational records.
 
-## 4. Contoso Insurance as the worked example
+## 9. Contoso Insurance as the worked example
 
 This repo is the worked example of the method above, applied to the Contoso Insurance Advisory Cockpit use case:
 
-- Control-plane inventory: `docs/FRONTIER-OPERATING-MODEL.md` section 5.
-- Role mapping onto this repo's named agents: `docs/FRONTIER-OPERATING-MODEL.md` section 6.
-- HITL/governance guardrails: `docs/FRONTIER-OPERATING-MODEL.md` section 7.
-- Work IQ <-> GitHub pattern (documented only): `docs/FRONTIER-OPERATING-MODEL.md` section 8.
-- Roadmap phasing: `docs/FRONTIER-OPERATING-MODEL.md` section 9.
+- Vision and operating loop: section 2 above.
+- What the model must deliver: section 3 above.
+- Control-plane inventory: section 4 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 5 for full detail.
+- Agent roster and role mapping: section 5 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 6 for full detail.
+- HITL/governance guardrails: section 6 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 7 for full detail.
+- Work IQ <-> GitHub pattern (documented only, not covered in this doc): `docs/FRONTIER-OPERATING-MODEL.md` section 8.
+- Roadmap phasing: section 7 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 9 for full detail.
 - The concrete artefacts this method produced: the 11 ADR-linked pattern docs in this same folder - see `docs/design/README.md` for the full index.
 
 ## Validate this live

--- a/docs/design/00-frontier-firm-operating-model-for-insurance.md
+++ b/docs/design/00-frontier-firm-operating-model-for-insurance.md
@@ -3,6 +3,8 @@
 **Audience:** EA / IT stakeholders of any insurer evaluating whether - and how - to establish a Frontier Firm-style agentic operating model.  
 **Related doc:** `docs/FRONTIER-OPERATING-MODEL.md` (full detail for this showcase's own instantiation)
 
+> **A note on ADR maturity:** several ADRs cited below (including ADR-0033, ADR-0038, and ADR-0039) are recorded as *Proposed hypothesis* - open architecture options awaiting an EA/IT decision, not settled conclusions. A citation here points to the option under consideration, not a ratified outcome; check each ADR's own Status field before treating a claim as decided.
+
 ## 1. Why a Frontier Firm model for an insurer
 
 Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, human agency, and the opportunity for every organization. That makes the first insurance question an operating-model question, not an integration question: before choosing any single API, UI, or data pattern, an insurer must decide how customer-facing employees, copilots, approval points, engineering delivery, and the system of record work together. That is how a Frontier Company actually builds and operates a solution with Microsoft's current agentic stack. Without that shared accountability model, every downstream pattern - Work IQ, GitHub, Dataverse, Copilot Studio, or core-system integration - gets implemented in isolation.

--- a/docs/superpowers/plans/2026-08-17-design-pattern-00-expansion.md
+++ b/docs/superpowers/plans/2026-08-17-design-pattern-00-expansion.md
@@ -1,0 +1,618 @@
+# Design Pattern 00 Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+(Design Pattern 00) from a short 4-section method doc into a full 9-section
+narrative — one condensed, insurance-reworded, diagram-illustrated subsection
+per idea doc (`docs/ideas/frontier-operating-system/00`–`05`), plus the
+existing method and worked-example sections — per the approved design spec
+(`docs/superpowers/specs/2026-08-17-frontier-operating-model-pattern-00-expansion-design.md`),
+with zero broken cross-references and zero content forked from
+`docs/FRONTIER-OPERATING-MODEL.md`.
+
+**Architecture:** Documentation-only change to one existing file, executed as
+a sequence of anchored text replacements ordered so the document stays in a
+valid, non-duplicate-heading state after every task (later sections are
+renumbered before earlier sections are touched, working from the end of the
+file backward, then new sections are inserted front-to-back). "Tests" are
+structural checks — PowerShell `Select-String` for heading sequence and
+cross-reference existence, plus manual Mermaid-render verification —
+consistent with this repo's existing doc-change convention (see
+`docs/superpowers/plans/2026-08-16-frontier-operating-model.md`).
+
+**Tech Stack:** Markdown + Mermaid (`flowchart`, `stateDiagram-v2`) only.
+Validation via PowerShell `Select-String` / `Test-Path` / `git diff` — no
+npm/pip packages, no repo build system involved.
+
+---
+
+## Reference: full target heading sequence (after Task 6)
+
+```text
+# Design Pattern 00: Frontier Firm operating model for insurance
+## 1. Why a Frontier Firm model for an insurer
+## 2. Vision and the operating loop
+## 3. What the operating model must deliver
+## 4. The five control planes and how they connect
+## 5. The agent roster behind the planes
+## 6. HITL governance and data sensitivity
+## 7. Roadmap, phased and status-tagged
+## 8. A four-step establishment method
+## 9. Contoso Insurance as the worked example
+## Validate this live
+## Decision
+```
+
+Every task below leaves the file with no duplicate heading numbers, even
+though earlier tasks leave temporary gaps (e.g. after Task 3 the file has
+headings 1, 4, 8, 9 — missing 2/3/5/6/7, but nothing duplicated). Do the
+tasks in order.
+
+---
+
+### Task 1: Renumber the worked-example section (§4 → §9) and extend its bullets
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace the worked-example section**
+
+Find this exact block (currently the last numbered section in the file):
+
+````text
+## 4. Contoso Insurance as the worked example
+
+This repo is the worked example of the method above, applied to the Contoso Insurance Advisory Cockpit use case:
+
+- Control-plane inventory: `docs/FRONTIER-OPERATING-MODEL.md` section 5.
+- Role mapping onto this repo's named agents: `docs/FRONTIER-OPERATING-MODEL.md` section 6.
+- HITL/governance guardrails: `docs/FRONTIER-OPERATING-MODEL.md` section 7.
+- Work IQ <-> GitHub pattern (documented only): `docs/FRONTIER-OPERATING-MODEL.md` section 8.
+- Roadmap phasing: `docs/FRONTIER-OPERATING-MODEL.md` section 9.
+- The concrete artefacts this method produced: the 11 ADR-linked pattern docs in this same folder - see `docs/design/README.md` for the full index.
+````
+
+Replace it with:
+
+````text
+## 9. Contoso Insurance as the worked example
+
+This repo is the worked example of the method above, applied to the Contoso Insurance Advisory Cockpit use case:
+
+- Vision and operating loop: section 2 above.
+- What the model must deliver: section 3 above.
+- Control-plane inventory: section 4 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 5 for full detail.
+- Agent roster and role mapping: section 5 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 6 for full detail.
+- HITL/governance guardrails: section 6 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 7 for full detail.
+- Work IQ <-> GitHub pattern (documented only, not covered in this doc): `docs/FRONTIER-OPERATING-MODEL.md` section 8.
+- Roadmap phasing: section 7 above, and `docs/FRONTIER-OPERATING-MODEL.md` section 9 for full detail.
+- The concrete artefacts this method produced: the 11 ADR-linked pattern docs in this same folder - see `docs/design/README.md` for the full index.
+````
+
+- [ ] **Step 2: Verify**
+
+Run:
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+```
+Expected: headings in this order — `## 1. Why a Frontier Firm model for an insurer`, `## 2. The five control planes, generically stated`, `## 3. A four-step establishment method`, `## 9. Contoso Insurance as the worked example`, `## Validate this live`, `## Decision`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): renumber worked-example section to 9 and extend its bullets"
+```
+
+---
+
+### Task 2: Renumber the establishment-method section (§3 → §8)
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace the heading**
+
+Find:
+```text
+## 3. A four-step establishment method
+
+Any insurer's EA/IT team can follow this method to stand up their own version:
+```
+
+Replace with:
+```text
+## 8. A four-step establishment method
+
+Any insurer's EA/IT team can follow this method to stand up their own version:
+```
+
+Only the heading number changes — the four numbered items beneath it are unchanged.
+
+- [ ] **Step 2: Verify**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+```
+Expected: `## 1. ...`, `## 2. The five control planes, generically stated`, `## 8. A four-step establishment method`, `## 9. Contoso Insurance as the worked example`, `## Validate this live`, `## Decision`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): renumber establishment-method section to 8"
+```
+
+---
+
+### Task 3: Renumber the control-planes section (§2 → §4) and add its diagram
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace the control-planes section**
+
+Find this exact block:
+
+````text
+## 2. The five control planes, generically stated
+
+| Control plane | Generic insurance meaning |
+| --- | --- |
+| Business / Teams | The coordination layer between customer-facing staff and the customers, brokers, partners, and internal colleagues they serve through the insurer's everyday workplace surfaces. |
+| Interaction / Work IQ | The human-agent interaction surface layered over collaboration tools, where people ask for help, inspect context, delegate tasks, and stay in control of agent work. |
+| Agent / Copilot Agent Mesh | The named roster of task-focused runtime and engineering agents, each with a clear purpose, owner, maturity, and handoff boundary. |
+| Engineering / GitHub | The delivery toolchain that versions the agent mesh itself: prompts, ADRs, issues, pull requests, CI evidence, and the engineering agents that keep the mesh reviewable and releasable. |
+| Operational / Dataverse + Power Platform | The operational system-of-record layer where customer-relationship processes, governed actions, audit, events, security, and CRM workflow live. |
+
+> **In this showcase:** Business/Teams, Agent/Copilot Agent Mesh, Engineering/GitHub, and Operational/Dataverse are **built**. Interaction/Work IQ is **documented only** - see `docs/FRONTIER-OPERATING-MODEL.md` section 8 for why, and how a real engagement would wire it up.
+
+## 8. A four-step establishment method
+````
+
+Replace it with:
+
+`````text
+## 4. The five control planes and how they connect
+
+| Control plane | Generic insurance meaning |
+| --- | --- |
+| Business / Teams | The coordination layer between customer-facing staff and the customers, brokers, partners, and internal colleagues they serve through the insurer's everyday workplace surfaces. |
+| Interaction / Work IQ | The human-agent interaction surface layered over collaboration tools, where people ask for help, inspect context, delegate tasks, and stay in control of agent work. |
+| Agent / Copilot Agent Mesh | The named roster of task-focused runtime and engineering agents, each with a clear purpose, owner, maturity, and handoff boundary. |
+| Engineering / GitHub | The delivery toolchain that versions the agent mesh itself: prompts, ADRs, issues, pull requests, CI evidence, and the engineering agents that keep the mesh reviewable and releasable. |
+| Operational / Dataverse + Power Platform | The operational system-of-record layer where customer-relationship processes, governed actions, audit, events, security, and CRM workflow live. |
+
+> **In this showcase:** Business/Teams, Agent/Copilot Agent Mesh, Engineering/GitHub, and Operational/Dataverse are **built**. Interaction/Work IQ is **documented only** - see `docs/FRONTIER-OPERATING-MODEL.md` section 8 for why, and how a real engagement would wire it up.
+
+These five planes are not independent — each Insight/Decision/Delivery/Outcome cycle crosses all five in sequence:
+
+```mermaid
+flowchart TB
+    classDef msft fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+    classDef contoso fill:#fde8e8,stroke:#b91c1c,stroke-width:1px,color:#111111
+    classDef shared fill:#e5e5e5,stroke:#666666,stroke-width:1px,color:#111111
+
+    CE["Customers and Employees"]:::shared
+    BP["Business / Teams and B2E"]:::shared
+    IP["Interaction / Work IQ (documented only)"]:::msft
+    AP["Agent / Copilot Agent Mesh"]:::msft
+    EP["Engineering / GitHub"]:::msft
+    OP["Operational / Dataverse and Power Platform"]:::shared
+    TL["Teams / B2E transparency loop"]:::shared
+
+    CE --> BP --> IP --> AP --> EP --> OP --> TL --> BP
+```
+
+*Legend: white = Microsoft platform capability, red = a Contoso Insurance-owned system, grey = shared/jointly-owned — the same convention used in `docs/FRONTIER-OPERATING-MODEL.md`'s Solution Context diagrams.*
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 5 (adapted table with Built/Documented-only status per plane) and its Solution Context section for the full Contoso-specific architecture.
+
+## 8. A four-step establishment method
+`````
+
+- [ ] **Step 2: Verify**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern '```mermaid'
+```
+Expected headings: `## 1. ...`, `## 4. The five control planes and how they connect`, `## 8. ...`, `## 9. ...`, `## Validate this live`, `## Decision`. Expected mermaid count: 1 match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): renumber control-planes section to 4 and add its diagram"
+```
+
+---
+
+### Task 4: Tighten §1 and insert the new vision (§2) and requirements (§3) sections
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace section 1 through the start of section 4**
+
+Find this exact block:
+
+```text
+## 1. Why a Frontier Firm model for an insurer
+
+Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, human agency, and the opportunity for every organization, which makes the first insurance question an operating-model question, not an integration question. Before choosing any single API, UI, or data pattern, an insurer has to decide how customer-facing employees, copilots, approval points, engineering delivery, and the system of record will work together, because that is how a Frontier Company actually builds and operates a solution with Microsoft's current agentic stack. If that division of labor is unclear, every downstream pattern - Work IQ, GitHub, Dataverse, Copilot Studio, or core-system integration - will be implemented without a shared accountability model.
+
+## 4. The five control planes and how they connect
+```
+
+Replace it with:
+
+`````text
+## 1. Why a Frontier Firm model for an insurer
+
+Microsoft's 2025/2026 Work Trend Index frames the Frontier Firm around agents, human agency, and the opportunity for every organization. That makes the first insurance question an operating-model question, not an integration question: before choosing any single API, UI, or data pattern, an insurer must decide how customer-facing employees, copilots, approval points, engineering delivery, and the system of record work together. That is how a Frontier Company actually builds and operates a solution with Microsoft's current agentic stack. Without that shared accountability model, every downstream pattern - Work IQ, GitHub, Dataverse, Copilot Studio, or core-system integration - gets implemented in isolation.
+
+Sections 2-7 below set out that operating model end to end: vision, requirements, architecture, agent roster, governance, and roadmap. Sections 8-9 then show how to establish it yourself and how Contoso Insurance did.
+
+## 2. Vision and the operating loop
+
+Contoso Insurance's Frontier Firm vision, adapted from the source idea doc's north star:
+
+> Every relevant interaction with a customer, employee, or system automatically strengthens Contoso Insurance's advice, product, and processes.
+
+Stated technically:
+
+> Contoso Insurance becomes a Human-led, Agent-operated advisory practice, in which the Business/Teams and B2E layer steers human-agent interaction, GitHub orchestrates the digital delivery, and Dataverse reflects the operational reality.
+
+This vision runs as a loop, not a one-off project:
+
+```mermaid
+flowchart LR
+    classDef stage fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+    I[Insight]:::stage --> D[Decision]:::stage --> DL[Delivery]:::stage --> O[Outcome]:::stage --> L[Learning]:::stage --> I
+
+    subgraph Sources["Where insight comes from"]
+        direction TB
+        S1[Advisory conversations]
+        S2[Service and claims cases]
+        S3[Teams / B2E reviews]
+        S4[Product usage]
+        S5[Customer feedback]
+        S6[Sprint reviews]
+    end
+    Sources --> I
+```
+
+Six principles keep the loop honest:
+
+| Principle | What it means for Contoso Insurance |
+| --- | --- |
+| Human-led | Advisors and named humans set direction, standards, priorities, and approvals ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md)). |
+| Agent-operated | Runtime and engineering agents handle analysis, structuring, proposals, drafts, and recurring operational work. |
+| HITL-controlled | Critical steps stay under human control, with no exceptions ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md)). |
+| GitHub-driven | Every implementation-relevant requirement becomes traceable, versioned, and sprint-ready (`AGENTS.md` section 3). |
+| Dataverse-backed | Operational truth and outcome measurement live in Dataverse and Power Platform ([ADR-0008](../adr/ADR-0008-thin-crm-over-systems-of-record.md)). |
+| Teams/B2E-visible | Delivery status stays visible to employees through Teams and the B2E layer ([ADR-0033](../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md)). |
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 4 maps each loop stage onto this repo's existing traceability chain, mechanism by mechanism.
+
+## 3. What the operating model must deliver
+
+Relevant insight about Contoso Insurance's customers, advisors, and processes is generated constantly - in Teams/B2E discussions, advisory notes, meeting transcripts, GitHub issues, sprint reviews, product usage, customer feedback, and operational Dataverse data. Without a standardized loop, that insight risks going uncaptured, unprioritized, never delivered, or never checked for impact after it ships.
+
+**Who this model is for**, mapped to this repo's real personas (`docs/PERSONAS-JOURNEY.md`) rather than generic role labels:
+
+| Audience | Personas | Role in the loop |
+| --- | --- | --- |
+| Primary - practitioners | P-01 Advisor (GA), P-02 General Agent lead, P-03 Assistance agent, P-04 Marketer, P-05 Broker manager | Generate Insight, consume Decision/Outcome status |
+| Secondary - build and govern | P-06 IT/Architect, P-07 Business owner/Data steward, plus the engineering agents (`AG-E-01` Product Owner and peers) | Turn Insight into Decision and Delivery, own Outcome measurement |
+
+**What this model is explicitly not**, for its first iteration:
+
+- No fully autonomous prioritization without human sign-off.
+- No autonomous PROD deployment without review.
+- No unreviewed processing of sensitive customer data - health, financial exposure, or claims detail - by an arbitrary agent.
+- No wholesale replacement of existing advisory or engineering processes.
+- No autonomously issued binding recommendation, quote, or policy change - agents recommend, a named human decides, with no exception (`AGENTS.md`).
+
+## 4. The five control planes and how they connect
+`````
+
+- [ ] **Step 2: Verify**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern '```mermaid'
+```
+Expected headings: `## 1. ...`, `## 2. Vision and the operating loop`, `## 3. What the operating model must deliver`, `## 4. The five control planes and how they connect`, `## 8. ...`, `## 9. ...`, `## Validate this live`, `## Decision`. Expected mermaid count: 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): tighten section 1 wording, add vision and requirements sections"
+```
+
+---
+
+### Task 5: Insert the agent roster (§5) and HITL governance (§6) sections
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace the end of section 4 through the start of section 8**
+
+Find this exact block:
+
+```text
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 5 (adapted table with Built/Documented-only status per plane) and its Solution Context section for the full Contoso-specific architecture.
+
+## 8. A four-step establishment method
+```
+
+Replace it with:
+
+`````text
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 5 (adapted table with Built/Documented-only status per plane) and its Solution Context section for the full Contoso-specific architecture.
+
+## 5. The agent roster behind the planes
+
+Every plane above runs on named agents, and every agent is advisory: it recommends, a human decides, with no exception ([ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md), `AGENTS.md`).
+
+| Idea-doc role | Existing agent(s) | Notes |
+| --- | --- | --- |
+| Voice of Customer | `AG-E-01` Product Owner (accountable intake), informed by `AG-F-04` Conversation Intelligence & Transcript Agent | Runtime signal feeds engineering backlog framing |
+| Product Discovery | `AG-E-01` Product Owner | - |
+| Architecture | `AG-E-03` Enterprise Architect, with `AG-E-08` Dataverse Modeler and `AG-E-09` Integration Engineer as specialists | Matches `AGENTS.md`'s non-delegable "Architecture approval" authority |
+| Delivery | `AG-E-02` Developer, with `AG-E-08` Dataverse Modeler and `AG-E-11` UX Designer | - |
+| Release | `AG-E-04` SecDevOps | Owns pipelines/environments per ADR-0039 |
+| Outcome | `AG-E-07` Data Engineer & Scientist (the Frontier Firm loop is explicit in their charter), fed by `AG-F-##` runtime telemetry | - |
+| Governance | `AG-E-06` Responsible-AI & Compliance Officer | Matches `AGENTS.md`'s non-delegable "RAI/compliance review" authority; ties to Purview (ADR-0038) |
+| Quality | Distributed - `AG-E-02` (tests), `AG-E-04` (pipeline gates), `AG-E-06` (RAI evals) | Shared by design, not force-fit to one owner |
+| *(cross-cutting)* | `AG-E-12` Frontier Firm Guide | Owns and maintains this operating model documentation itself |
+
+A signal only becomes a product change once a human has said so:
+
+```mermaid
+flowchart LR
+    classDef stage fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+    SIG["Customer / employee signal"]:::stage --> RUN["Runtime agent AG-F-## (advisory only)"]:::stage
+    RUN --> HUM{"Human decision: accept, edit, or dismiss"}
+    HUM -- "becomes a product change" --> ENG["Engineering agent AG-E-##"]:::stage
+    ENG --> GH["GitHub issue / PR"]:::stage
+    HUM -- "no change needed" --> DONE[No further action]
+```
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 6 for the complete role-mapping rationale, `AGENTS.md` for the full agent registry and its non-delegable-authority rules.
+
+## 6. HITL governance and data sensitivity
+
+Five principles govern every agent in the mesh:
+
+1. Agents produce proposals, not final decisions, in critical processes.
+2. Sensitive customer data is minimized or redacted before it reaches GitHub.
+3. Every relevant publication or handoff has a named owner.
+4. Every agent action is traceable.
+5. Automation may increase transparency; it never replaces accountability.
+
+Four data classes decide how a signal may be handled:
+
+| Class | Examples | Processing rule |
+| --- | --- | --- |
+| Public / non-critical | General feature requests, technical release notes, non-personal process notes | Agentic processing allowed; GitHub intake after standard review |
+| Internal business data | Internal priorities, roadmap topics, process issues, employee feedback | Authorized teams/GitHub areas only; no auto-publish without review |
+| Personal customer data (PII) | Name, contact details, advisory notes with personal reference | Redaction before GitHub, purpose limitation, human review |
+| Sensitive data | Health data (life/health lines), financial exposure, claims specifics | Highest protection class; no unreviewed GitHub handoff - only abstracted requirements or anonymized patterns |
+
+**Redaction in practice** - a raw signal never reaches GitHub as-is:
+
+- Raw: *"Customer Jane Doe mentioned during her claim follow-up that the online claim-status tracker is confusing."*
+- GitHub-safe: *"A customer mentioned during a claim follow-up that the online claim-status tracker is confusing."*
+- As a requirement: *"As a customer, I want to track my claim status with minimal steps, so that I don't need to call the service desk for updates."*
+
+Every proposal moves through the same approval states, end to end:
+
+```mermaid
+stateDiagram-v2
+    [*] --> DraftedByAgent
+    DraftedByAgent --> NeedsHumanReview
+    NeedsHumanReview --> Approved
+    NeedsHumanReview --> NeedsChanges
+    NeedsHumanReview --> Rejected
+    NeedsChanges --> NeedsHumanReview
+    Approved --> CreatedInGitHub
+    CreatedInGitHub --> InSprint
+    InSprint --> DeliveredToTest
+    DeliveredToTest --> DeliveredToProd
+    DeliveredToProd --> OutcomeReviewed
+    OutcomeReviewed --> [*]
+    Rejected --> [*]
+```
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance).
+
+## 8. A four-step establishment method
+`````
+
+- [ ] **Step 2: Verify**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern '```mermaid|```stateDiagram-v2'
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "\bEND\b"
+```
+Expected headings now include `## 5. The agent roster behind the planes` and `## 6. HITL governance and data sensitivity` between `## 4. ...` and `## 8. ...`. Expected diagram count: 4 (2 flowchart + 1 flowchart + 1 stateDiagram, cumulative with Tasks 3-4). Expected `\bEND\b` matches: none (the reserved Mermaid word `end` must not appear as a bare node id — this repo's diagram uses `DONE`, not `END`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): add agent roster and HITL governance sections"
+```
+
+---
+
+### Task 6: Insert the roadmap section (§7)
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace the end of section 6 through the start of section 8**
+
+Find this exact block:
+
+```text
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance).
+
+## 8. A four-step establishment method
+```
+
+Replace it with:
+
+`````text
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 7, [ADR-0014](../adr/ADR-0014-agents-advisory-by-design.md) (agents advisory by design), [ADR-0038](../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) (Purview compliance).
+
+## 7. Roadmap, phased and status-tagged
+
+The same six phases `docs/FRONTIER-OPERATING-MODEL.md` section 9 defines, tagged so nobody mistakes narrative for delivered capability:
+
+```mermaid
+flowchart LR
+    classDef built fill:#d1fae5,stroke:#065f46,stroke-width:1px,color:#111111
+    classDef demoed fill:#fef3c7,stroke:#92400e,stroke-width:1px,color:#111111
+    classDef docOnly fill:#e5e5e5,stroke:#666666,stroke-width:1px,stroke-dasharray: 4 2,color:#111111
+
+    P0["Phase 0: Foundation"]:::built --> P1["Phase 1: Teams/B2E to GitHub transparency"]:::demoed
+    P1 --> P2["Phase 2: Work IQ agent intake"]:::docOnly
+    P2 --> P3["Phase 3: Sprint review to GitHub"]:::built
+    P3 --> P4["Phase 4: Release to outcome loop"]:::demoed
+    P4 --> P5["Phase 5: Agent mesh scaling"]:::demoed
+```
+
+*Legend: green = Built, amber = Demoed via docs, grey dashed = Documented-only - a deliberately different palette from the ownership colours in section 4, because this diagram encodes delivery status, not who owns each plane.*
+
+**Full detail:** `docs/FRONTIER-OPERATING-MODEL.md` section 9 for the full description of each phase's deliverables.
+
+## 8. A four-step establishment method
+`````
+
+- [ ] **Step 2: Verify**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+```
+Expected: exactly `## 1.` through `## 9.` in sequence (1,2,3,4,5,6,7,8,9), then `## Validate this live`, then `## Decision` - matching the reference sequence at the top of this plan.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): add roadmap section"
+```
+
+---
+
+### Task 7: Update the "Validate this live" walk order
+
+**Files:**
+- Modify: `docs/design/00-frontier-firm-operating-model-for-insurance.md`
+
+- [ ] **Step 1: Replace the closing walk-through paragraph**
+
+Find:
+```text
+## Validate this live
+
+During the demo, open `docs/FRONTIER-OPERATING-MODEL.md` and walk section by section (section 5 control planes -> section 6 role mapping -> section 7 governance -> section 8 Work IQ pattern -> section 9 roadmap) to show this is a real, repo-grounded method, not a slide-only framework. Then open `docs/superpowers/sprints/` to show the requirement -> ADR -> design-pattern -> deployed-evidence loop this repo actually runs.
+```
+
+Replace with:
+```text
+## Validate this live
+
+During the demo, walk this document section by section first (section 2 vision -> section 3 requirements -> section 4 control planes -> section 5 agents -> section 6 governance -> section 7 roadmap -> section 8 method -> section 9 worked example) to deliver the full mental model in one pass. Then open `docs/FRONTIER-OPERATING-MODEL.md` for full depth on any section, walking it the same way (section 5 control planes -> section 6 role mapping -> section 7 governance -> section 8 Work IQ pattern -> section 9 roadmap) to show this is a real, repo-grounded method, not a slide-only framework. Then open `docs/superpowers/sprints/` to show the requirement -> ADR -> design-pattern -> deployed-evidence loop this repo actually runs.
+```
+
+`## Decision` immediately below is unchanged - do not touch it.
+
+- [ ] **Step 2: Verify**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "Validate this live|## Decision"
+```
+Expected: both headings present, in that order, each exactly once.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): update validate-this-live walk order"
+```
+
+---
+
+### Task 8: Final verification pass
+
+**Files:**
+- Read-only checks against: `docs/design/00-frontier-firm-operating-model-for-insurance.md`, `docs/design/README.md`, `docs/FRONTIER-OPERATING-MODEL.md`, `docs/adr/`, `AGENTS.md`, `docs/PERSONAS-JOURNEY.md`
+
+- [ ] **Step 1: Confirm the final heading sequence is complete and sequential**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "^## "
+```
+Expected: `## 1.` through `## 9.` with no gaps and no duplicates, followed by `## Validate this live` and `## Decision`.
+
+- [ ] **Step 2: Confirm every Mermaid fence opens and closes (even backtick-fence count)**
+
+```powershell
+(Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern '^```' -AllMatches).Matches.Count
+```
+Expected: an even number (one open + one close per diagram; 5 diagrams total across sections 2, 4, 5, 6, 7 → 10).
+
+- [ ] **Step 3: Confirm the reserved Mermaid word `end` is never used as a bare node id**
+
+```powershell
+Select-String -Path "docs/design/00-frontier-firm-operating-model-for-insurance.md" -Pattern "\bEND\b|-->\s*end\b"
+```
+Expected: no matches.
+
+- [ ] **Step 4: Confirm every ADR cross-reference resolves to a real file**
+
+```powershell
+$adrs = @("ADR-0008-thin-crm-over-systems-of-record.md","ADR-0014-agents-advisory-by-design.md","ADR-0033-crm-ux-placement-in-b2e-landscape.md","ADR-0038-purview-power-platform-dynamics365-compliance.md")
+foreach ($a in $adrs) { Test-Path "docs/adr/$a" }
+```
+Expected: `True` for all four.
+
+- [ ] **Step 5: Confirm `AGENTS.md` and `docs/PERSONAS-JOURNEY.md` exist**
+
+```powershell
+Test-Path "AGENTS.md"
+Test-Path "docs/PERSONAS-JOURNEY.md"
+```
+Expected: `True`, `True`.
+
+- [ ] **Step 6: Check `docs/design/README.md`'s index description still fits**
+
+```powershell
+Select-String -Path "docs/design/README.md" -Pattern "Frontier Firm operating model for insurance"
+```
+Expected: one match, row still reads `| 00 | [Frontier Firm operating model for insurance](./00-frontier-firm-operating-model-for-insurance.md) | \`docs/FRONTIER-OPERATING-MODEL.md\` |`. No edit needed — the one-line description still accurately describes the expanded doc's purpose (it is still "the Frontier Firm operating model for insurance," now told in full rather than in outline).
+
+- [ ] **Step 7: Review the full diff for the whole change set**
+
+```bash
+git diff main -- docs/design/00-frontier-firm-operating-model-for-insurance.md | Out-String
+```
+Read it end to end. Confirm: no leftover old heading numbers, no duplicated section, no accidental deletion of the unchanged `## Decision` section, wording reads naturally across old/new section boundaries.
+
+- [ ] **Step 8: Fix anything found, then do a final commit only if Steps 1-7 required changes**
+
+```bash
+git add docs/design/00-frontier-firm-operating-model-for-insurance.md
+git commit -m "docs(design-pattern-00): fix issues found in final verification pass"
+```
+
+If Steps 1-7 found no issues, skip this commit — Task 6 and Task 7's commits are already the final state.

--- a/docs/superpowers/specs/2026-08-17-frontier-operating-model-pattern-00-expansion-design.md
+++ b/docs/superpowers/specs/2026-08-17-frontier-operating-model-pattern-00-expansion-design.md
@@ -1,0 +1,315 @@
+# Frontier Operating Model — Design Pattern 00 Expansion — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Status | Draft — pending user review |
+| Date | 2026-08-17 |
+| Author | AG-E-12 Frontier Firm Guide (drafted via Copilot CLI, brainstorming skill) |
+| Related | [docs/design/00-frontier-firm-operating-model-for-insurance.md](../../design/00-frontier-firm-operating-model-for-insurance.md) · [docs/FRONTIER-OPERATING-MODEL.md](../../FRONTIER-OPERATING-MODEL.md) · `docs/ideas/frontier-operating-system/` (00–05) · [docs/PERSONAS-JOURNEY.md](../../PERSONAS-JOURNEY.md) · [ADR-0014](../../adr/ADR-0014-agents-advisory-by-design.md) · [ADR-0038](../../adr/ADR-0038-purview-power-platform-dynamics365-compliance.md) · prior spec [2026-08-16-frontier-operating-model-design.md](./2026-08-16-frontier-operating-model-design.md) |
+| Licence | Documentation only — no runtime capability, no agent behaviour change |
+| Upgrade impact | Additive edit to one existing file (`docs/design/00-frontier-firm-operating-model-for-insurance.md`). No rename, no ADR change, no other file touched. |
+
+## 1. Purpose and scope
+
+This is step one of a broader, step-by-step wording-and-diagram polish pass across the repo's documentation (later steps, out of scope here, will apply the same treatment to other docs). This step expands
+`docs/design/00-frontier-firm-operating-model-for-insurance.md` ("Design
+Pattern 00") from its current short 4-section "method" doc into a full
+narrative that walks an EA/IT stakeholder through all six parts of the
+source idea-doc package (`docs/ideas/frontier-operating-system/00`–`05`),
+reworded for Contoso Insurance, each illustrated with a Mermaid diagram.
+`docs/FRONTIER-OPERATING-MODEL.md` remains the canonical full-detail
+reference — no content is forked or duplicated; condensed sections in
+Design Pattern 00 cross-link down to it for depth.
+
+## 2. Why this matters now
+
+- A prior initiative (PR #116, merged 2026-08-16) translated the idea-doc
+  package into `FRONTIER-OPERATING-MODEL.md` (full reference, §1–12) and
+  created Design Pattern 00 as a short "method" doc pointing at it.
+- Design Pattern 00 today only thinly reflects the idea docs: it has the
+  five-control-planes table and the four-step method, but nothing
+  resembling the north-star vision/loop (idea 00), the PRD's problem
+  statement/audiences/non-goals (idea 01), a control-plane architecture
+  diagram (idea 02), the agent roster (idea 03), HITL data classes/
+  redaction pattern (idea 04), or the phased roadmap (idea 05). Several of
+  those (idea 01's PRD framing, idea 02's diagram, idea 04's data-class/
+  redaction detail) don't live anywhere yet, even in condensed form.
+- `docs/design/README.md` already instructs demo presenters to "start with
+  pattern 00 to set the Frontier Firm mental model" — so it should actually
+  deliver that mental model, not just point elsewhere for all of it.
+
+## 3. Decisions already made (brainstorming Q&A, 2026-08-17)
+
+| Question | Decision |
+| --- | --- |
+| Target shape | Expand to a full 6-part narrative — one insurance-reworded subsection + diagram per idea doc (00–05) |
+| Overlap with `FRONTIER-OPERATING-MODEL.md` | Condensed + cross-link — no content forked in two places |
+| Working branch | Continue on `docs/s3-test-evidence-e2e-verify` (no new branch). Flag: this branch carries an active, unrelated PR #119 (sprint-003 test evidence) — this change will land in its own clean, separately-scoped commit so it can be split out later if needed. |
+
+## 4. Approaches considered
+
+**Approach A — expand Design Pattern 00 in place, condensed-with-cross-links (chosen).**
+Delivers the full mental model in the doc that's supposed to set it, with
+no duplication. Trade-off: the doc grows roughly 6–8× in length (~50 →
+~300–400 lines) — still single-purpose, but a longer read.
+
+**Approach B — keep Design Pattern 00 short, push all depth into
+`FRONTIER-OPERATING-MODEL.md` only (rejected by user).** Smaller diff,
+stays skimmable, but doesn't fulfil the "start with pattern 00 to set the
+mental model" promise — the reader has to jump elsewhere for almost
+everything.
+
+**Approach C — merge Design Pattern 00 and `FRONTIER-OPERATING-MODEL.md`
+into one doc (rejected).** Zero duplication risk, but conflates two
+different audiences/purposes: Design Pattern 00 is a demo-ready
+walkthrough; `FRONTIER-OPERATING-MODEL.md` is a full reference that also
+carries spec-style bookkeeping sections (§10 Deliverables, §11 Out of
+scope, §12 Open validation triggers). `docs/design/README.md`'s whole
+premise is a library of short, demo-ready pattern docs distinct from deep
+reference docs — merging breaks that premise.
+
+## 5. Detailed design — new section-by-section structure
+
+Final structure, in order (titles are final; renumbered sections keep
+their existing content unchanged except for the number):
+
+1. **Why a Frontier Firm model for an insurer** — unchanged, wording
+   tightened only.
+2. **NEW — Vision and the operating loop** *(from idea 00)*
+   - Vision statement, adapted:
+     > Every relevant interaction with a customer, employee, or system
+     > automatically strengthens Contoso Insurance's advice, product, and
+     > processes.
+     >
+     > Contoso Insurance becomes a Human-led, Agent-operated advisory
+     > practice, where the B2E/Work IQ layer steers human-agent
+     > interaction, GitHub orchestrates the digital delivery, and
+     > Dataverse reflects the operational reality.
+   - Frontier-Firm principles (6, reworded and tied to existing ADRs):
+     Human-led (ADR-0014) · Agent-operated (`AG-F-##`/`AG-E-##`) ·
+     HITL-controlled (ADR-0014) · GitHub-driven (`AGENTS.md` §3) ·
+     Dataverse-backed (ADR-0008) · Teams/B2E-visible (ADR-0033).
+   - Diagram (draft, illustrative):
+     ```mermaid
+     flowchart LR
+         classDef stage fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+         I[Insight]:::stage --> D[Decision]:::stage --> DL[Delivery]:::stage --> O[Outcome]:::stage --> L[Learning]:::stage --> I
+
+         subgraph Sources["Where insight comes from"]
+             direction TB
+             S1[Advisory conversations]
+             S2[Service and claims cases]
+             S3[Teams / B2E reviews]
+             S4[Product usage]
+             S5[Customer feedback]
+             S6[Sprint reviews]
+         end
+         Sources --> I
+     ```
+   - Cross-link: `FRONTIER-OPERATING-MODEL.md` §4 (North-star loop and
+     existing traceability) for the stage-by-mechanism mapping table.
+3. **NEW — What the operating model must deliver** *(condensed PRD, from
+   idea 01)*
+   - Problem statement, adapted: insight today lives in silos (Teams/B2E
+     discussions, advisory notes, meeting transcripts, GitHub issues,
+     sprint reviews, product usage, customer feedback, operational
+     Dataverse data) — without a standardized loop it risks going
+     uncaptured, unprioritized, undelivered, or unmeasured.
+   - Audiences — mapped to this repo's **real personas**
+     (`docs/PERSONAS-JOURNEY.md`), not generic labels: primary =
+     P-01 Advisor/GA, P-02 General Agent lead, P-03 Assistance agent,
+     P-04 Marketer, P-05 Broker manager; secondary = P-06 IT/Architect,
+     P-07 Business owner/Data steward, plus the engineering agents
+     (`AG-E-01` Product Owner et al.) as the "build it" audience.
+   - Non-goals (from idea 01 §8, reworded, tied to ADR-0014/ADR-0038): no
+     fully autonomous prioritization without human sign-off; no autonomous
+     PROD deployment without review; no unreviewed processing of sensitive
+     customer data (health, financial exposure, claims) by an arbitrary
+     agent; no wholesale replacement of existing advisory or engineering
+     processes; no autonomously issued binding recommendations, quotes, or
+     policy changes.
+   - No diagram for this section — a short table is clearer than a
+     diagram here, consistent with the "condensed" decision (no
+     diagram-for-diagram's-sake).
+   - Cross-link: none exists in `FRONTIER-OPERATING-MODEL.md` today — this
+     is genuinely net-new content, not a duplicate.
+4. **The five control planes and how they connect** — keep the existing
+   table verbatim; **add** a Mermaid diagram (draft):
+   ```mermaid
+   flowchart TB
+       classDef msft fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+       classDef contoso fill:#fde8e8,stroke:#b91c1c,stroke-width:1px,color:#111111
+       classDef shared fill:#e5e5e5,stroke:#666666,stroke-width:1px,color:#111111
+
+       CE["Customers and Employees"]:::shared
+       BP["Business / Teams and B2E"]:::shared
+       IP["Interaction / Work IQ (documented only)"]:::msft
+       AP["Agent / Copilot Agent Mesh"]:::msft
+       EP["Engineering / GitHub"]:::msft
+       OP["Operational / Dataverse and Power Platform"]:::shared
+       TL["Teams / B2E transparency loop"]:::shared
+
+       CE --> BP --> IP --> AP --> EP --> OP --> TL --> BP
+   ```
+   This reuses the existing `msft`/`contoso`/`shared` ownership colour
+   convention from `FRONTIER-OPERATING-MODEL.md`'s Solution Context
+   diagrams, because this diagram genuinely encodes the same dimension
+   (who owns/builds each plane). Cross-link: `FRONTIER-OPERATING-MODEL.md`
+   §5 (adapted table with Built/Documented-only status) + the Solution
+   Context diagrams for full Contoso-specific architecture.
+5. **NEW — The agent roster behind the planes** *(from idea 03, reusing
+   `FRONTIER-OPERATING-MODEL.md` §6's table rather than re-deriving from
+   the German original)*
+   - Short intro: agents are advisory; they recommend, never decide
+     (ADR-0014).
+   - Reuse `FRONTIER-OPERATING-MODEL.md` §6's role-mapping table as-is
+     (idea-doc role → existing agent(s) → notes).
+   - Diagram (draft) visualizing the runtime-vs-engineering agent split
+     that `AGENTS.md` draws (its "two classes of agent" framing) but that
+     isn't diagrammed anywhere yet:
+     ```mermaid
+     flowchart LR
+         classDef stage fill:#ffffff,stroke:#333333,stroke-width:1px,color:#111111
+         SIG["Customer / employee signal"]:::stage --> RUN["Runtime agent (AG-F-##)\nadvisory only"]:::stage
+         RUN --> HUM{"Human decision:\naccept / edit / dismiss"}
+         HUM -- "becomes a product change" --> ENG["Engineering agent (AG-E-##)"]:::stage
+         ENG --> GH["GitHub issue / PR"]:::stage
+         HUM -- "no change needed" --> END[No further action]
+     ```
+   - Cross-link: `FRONTIER-OPERATING-MODEL.md` §6 (full table + rationale),
+     `AGENTS.md` (full agent registry + non-delegable authority rules).
+6. **NEW — HITL governance and data sensitivity** *(from idea 04)*
+   - Governance principles (5, reworded): agents produce proposals, not
+     final decisions, in critical processes; sensitive customer data is
+     minimized/redacted before reaching GitHub; every relevant publication
+     or handoff has a named owner; every agent action is traceable;
+     automation may increase transparency but never replaces
+     accountability.
+   - Data classes reworded for insurance (4 classes, each with examples +
+     processing rule): public/non-critical; internal business data;
+     personal customer data/PII (redaction + purpose limitation + human
+     review); sensitive data — health for life/health lines, financial
+     exposure, claims specifics (highest protection class, no unreviewed
+     GitHub handoff, only abstracted requirements or anonymized patterns).
+   - One insurance-flavored redaction-pattern example (raw signal → GitHub-
+     safe version → proper user story), e.g.:
+     - Raw: "Customer Jane Doe mentioned during her claim follow-up that
+       the online claim-status tracker is confusing."
+     - GitHub-safe: "A customer mentioned during a claim follow-up that
+       the online claim-status tracker is confusing."
+     - As a requirement: "As a customer, I want to track my claim status
+       with minimal steps, so that I don't need to call the service desk
+       for updates."
+   - Diagram (draft) — approval-state flow from idea 04 §7:
+     ```mermaid
+     stateDiagram-v2
+         [*] --> DraftedByAgent
+         DraftedByAgent --> NeedsHumanReview
+         NeedsHumanReview --> Approved
+         NeedsHumanReview --> NeedsChanges
+         NeedsHumanReview --> Rejected
+         NeedsChanges --> NeedsHumanReview
+         Approved --> CreatedInGitHub
+         CreatedInGitHub --> InSprint
+         InSprint --> DeliveredToTest
+         DeliveredToTest --> DeliveredToProd
+         DeliveredToProd --> OutcomeReviewed
+         OutcomeReviewed --> [*]
+         Rejected --> [*]
+     ```
+   - Cross-link: `FRONTIER-OPERATING-MODEL.md` §7 (thin HITL/governance
+     section), ADR-0014, ADR-0038.
+7. **Roadmap, phased and status-tagged** *(condensed from idea 05, reusing
+   `FRONTIER-OPERATING-MODEL.md` §9's six phases and Built/Demoed/
+   Documented-only tags verbatim rather than re-deriving from idea 05)*
+   - Diagram (draft) — **deliberately a new, distinct colour convention**
+     from the `msft`/`contoso`/`shared` ownership palette used in §4,
+     because this diagram encodes a different dimension (delivery status,
+     not system ownership) — reusing the same 3 colours for two different
+     meanings across diagrams would confuse readers, not create alignment:
+     ```mermaid
+     flowchart LR
+         classDef built fill:#d1fae5,stroke:#065f46,stroke-width:1px,color:#111111
+         classDef demoed fill:#fef3c7,stroke:#92400e,stroke-width:1px,color:#111111
+         classDef docOnly fill:#e5e5e5,stroke:#666666,stroke-width:1px,stroke-dasharray: 4 2,color:#111111
+
+         P0["Phase 0: Foundation"]:::built --> P1["Phase 1: Teams/B2E to GitHub transparency"]:::demoed
+         P1 --> P2["Phase 2: Work IQ agent intake"]:::docOnly
+         P2 --> P3["Phase 3: Sprint review to GitHub"]:::built
+         P3 --> P4["Phase 4: Release to outcome loop"]:::demoed
+         P4 --> P5["Phase 5: Agent mesh scaling"]:::demoed
+     ```
+     Legend: green = Built, amber = Demoed via docs, grey dashed =
+     Documented-only.
+   - Cross-link: `FRONTIER-OPERATING-MODEL.md` §9 for the full phase
+     descriptions (reused verbatim, so no new detail is needed here).
+8. **A four-step establishment method** — unchanged content, renumbered
+   from the current §3.
+9. **Contoso Insurance as the worked example** — unchanged content,
+   renumbered from the current §4, with its bullet list extended so items
+   now covered in this same doc point at sections 2/3/5/6/7 above, while
+   items still only detailed in `FRONTIER-OPERATING-MODEL.md` (terminology
+   adaptation §3, the Work IQ↔GitHub pattern §8) keep pointing there.
+
+Unchanged closing sections, both updated only for the new walk order:
+
+- **Validate this live** — walk order becomes: this doc section by section
+  (2 vision → 3 requirements → 4 control planes → 5 agents → 6 governance
+  → 7 roadmap → 8 method → 9 worked example), then
+  `FRONTIER-OPERATING-MODEL.md` for full depth, then
+  `docs/superpowers/sprints/` for the delivery-evidence loop.
+- **Decision** — unchanged; still no accept/reject recorded (this remains
+  a method doc, not an ADR).
+
+## 6. Diagram inventory
+
+| # | Section | Diagram type | Shows | Colour convention |
+| --- | --- | --- | --- | --- |
+| 1 | §2 Vision and operating loop | `flowchart` | Insight→Decision→Delivery→Outcome→Learning loop + insurance-specific insight sources | Plain (process flow, not ownership) |
+| 2 | §4 Five control planes | `flowchart TB` | Customers/Employees through the 5 planes and back to the transparency loop | Reuses `msft`/`contoso`/`shared` ownership classDef |
+| 3 | §5 Agent roster | `flowchart LR` | Signal → runtime agent → human decision → engineering agent → GitHub | Plain (process flow) |
+| 4 | §6 HITL governance | `stateDiagram-v2` | Approval-state flow, Drafted → Outcome Reviewed | Plain (state flow) |
+| 5 | §7 Roadmap | `flowchart LR` | 6 phases, coloured by delivery status | New `built`/`demoed`/`docOnly` classDef — deliberately distinct from the ownership palette |
+
+## 7. Content grounding / sourcing map
+
+| Section | Primary source | Reused from this repo | Net-new authoring |
+| --- | --- | --- | --- |
+| §2 Vision and operating loop | idea 00 §2–3 | `FRONTIER-OPERATING-MODEL.md` §4 (cross-linked, not copied) | Vision statement reworded; diagram is new |
+| §3 What it must deliver | idea 01 §3, 5, 8 | `docs/PERSONAS-JOURNEY.md`, ADR-0014 | Problem statement, audience table, non-goals — all newly condensed |
+| §4 Five control planes | idea 02 §3–4 (diagram only) | Existing table kept verbatim | New diagram only |
+| §5 Agent roster | idea 03 §2–3 (principles + roster names) | `FRONTIER-OPERATING-MODEL.md` §6 table (reused verbatim) | Intro paragraph + new small diagram |
+| §6 HITL governance | idea 04 §2–5, 7 | ADR-0014, ADR-0038 (cross-linked) | Principles/data classes/redaction example reworded; diagram new |
+| §7 Roadmap | idea 05 (phase names only) | `FRONTIER-OPERATING-MODEL.md` §9 (six phases + status tags reused verbatim) | New diagram only |
+| §8 Method | n/a (repo-original) | Existing §3 kept as-is | None |
+| §9 Worked example | n/a | Existing §4 kept | Bullet list extended only |
+
+## 8. Out of scope for this spec
+
+- No changes to `FRONTIER-OPERATING-MODEL.md`, `MICROSOFT-FRAMEWORKS.md`,
+  or any ADR in this pass (later steps in the broader polish initiative may
+  revisit them).
+- No changes to the other 11 `docs/design/*.md` pattern docs.
+- No renumbering or renaming of any agent, ADR, or file.
+- No new external citations — this reuses `FRONTIER-OPERATING-MODEL.md`
+  §2's existing grounding table by reference rather than re-citing sources.
+
+## 9. Validation / acceptance criteria
+
+- Every internal cross-reference (to `FRONTIER-OPERATING-MODEL.md`
+  sections, ADRs, `AGENTS.md`, `PERSONAS-JOURNEY.md`) resolves to a real,
+  existing anchor.
+- Every new Mermaid diagram uses valid `flowchart`/`stateDiagram-v2` syntax
+  and renders in GitHub's built-in Mermaid preview.
+- `docs/design/README.md`'s one-line index description for pattern 00
+  still accurately describes the doc after expansion (check wording, tweak
+  only if it now undersells the doc).
+- No content is copied verbatim from `FRONTIER-OPERATING-MODEL.md` beyond
+  short quoted table rows — new prose is freshly condensed, not pasted.
+- The file keeps its existing path and filename (no rename).
+
+## 10. Open questions / risks
+
+- Final doc length (~300–400 lines) is acceptable for a demo/reference
+  doc; flag during review if it should be split instead.
+- None blocking.

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -16,7 +16,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, #106 ✅ merged | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
 | mda-app | #64 | DESIGN-SENSITIVE | feat/s3-mda-app-publish (deleted, merged), feat/s3-solution-version-sync-and-app-reconcile (deleted, merged), fix/pcf-control-import-scaffolding (deleted, merged), fix/pcf-control-naming (deleted, merged) | #100 (docs), #110 ✅ merged, #112 ✅ merged, #114 ✅ merged, #115 ✅ merged | ✅ both PCF controls live-imported in DEV under final names | `publish-advisor-cockpit-app.ps1` implements the sitemap/app-module/component/role reconciliation end to end (10/10 plan tasks, 21/21 Pester, 2 Dataverse Web API protocol bugs found+fixed in review) and is wired into `cd-solution-dev.yml` (2026-08-15, merged `75d89c8`); owner manually authored the app module + sitemap live in DEV (`crmshow_AdvisorCockpit`) while diagnosing why the app wasn't visible — contract reconciled to match, real `clientType=4`/`formFactor=1` confirmed (#112, merged `306c9b6`); `Set-SolutionVersions.ps1` closes a repo-wide gap where manifest.json-declared versions never reached live Dataverse; Custom Page hosting approach abandoned in favour of Contact Form hosting; `pac pcf push` root-caused to 3 hand-scaffolding defects (missing `.targets` imports, control manifest not in a `<ControlName>/` subfolder causing the compiled solution-packager task to silently drop it from `<CustomControls>`, missing eslint config/deps) — **not** a missing VS workload; both `crmshow_crmshow.AdvisorCockpit` and `crmshow_crmshow.SalesLeaderDashboard` confirmed as real components of `crmshow_Sales` via `pac solution export` (#114); **follow-up naming fix (#115, merged):** technical names shortened to `crmshow_PCF.AdvisorCockpit` / `crmshow_PCF.SalesLeaderDashboard` (namespace `crmshow` was redundant with the `crmshow` publisher prefix — Dataverse's `<prefix>_<namespace>.<constructor>` dot is a hard platform constraint, confirmed via Microsoft Learn) with distinct display names `CRMShow_AdvisorCockpit` / `CRMShow_SalesLeaderDashboard`; the resulting orphaned `crmshow_crmshow.*` components were deleted from DEV via the Maker Portal (no `pac` CLI path exists for single-component deletion), verified via `pac solution export` showing only the two `crmshow_PCF.*` controls remain |
-| e2e-verify | #65 | EXECUTION-ONLY | — | — | ⏳ DEV-gated | DEV→TEST evidence; #64 now complete, this stream is next |
+| e2e-verify | #65 | EXECUTION-ONLY | feat/s3-test-promote-sales | #118 ⏳ open | 🚧 in progress | DEV dispatch `31962217108` found a pre-existing lead-lookup metadata bug (blocks a fully-green DEV run, not this stream's own work); TEST dispatch `31963834793` rejected by environment protection (needs PR #118 merged to `main` first) |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
 
 ## Run log
@@ -764,6 +764,25 @@ Live status for the Advisor Cockpit (charter **#55**). See the
   stream **#64 (mda-app) is complete**; stream **#65 (e2e-verify, DEV→TEST
   promotion)** is next.
 
+- **2026-08-16 (e2e-verify started; DEV dispatch found a new bug; TEST
+  dispatch confirmed the branch-protection gate) -** Opened **PR #117**
+  (this STATUS.md reconciliation) and **PR #118** (adds
+  `crmshow_Integration`/`crmshow_Sales` to `cd-solution-test.yml`, since
+  neither was wired into the TEST promotion pipeline). Dispatched a fresh
+  `cd-solution-dev.yml` on `main` (run `31962217108`) to refresh the stale
+  DEV evidence noted below — it failed partway through `author`, surfacing
+  a genuine, pre-existing bug unrelated to this sprint's PCF/mda-app work:
+  `Publish-InsuranceFoundation.ps1` tries to create the
+  `crmshow_leadclusterid` Lookup column on `lead` via a plain metadata
+  Attributes POST, which Dataverse rejects for Lookup types. Then dispatched
+  `cd-solution-test.yml` from PR #118's branch to exercise the new
+  Sales-promotion logic — GitHub rejected it outright with *"Branch
+  ... is not allowed to deploy to dev due to environment protection
+  rules"*, confirming the `dev`/`test` Environments only accept dispatches
+  from `main`. Both PRs are open, un-merged, and were **not self-merged**
+  by the agent per the sprint operating model. Full detail in the evidence
+  section immediately below.
+
 ## Live DEV + TEST evidence
 
 Required by the [Sprint Operating Model's "Sprint closing" policy](../../SPRINT-OPERATING-MODEL.md#sprint-closing--required-dev--test-evidence)
@@ -773,17 +792,30 @@ sprint can be called closed. Mirrors the structure of
 — one row per pipeline step, run links, and actual test-count evidence, not
 bare claims.
 
-**DEV evidence — stale, a fresh run is needed.** The most recent
-confirmed-green live DEV run is
+**DEV evidence — fresh run attempted (2026-08-16), failed; found a new,
+pre-existing bug.** Dispatched
+[31962217108](https://github.com/urruegg/CRMShowcase/actions/runs/31962217108)
+against `main`: `validate` green (offline suite passed); `author` reached
+`Reconcile demo-safe metadata` and failed there —
+`Publish-InsuranceFoundation.ps1` POSTs the new `crmshow_leadclusterid`
+Lookup column (`lead` → `crmshow_leadcluster`, added per the schema in
+`solution/schema/insurance-foundation.json`, ADR-0009) straight to
+`EntityDefinitions(LogicalName='lead')/Attributes`, which Dataverse's
+metadata Web API rejects for Lookup-type attributes
+(`0x80040203: Attribute of type LookupAttributeMetadata cannot be created
+through the SDK`) — lookups must be created via the relationship-creation
+endpoint instead. This is the first live run to exercise this code path
+(the prior confirmed-green run,
 [31805085480](https://github.com/urruegg/CRMShowcase/actions/runs/31805085480)
-(2026-08-14, before the seed-pipeline PRs in this document): `validate`
-12m22s, `author` 9m13s, full offline suite green. That run predates
-PRs #101–#106 (claims/`crmshow_seedkey`/`Get-AccountKeyMap`/account
-upserts/seed+smoke pipeline steps), all of which are now merged to `main` —
-**a new dispatch is needed** to author anything still pending intake-export
-and to produce the first live evidence of the seed + smoke steps actually
-running (including observing the documented two-pass-convergence behavior).
-Not yet done.
+from 2026-08-14, predates it). Everything the script reconciled *before*
+that step (account/contact fields incl. `crmshow_seedkey`,
+`crmshow_mastershipstatus`, `crmshow_mastersystem`, `crmshow_lastsyncedon`,
+`crmshow_consentemail`, `crmshow_consentphone`) succeeded and is live in
+DEV — Dataverse metadata changes are not transactional across the whole
+script, so this is a partial-but-not-corrupt state. **Not yet fixed** —
+tracked as a new gap under foundational-tables (#57); needs the lookup/
+relationship creation call fixed in `Publish-InsuranceFoundation.ps1` (or
+its underlying Dataverse client) before a fully green DEV run is possible.
 
 **TEST evidence — not started, now unblocked.** No promotion of this
 sprint's schema/data to TEST has been attempted yet. It was sequentially
@@ -794,9 +826,23 @@ starting under stream `e2e-verify` (#65) in the table above.
 **Gap found while starting #65:** `cd-solution-test.yml` today only
 exports/imports `crmshow_Foundation` and `crmshow_DataModel` — it does not
 include `crmshow_Sales` (the solution holding the Advisor Cockpit MDA app +
-both PCF controls). This solution needs to be added to the promotion
-pipeline before a TEST dispatch can produce any evidence of this sprint's
-actual surface.
+both PCF controls), nor its dependency `crmshow_Integration`. Fixed in
+**PR #118** (open, not yet merged): adds both to the `export-from-dev` and
+`import-to-test` jobs, importing in `solution/manifest.json` `dependsOn`
+order (Foundation → DataModel → Integration → Sales).
+
+**TEST dispatch attempted (2026-08-16), rejected by environment protection
+— confirms the governance model is working as intended.** Dispatching
+`cd-solution-test.yml` from PR #118's branch
+([31963834793](https://github.com/urruegg/CRMShowcase/actions/runs/31963834793))
+was rejected outright by GitHub before any step ran: *"Branch
+'feat/s3-test-promote-sales' is not allowed to deploy to dev due to
+environment protection rules."* The `dev`/`test` GitHub Environments are
+restricted to deployments from `main` — so PR #118 (and ideally #117) must
+be reviewed and merged first; per this repo's sprint operating model, that
+merge is **not self-service by the agent** ("PR intake, never self-merge —
+human merge"). Once merged, re-dispatch `cd-solution-test.yml` from `main`
+to produce the first-ever TEST evidence for this sprint.
 
 **Reason TEST had not been reached until now (explicit, per the anchored
 policy — not a silent omission):** sprint-003's own path was

--- a/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
+++ b/docs/superpowers/sprints/sprint-003-advisor-cockpit/STATUS.md
@@ -16,7 +16,7 @@ Live status for the Advisor Cockpit (charter **#55**). See the
 | cockpit-tables | #58 | EXECUTION-ONLY | feat/s3-phase3-cockpit-tables | #100 (docs) | ✅ DEV-authored (run 31805085480, 2026-08-14) | `crmshow_nextbestaction`/`crmshow_nbaprovenance`/`crmshow_measuresnapshot` authored live in DEV; source intake-export into `solution/core/datamodel` still pending |
 | seed-pipeline | #60 (follow-up) | EXECUTION-ONLY | feat/s3-seed-claims-mapping, feat/s3-account-seedkey, feat/s3-account-keymap-resolver, feat/s3-account-upserts, feat/s3-cd-seed-wiring | #101 ✅ merged, #102 ✅ merged, #103 ✅ merged, #104 ✅ merged (docs), #105 ✅ merged, #106 ✅ merged | ✅ code-complete | claims.json mapped to `crmshow_claimprojection` + 14/14 Pester (#101); `crmshow_seedkey` added to `account` (#102, contract 1.2.0); `Get-AccountKeyMap` resolver auto-wired into `Invoke-AdvisorCockpitSeed` (#103, 17/17 Pester); account upserts (name/crmshow_accounttype/crmshow_seedkey) implemented via POST-or-PATCH-by-GUID since `account` has no registered Dataverse alternate key (#105, 22/22 Pester); `cd-solution-dev.yml` now calls `seed-advisor-cockpit.ps1` after convergence validation (2026-08-15) — code-complete end-to-end, not yet verified against a live dispatch; contacts/roles + policies.json deferred separately |
 | mda-app | #64 | DESIGN-SENSITIVE | feat/s3-mda-app-publish (deleted, merged), feat/s3-solution-version-sync-and-app-reconcile (deleted, merged), fix/pcf-control-import-scaffolding (deleted, merged), fix/pcf-control-naming (deleted, merged) | #100 (docs), #110 ✅ merged, #112 ✅ merged, #114 ✅ merged, #115 ✅ merged | ✅ both PCF controls live-imported in DEV under final names | `publish-advisor-cockpit-app.ps1` implements the sitemap/app-module/component/role reconciliation end to end (10/10 plan tasks, 21/21 Pester, 2 Dataverse Web API protocol bugs found+fixed in review) and is wired into `cd-solution-dev.yml` (2026-08-15, merged `75d89c8`); owner manually authored the app module + sitemap live in DEV (`crmshow_AdvisorCockpit`) while diagnosing why the app wasn't visible — contract reconciled to match, real `clientType=4`/`formFactor=1` confirmed (#112, merged `306c9b6`); `Set-SolutionVersions.ps1` closes a repo-wide gap where manifest.json-declared versions never reached live Dataverse; Custom Page hosting approach abandoned in favour of Contact Form hosting; `pac pcf push` root-caused to 3 hand-scaffolding defects (missing `.targets` imports, control manifest not in a `<ControlName>/` subfolder causing the compiled solution-packager task to silently drop it from `<CustomControls>`, missing eslint config/deps) — **not** a missing VS workload; both `crmshow_crmshow.AdvisorCockpit` and `crmshow_crmshow.SalesLeaderDashboard` confirmed as real components of `crmshow_Sales` via `pac solution export` (#114); **follow-up naming fix (#115, merged):** technical names shortened to `crmshow_PCF.AdvisorCockpit` / `crmshow_PCF.SalesLeaderDashboard` (namespace `crmshow` was redundant with the `crmshow` publisher prefix — Dataverse's `<prefix>_<namespace>.<constructor>` dot is a hard platform constraint, confirmed via Microsoft Learn) with distinct display names `CRMShow_AdvisorCockpit` / `CRMShow_SalesLeaderDashboard`; the resulting orphaned `crmshow_crmshow.*` components were deleted from DEV via the Maker Portal (no `pac` CLI path exists for single-component deletion), verified via `pac solution export` showing only the two `crmshow_PCF.*` controls remain |
-| e2e-verify | #65 | EXECUTION-ONLY | feat/s3-test-promote-sales | #118 ⏳ open | 🚧 in progress | DEV dispatch `31962217108` found a pre-existing lead-lookup metadata bug (blocks a fully-green DEV run, not this stream's own work); TEST dispatch `31963834793` rejected by environment protection (needs PR #118 merged to `main` first) |
+| e2e-verify | #65 | EXECUTION-ONLY | feat/s3-test-promote-sales | #118 ✅ merged | 🚧 in progress | TEST run `31964290915`: `crmshow_Foundation`/`DataModel`/`Integration` promoted to TEST for the first time this sprint; `crmshow_Sales` blocked — its DEV app module has a stray MCP Server/Copilot-Agent dependency (pre-flagged in the intake BOM as `targetSolution=None`, never resolved) not present in the exported package or in TEST |
 | nba-agent | #61 | DESIGN-SENSITIVE | — | — | ⏸ deferred | out of sprint; needs a use-case description |
 
 ## Run log
@@ -827,22 +827,63 @@ starting under stream `e2e-verify` (#65) in the table above.
 exports/imports `crmshow_Foundation` and `crmshow_DataModel` — it does not
 include `crmshow_Sales` (the solution holding the Advisor Cockpit MDA app +
 both PCF controls), nor its dependency `crmshow_Integration`. Fixed in
-**PR #118** (open, not yet merged): adds both to the `export-from-dev` and
+**PR #118** (merged): adds both to the `export-from-dev` and
 `import-to-test` jobs, importing in `solution/manifest.json` `dependsOn`
 order (Foundation → DataModel → Integration → Sales).
 
-**TEST dispatch attempted (2026-08-16), rejected by environment protection
+**TEST dispatch attempt #1 (2026-08-16), rejected by environment protection
 — confirms the governance model is working as intended.** Dispatching
 `cd-solution-test.yml` from PR #118's branch
 ([31963834793](https://github.com/urruegg/CRMShowcase/actions/runs/31963834793))
 was rejected outright by GitHub before any step ran: *"Branch
 'feat/s3-test-promote-sales' is not allowed to deploy to dev due to
 environment protection rules."* The `dev`/`test` GitHub Environments are
-restricted to deployments from `main` — so PR #118 (and ideally #117) must
+restricted to deployments from `main` — confirms PR #118 (and #117) had to
 be reviewed and merged first; per this repo's sprint operating model, that
-merge is **not self-service by the agent** ("PR intake, never self-merge —
-human merge"). Once merged, re-dispatch `cd-solution-test.yml` from `main`
-to produce the first-ever TEST evidence for this sprint.
+merge was **not self-service by the agent** ("PR intake, never self-merge —
+human merge"). Owner approved and merged both PRs 2026-08-16.
+
+**TEST dispatch attempt #2 (2026-08-16/17), first-ever partial TEST
+evidence — 3 of 4 solutions promoted; `crmshow_Sales` blocked on a
+pre-flagged external dependency.** Re-dispatched
+`cd-solution-test.yml` from `main`
+([31964290915](https://github.com/urruegg/CRMShowcase/actions/runs/31964290915)):
+`export-from-dev` green (all four solutions exported). The `test`
+Environment required manual approval — dispatched ~20:20, approved
+overnight, `import-to-test` resumed ~05:58 the next morning. Imports then
+ran **in manifest `dependsOn` order and each one published successfully**:
+`crmshow_Foundation` (~5 min incl. publish), `crmshow_DataModel` (~4 min),
+`crmshow_Integration` (~1.5 min) — **all three now confirmed live in TEST
+for the first time this sprint.** `crmshow_Sales` then failed:
+
+```
+Error: Solution manifest import: FAILURE: The following solution cannot be
+imported: crmshow_Sales. Some dependencies are missing.
+  Required: MCPServer "crmshow_AdvisorCockpit_MCPServer"
+  Required: uxagentproject {57de26e1-9bfa-452d-a8e8-fa45a00dd0e5}
+  (both dependencies of AppElement crmshow_AdvisorCockpit)
+```
+
+The live DEV `crmshow_AdvisorCockpit` app module has picked up a hard
+dependency on an MCP Server + Copilot Studio Agent-Builder project
+(`uxagentproject`) — almost certainly added automatically by the Maker
+Portal App Designer when the owner manually authored the app module/sitemap
+live in DEV (see the mda-app entry above). **Neither component is part of
+the exported `crmshow_Sales` managed package**, and neither exists in TEST,
+so the import is rejected. This is not a new/surprise risk: the exact same
+external-dependency shape (`type:MCPServer`, donor name
+`cr7e8_AdvisorCockpit_MCPServer`) was already flagged during the original
+intake BOM analysis
+([intake/contoso-insurance/bom/artefacts.csv](../../../../intake/contoso-insurance/bom/artefacts.csv#L603)),
+with `disposition=Investigate`, `targetSolution=None` (i.e. explicitly
+**not** meant to be carried into `crmshow_Sales`), and
+`licenceReview=Required`. It silently reappeared (recreated with the
+`crmshow_` prefix) when the app module was hand-authored in DEV, and has
+never been removed or resolved. **Not fixed** — needs a human decision
+(remove the Copilot/AI-assistant feature from the `crmshow_AdvisorCockpit`
+app module in DEV to drop the dependency, or deliberately promote the
+MCP Server/Agent to TEST too) before `crmshow_Sales` can be promoted;
+tracked as a new gap under stream `e2e-verify` (#65).
 
 **Reason TEST had not been reached until now (explicit, per the anchored
 policy — not a silent omission):** sprint-003's own path was


### PR DESCRIPTION
## What
Records the first-ever live TEST promotion evidence for sprint-003, and documents a newly-found blocker for `crmshow_Sales`.

## Results
- **`crmshow_Foundation`, `crmshow_DataModel`, `crmshow_Integration`**: imported and published successfully into TEST (run [31964290915](https://github.com/urruegg/CRMShowcase/actions/runs/31964290915)) — first time this sprint.
- **`crmshow_Sales`**: import rejected — the live DEV `crmshow_AdvisorCockpit` app module depends on an MCP Server + Copilot Studio Agent-Builder project (`uxagentproject`) that isn't in the exported package and doesn't exist in TEST.
- This exact dependency shape was already flagged during the original intake BOM analysis (`targetSolution=None`, `disposition=Investigate`) but was never resolved before the app module was hand-authored live in DEV.

## Also recovers an orphaned commit
A prior STATUS.md commit was pushed to `docs/s3-status-reconcile-115` *after* PR #117 had already merged, so it never landed on `main`. Cherry-picked here, and the stale branch was deleted.

## Next step (not in this PR)
Needs a human decision: remove the Copilot/AI-assistant feature from the `crmshow_AdvisorCockpit` app module in DEV to drop the dependency, or deliberately promote the MCP Server/Agent to TEST too.

## Traceability
US-story: #65 (e2e-verify), sprint-003 (#55). Docs-only change.