### PR TITLE
sprint-004/prereq-fixes: fix #120 lookup creation via RelationshipDefinitions

### DIFF
--- a/scripts/solution/Publish-InsuranceFoundation.ps1
+++ b/scripts/solution/Publish-InsuranceFoundation.ps1
@@ -414,6 +414,54 @@ function Get-OrdinaryRelationshipRequest {
     }
 }
 
+function New-NativeLookupRelationshipMetadata {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Extension)
+
+    if (@($Extension.lookup.targets).Count -ne 1) {
+        throw "Native lookup extension '$($Extension.logicalName)' must target exactly one entity."
+    }
+    $target = [string]$Extension.lookup.targets[0]
+    return [ordered]@{
+        '@odata.type' = 'Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata'
+        SchemaName = $Extension.schemaName
+        ReferencedAttribute = "${target}id"
+        ReferencedEntity = $target
+        ReferencingEntity = $Extension.table
+        AssociatedMenuConfiguration = @{
+            Behavior = 'UseLabel'
+            Group = 'Details'
+            Label = ConvertTo-LocalizedLabel $Extension.metadata.label
+            Order = 10000
+        }
+        CascadeConfiguration = Get-ExpectedOrdinaryRelationshipCascade `
+            -ReferencedEntity $target
+        Lookup = [ordered]@{
+            '@odata.type' = 'Microsoft.Dynamics.CRM.LookupAttributeMetadata'
+            LogicalName = $Extension.logicalName
+            SchemaName = $Extension.schemaName
+            AttributeType = 'Lookup'
+            AttributeTypeName = @{ Value = 'LookupType' }
+            DisplayName = ConvertTo-LocalizedLabel $Extension.metadata.label
+            Description = ConvertTo-LocalizedLabel $Extension.metadata.description
+            RequiredLevel = ConvertTo-RequiredLevel ([bool]$Extension.required)
+            IsAuditEnabled = @{ Value = [bool]$Extension.auditing }
+        }
+    }
+}
+
+function Get-NativeLookupRelationshipRequest {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Extension)
+
+    return [pscustomobject]@{
+        Method = 'POST'
+        Path = '/RelationshipDefinitions'
+        Solution = $Extension.solution
+        Body = New-NativeLookupRelationshipMetadata -Extension $Extension
+    }
+}
+
 function Get-CustomerRelationshipContract {
     [CmdletBinding()]
     param(
@@ -1195,6 +1243,22 @@ function Get-PicklistAttributeMetadata {
     )
 }
 
+function Get-NativeLookupRelationshipMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$TableLogicalName,
+        [Parameter(Mandatory)] [string]$AttributeLogicalName
+    )
+
+    $escapedTableName = ConvertTo-ODataKeyString $TableLogicalName
+    $escapedAttributeName = ConvertTo-ODataKeyString $AttributeLogicalName
+    return Get-One (
+        "/EntityDefinitions(LogicalName='$escapedTableName')/ManyToOneRelationships?" +
+        "`$select=MetadataId,SchemaName,ReferencedEntity,ReferencingEntity,ReferencingAttribute,CascadeConfiguration&" +
+        "`$filter=ReferencingAttribute eq '$escapedAttributeName'"
+    )
+}
+
 function Get-TypedAttributeMetadata {
     param(
         [Parameter(Mandatory)] [string]$TableLogicalName,
@@ -1869,6 +1933,10 @@ function Repair-CustomerRelationshipCascade {
 
 function Invoke-NativeExtensionReconciliation {
     param($Extension)
+    if ($Extension.type -eq 'Lookup') {
+        Invoke-NativeLookupExtensionReconciliation $Extension
+        return
+    }
     $existing = Get-PicklistAttributeMetadata $Extension.table `
         $Extension.logicalName
     if ($null -eq $existing) {
@@ -1900,6 +1968,58 @@ function Invoke-NativeExtensionReconciliation {
     } else {
         Write-Output "$($Extension.table)/$($Extension.logicalName): Unchanged"
     }
+}
+
+function Test-NativeLookupRelationshipCompatibility {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Existing,
+        [Parameter(Mandatory)] $Extension
+    )
+
+    $component = "$($Extension.table)/$($Extension.logicalName)"
+    $target = [string]$Extension.lookup.targets[0]
+    if ([string]::IsNullOrWhiteSpace([string]$Existing.SchemaName) -or
+        [string]$Existing.SchemaName -ne $Extension.schemaName -or
+        [string]::IsNullOrWhiteSpace([string]$Existing.ReferencedEntity) -or
+        [string]$Existing.ReferencedEntity -ne $target -or
+        [string]::IsNullOrWhiteSpace([string]$Existing.ReferencingEntity) -or
+        [string]$Existing.ReferencingEntity -ne $Extension.table -or
+        [string]::IsNullOrWhiteSpace([string]$Existing.ReferencingAttribute) -or
+        [string]$Existing.ReferencingAttribute -ne $Extension.logicalName) {
+        throw "Structural relationship target conflict for '$component'."
+    }
+
+    $expectedCascade = Get-ExpectedOrdinaryRelationshipCascade `
+        -ReferencedEntity $target
+    foreach ($action in @($expectedCascade.Keys | Sort-Object)) {
+        if ([string]$Existing.CascadeConfiguration.$action -ne
+            [string]$expectedCascade[$action]) {
+            throw "Structural relationship cascade conflict for '$($Extension.schemaName)': '$action' must be '$($expectedCascade[$action])'."
+        }
+    }
+}
+
+function Invoke-NativeLookupExtensionReconciliation {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Extension)
+
+    $existing = Get-NativeLookupRelationshipMetadata `
+        -TableLogicalName $Extension.table `
+        -AttributeLogicalName $Extension.logicalName
+    if ($null -eq $existing) {
+        Invoke-PlannedRequest (
+            Get-NativeLookupRelationshipRequest -Extension $Extension
+        ) | Out-Null
+        Write-Output "$($Extension.table)/$($Extension.logicalName): Created"
+        return
+    }
+
+    Assert-SolutionOwnership $existing $Extension.solution `
+        "$($Extension.table)/$($Extension.logicalName)"
+    Test-NativeLookupRelationshipCompatibility -Existing $existing `
+        -Extension $Extension
+    Write-Output "$($Extension.table)/$($Extension.logicalName): Unchanged"
 }
 
 function Invoke-ChildRequestIfMissing {

--- a/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
+++ b/scripts/solution/tests/Publish-InsuranceFoundation.Tests.ps1
@@ -1045,6 +1045,30 @@ Describe 'Insurance Foundation reconciliation' {
                     -AttributeLogicalName $attributeLogicalName
             }
             if ($Method -eq 'GET' -and
+                $Path -match (
+                    "^/EntityDefinitions\(LogicalName='((?:[^']|'')*)'\)" +
+                    '/ManyToOneRelationships\?'
+                )) {
+                $logicalName = $Matches[1].Replace("''", "'")
+                $table = Get-ContractTableByLogicalName $logicalName
+                if ($null -eq $table -or
+                    -not $script:createdTables.Contains($logicalName)) {
+                    return [pscustomobject]@{ value = @() }
+                }
+                $includeCustomerRelationships = @(
+                    $table.columns | Where-Object type -eq 'Customer'
+                ).Count -eq 0 -or
+                    $script:tablesWithCustomerRelationships.Contains(
+                        $logicalName
+                    )
+                return [pscustomobject]@{
+                    value = @((
+                        New-TableMetadataSnapshot -Table $table `
+                            -IncludeCustomerRelationships:$includeCustomerRelationships
+                    ).ManyToOneRelationships)
+                }
+            }
+            if ($Method -eq 'GET' -and
                 $Path -like "/GlobalOptionSetDefinitions(Name='*") {
                 $name = [regex]::Match(
                     $Path, "Name='([^']+)'"
@@ -1117,13 +1141,14 @@ Describe 'Insurance Foundation reconciliation' {
         $created = @($script:calls | Where-Object Method -eq 'POST')
         @($created | Where-Object Path -eq '/GlobalOptionSetDefinitions').Count | Should -Be 14
         @($created | Where-Object Path -eq '/EntityDefinitions').Count | Should -Be 8
+        @($created | Where-Object Path -eq '/RelationshipDefinitions').Count | Should -Be 1
         @($created | Where-Object Path -eq '/PublishXml').Count | Should -Be 16
         foreach ($publish in @($created | Where-Object Path -eq '/PublishXml')) {
             $publish.Body.ParameterXml |
                 Should -Match '^<importexportxml><entities><entity>crmshow_[a-z]+</entity></entities></importexportxml>$'
         }
         @($created | Where-Object Path -match "EntityDefinitions\(LogicalName='(?:account|contact|lead|incident)'\)/Attributes").Count |
-            Should -Be 21
+            Should -Be 20
         @($created | Where-Object Path -match '/Keys$').Count | Should -Be 8
         @($created | Where-Object Path -eq '/workflows').Count | Should -Be 0
         @($created | Where-Object Path -eq '/systemforms').Count | Should -Be 8
@@ -1413,7 +1438,10 @@ Describe 'Insurance Foundation reconciliation' {
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and
             $_.Path -match "EntityDefinitions\(LogicalName='(?:account|contact|lead|incident)'\)/Attributes$"
-        }).Count | Should -Be 21
+        }).Count | Should -Be 20
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        }).Count | Should -Be 1
         @($script:calls | Where-Object {
             $_.Method -eq 'POST' -and $_.Path -eq '/EntityDefinitions'
         }).Count | Should -Be 8
@@ -1740,7 +1768,7 @@ Describe 'Insurance Foundation reconciliation' {
             "/EntityDefinitions(LogicalName='contact')/Attributes",
             "/EntityDefinitions(LogicalName='contact')/Attributes",
             "/EntityDefinitions(LogicalName='contact')/Attributes",
-            "/EntityDefinitions(LogicalName='lead')/Attributes",
+            '/RelationshipDefinitions',
             "/EntityDefinitions(LogicalName='lead')/Attributes",
             "/EntityDefinitions(LogicalName='lead')/Attributes",
             "/EntityDefinitions(LogicalName='lead')/Attributes",
@@ -2306,6 +2334,105 @@ Describe 'Insurance Foundation reconciliation' {
         $script:calls[0].Path | Should -Match (
             '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?'
         )
+    }
+
+    It 'creates Lookup-type native extensions through RelationshipDefinitions instead of Attributes' {
+        $extension = @($script:contract.nativeExtensions | Where-Object {
+            $_.logicalName -eq 'crmshow_leadclusterid'
+        })[0]
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET' -and $Path -match '/ManyToOneRelationships\?') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'POST') {
+                return [pscustomobject]@{}
+            }
+            throw "Unsupported mocked endpoint: $Method $Path"
+        }
+
+        Invoke-NativeExtensionReconciliation $extension | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and
+            $_.Path -eq "/EntityDefinitions(LogicalName='$($extension.table)')/Attributes"
+        }) | Should -BeNullOrEmpty
+        $create = @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -eq '/RelationshipDefinitions'
+        })[0]
+        $create | Should -Not -BeNullOrEmpty
+        $create.Body.'@odata.type' |
+            Should -Be 'Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata'
+        $create.Body.SchemaName | Should -Be $extension.schemaName
+        $create.Body.ReferencedEntity |
+            Should -Be ([string]$extension.lookup.targets[0])
+        $create.Body.ReferencingEntity | Should -Be $extension.table
+        $create.Body.Lookup.LogicalName | Should -Be $extension.logicalName
+        $create.Body.Lookup.SchemaName | Should -Be $extension.schemaName
+        $create.Body.Lookup.AttributeType | Should -Be 'Lookup'
+        $create.Body.Lookup.AttributeTypeName.Value | Should -Be 'LookupType'
+    }
+
+    It 'does not recreate Lookup-type native extensions when the relationship already exists' {
+        $extension = @($script:contract.nativeExtensions | Where-Object {
+            $_.logicalName -eq 'crmshow_leadclusterid'
+        })[0]
+        $target = [string]$extension.lookup.targets[0]
+        $existing = [pscustomobject]@{
+            MetadataId = 'native-lookup-relationship'
+            SchemaName = $extension.schemaName
+            ReferencedEntity = $target
+            ReferencingEntity = $extension.table
+            ReferencingAttribute = $extension.logicalName
+            SolutionUniqueName = $extension.solution
+            CascadeConfiguration = [pscustomobject](
+                Get-ExpectedOrdinaryRelationshipCascade -ReferencedEntity $target
+            )
+        }
+        Mock Invoke-DataverseRequest {
+            param($Method, $Path, $Body, $Headers)
+            $script:calls.Add([pscustomobject]@{
+                Method = $Method; Path = $Path; Body = $Body; Headers = $Headers
+            })
+            if ($Method -eq 'GET' -and
+                $Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?') {
+                return [pscustomobject]@{ value = @() }
+            }
+            if ($Method -eq 'GET' -and $Path -match '/ManyToOneRelationships\?') {
+                return [pscustomobject]@{ value = @($existing) }
+            }
+            if ($Method -eq 'POST') {
+                return [pscustomobject]@{}
+            }
+            throw "Unsupported mocked endpoint: $Method $Path"
+        }
+
+        Invoke-NativeExtensionReconciliation $extension | Out-Null
+
+        @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and
+            $_.Path -match '/Attributes/Microsoft\.Dynamics\.CRM\.PicklistAttributeMetadata\?'
+        }) | Should -BeNullOrEmpty
+        @($script:calls | Where-Object {
+            $_.Method -eq 'GET' -and $_.Path -match '/ManyToOneRelationships\?'
+        }).Count | Should -Be 1
+        @($script:calls | Where-Object {
+            $_.Method -eq 'POST' -and $_.Path -in @(
+                '/RelationshipDefinitions',
+                "/EntityDefinitions(LogicalName='$($extension.table)')/Attributes"
+            )
+        }) | Should -BeNullOrEmpty
     }
 
     It 'rejects UserLocal date metadata for the UTC contract' {


### PR DESCRIPTION
Closes #120. Part of sprint-004 charter #125.

Fixes the live failure from run https://github.com/urruegg/CRMShowcase/actions/runs/31962217108: Invoke-NativeExtensionReconciliation now branches on Lookup-typed native extensions, checking existence via ManyToOneRelationships and creating via POST /RelationshipDefinitions instead of the generic Attributes POST Dataverse rejects for LookupAttributeMetadata.

Verified:
- Full offline scripts/solution/tests suite: 424 passed, 0 failed, 2 skipped.
- Live re-validation dispatched against this branch (run https://github.com/urruegg/CRMShowcase/actions/runs/32031985164): validate job (full offline suite) green in 23m12s; author job rejected by the dev environment's branch-protection rules (only main may deploy) -- expected, not a code issue. Live DEV re-authoring of the #124-related tables will be verified once this merges to main.

#124 status: the DEV-authored tables from sprint-003 (crmshow_leadcluster, crmshow_claimprojection, crmshow_nextbestaction, crmshow_nbaprovenance, crmshow_measuresnapshot) no longer exist live in crmshowdev -- confirmed via direct query. Root-cause hypothesis: an earlier authoring attempt partially failed on exactly this #120 bug. Re-authoring (via cd-solution-dev.yml on main, after this merges) and the intake-export are tracked as follow-up in docs/superpowers/sprints/sprint-004-advisor-cockpit-demo-data/STATUS.md -- not resolved by this PR alone.