### PR TITLE
sprint-004/tenant-user-inventory: resolve DEV/TEST presenter identity

### DIFF
--- a/scripts/solution/Get-DemoPresenterUser.ps1
+++ b/scripts/solution/Get-DemoPresenterUser.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+    Resolves the demo presenter identity for a Dataverse environment (Sprint-004).
+.DESCRIPTION
+    Personalized live demos need seeded records owned by a real, loggable-in
+    identity. Rather than committing a personal UPN/e-mail to this (public)
+    repository, the presenter is resolved at runtime by role pattern: the
+    enabled, interactive (accessmode = 0, i.e. Read-Write) System
+    Administrator in the target environment. This deliberately excludes CI
+    application users (accessmode = 4, Non-interactive — see ADR-0005) and
+    any disabled account.
+
+    When more than one qualifying user is found, resolution is deterministic
+    (sorted by fullname, first wins) with a logged warning naming the count,
+    so a live-demo operator knows which identity got assigned. An explicit
+    -PresenterUserId always wins and skips the Dataverse query entirely.
+
+    Throws when no qualifying user is found, rather than silently seeding
+    ownerless demo data or falling back to a non-interactive application
+    user — owner assignment is the whole point of this script.
+
+    Live-verified (2026-08-17) against crmshowdev: the sole enabled,
+    interactive user is the tenant's own admin@ABSx15847880.onmicrosoft.com
+    ("MOD Administrator", accessmode 0, System Administrator + Basic User
+    roles); the CI application user "# crm-showcase-ci-dev" is accessmode 4
+    and is correctly excluded by this filter.
+#>
+[CmdletBinding()]
+param(
+    [string]$EnvironmentUrl,
+    [string]$PresenterUserId
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-DemoPresenterUser {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$EnvironmentUrl,
+        [string]$PresenterUserId
+    )
+
+    if ($PresenterUserId) {
+        return $PresenterUserId
+    }
+
+    $baseUrl = $EnvironmentUrl.TrimEnd('/')
+    $url = "$baseUrl/api/data/v9.2/systemusers?" +
+        "`$select=systemuserid,fullname,accessmode&`$filter=isdisabled eq false&" +
+        "`$expand=systemuserroles_association(`$select=name)"
+    $response = az rest --method GET --url $url --resource "$baseUrl/" --only-show-errors | ConvertFrom-Json
+
+    $admins = @($response.value | Where-Object {
+        $_.accessmode -eq 0 -and
+        @($_.systemuserroles_association | ForEach-Object { $_.name }) -contains 'System Administrator'
+    })
+
+    if ($admins.Count -eq 0) {
+        throw "No enabled, interactive System Administrator found in '$EnvironmentUrl'. Refusing to seed ownerless demo data -- pass -PresenterUserId explicitly if this is intentional."
+    }
+    if ($admins.Count -gt 1) {
+        Write-Warning "Get-DemoPresenterUser: $($admins.Count) System Administrators found; using the first alphabetically by fullname."
+    }
+    $chosen = @($admins | Sort-Object fullname)[0]
+    return [string]$chosen.systemuserid
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    if ($EnvironmentUrl) {
+        Get-DemoPresenterUser -EnvironmentUrl $EnvironmentUrl -PresenterUserId $PresenterUserId
+    }
+}

--- a/scripts/solution/tests/Get-DemoPresenterUser.Tests.ps1
+++ b/scripts/solution/tests/Get-DemoPresenterUser.Tests.ps1
@@ -1,0 +1,52 @@
+# Pester tests for Get-DemoPresenterUser (Sprint-004, tenant-user-inventory stream).
+# Dot-sourced (non-mandatory params, auto-invoke guard) so no live Dataverse
+# environment is touched — az rest is mocked throughout.
+
+BeforeAll {
+    . "$PSScriptRoot/../Get-DemoPresenterUser.ps1"
+}
+
+Describe 'Get-DemoPresenterUser' {
+    It 'returns the explicit override without calling az' {
+        Mock az {}
+        $result = Get-DemoPresenterUser -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' -PresenterUserId '11111111-1111-1111-1111-111111111111'
+        $result | Should -Be '11111111-1111-1111-1111-111111111111'
+        Should -Invoke -CommandName az -Times 0 -Exactly
+    }
+
+    It 'resolves the single enabled interactive System Administrator' {
+        Mock az {
+            '{"value":[{"systemuserid":"aaa","fullname":"Rahel Moser","accessmode":0,"systemuserroles_association":[{"name":"System Administrator"}]},{"systemuserid":"bbb","fullname":"CI App User","accessmode":4,"systemuserroles_association":[{"name":"System Administrator"}]}]}'
+        }
+        $result = Get-DemoPresenterUser -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com'
+        $result | Should -Be 'aaa'
+    }
+
+    It 'picks the alphabetically-first fullname and warns when multiple admins are found' {
+        Mock az {
+            '{"value":[{"systemuserid":"zzz","fullname":"Zoe Admin","accessmode":0,"systemuserroles_association":[{"name":"System Administrator"}]},{"systemuserid":"aaa","fullname":"Anna Admin","accessmode":0,"systemuserroles_association":[{"name":"System Administrator"}]}]}'
+        }
+        $result = Get-DemoPresenterUser -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' -WarningVariable warnings -WarningAction SilentlyContinue
+        $result | Should -Be 'aaa'
+        $warnings | Should -Not -BeNullOrEmpty
+    }
+
+    It 'throws when no enabled interactive System Administrator is found' {
+        Mock az { '{"value":[]}' }
+        { Get-DemoPresenterUser -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' } | Should -Throw
+    }
+
+    It 'excludes a disabled or non-interactive System Administrator' {
+        Mock az {
+            '{"value":[{"systemuserid":"ci","fullname":"CI App User","accessmode":4,"systemuserroles_association":[{"name":"System Administrator"}]}]}'
+        }
+        { Get-DemoPresenterUser -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' } | Should -Throw
+    }
+
+    It 'excludes a user with no System Administrator role even if interactive' {
+        Mock az {
+            '{"value":[{"systemuserid":"basic","fullname":"Basic User","accessmode":0,"systemuserroles_association":[{"name":"Basic User"}]}]}'
+        }
+        { Get-DemoPresenterUser -EnvironmentUrl 'https://crmshowdev.crm.dynamics.com' } | Should -Throw
+    }
+}


### PR DESCRIPTION
Closes #129. Part of sprint-004 charter #125. See docs/superpowers/sprints/sprint-004-advisor-cockpit-demo-data/streams/tenant-user-inventory.md for the handover packet.