### PR TITLE
docs(code-apps): design Advisor Cockpit B1/B2 parity proof

### DIFF
--- a/docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md
+++ b/docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md
@@ -9,12 +9,13 @@
 | **Deciders** | `AG-E-03` Enterprise Architect (accountable — UX/system-boundary decision) · `AG-E-02` Developer (implementation feasibility) · `AG-E-06` Responsible-AI & Compliance Officer (Copilot embedding/content-safety inheritance) · customer IT/Architect (`P-06`) |
 | **Topic area** | A1 — Architecture vision (where the CRM system boundary meets the employee-facing UX boundary) · A5 — Workflow/business cases (how `P-01` Advisor, `P-03` Assistance agent, `P-04` Marketer actually work day to day) · A6 — AI/agents/governance (how `AG-F-01`/`AG-F-03`/`AG-F-04` agents are surfaced) |
 | **Use case** | Illustrated with **AG-F-01 Next-Best-Action Agent** (Advisory Cockpit) walk-throughs below each option |
-| **Licence** | `[TBD]` — varies by option; every option still consumes standard Dataverse/Copilot Studio per-user entitlements, see below |
-| **Upgrade impact** | High for Option A (every native D365/Copilot Studio feature investment must be re-built by hand in Angular) · Medium for Option C · Low for Option B (Microsoft maintains the UI) |
+| **Licence** | Option-specific — validate Power Apps Premium and applicable Dynamics 365 / Copilot Studio rights per persona; headless options may also consume connector, message, or BFF capacity |
+| **Upgrade impact** | High for Option A (every native D365/Copilot Studio feature investment must be re-built by hand in Angular) · Medium for Option C · Low for Option B's native baseline · Medium for the focused B1/B2 Code App variants |
 | **CAF methodology** | Plan · Adopt — this is a target-application-architecture decision, not an environment or governance change |
 | **WAF pillar(s)** | Primary: Operational Excellence (one UX to build and maintain vs. two) and Performance Efficiency (latency/consistency of the advisor's daily workflow). Trade-off against: Cost Optimization (Option A's ongoing custom-build cost) |
 | **Zero Trust** | Orthogonal to this ADR — every option authenticates through the same Entra ID token and Conditional Access posture established in [ADR-0032](./ADR-0032-entra-power-platform-dynamics365-identity-access-management.md); this ADR only changes **where** that token is used to reach CRM's surfaces, not how identity is verified |
 | **Responsible AI** | Whichever option is chosen, AI-drafted content (NBA rationale, Copilot chat replies) must remain disclosed as AI-assisted and grounded in retrieved CRM context ([docs/AI.md](../AI.md)); Option A carries the added burden of re-implementing that disclosure/grounding UX by hand instead of inheriting it from Copilot Studio's native surface |
+| **B1/B2 parity design** | [Power Apps Code Apps Foundation and Advisor Cockpit B1/B2 Parity Proof](../superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md) |
 
 > **Illustrative naming note.** "B2E" (Business-to-Employee), its Angular
 > technology choice, and the "Absprung" (jump/cross-launch) behaviour it
@@ -92,7 +93,10 @@ flowchart LR
     subgraph OB["Option B — CRM is the UX layer"]
         direction LR
         LINK["Cross-launch\n(SSO deep link)"]
-        COCKPIT_B["Advisor Cockpit\n(native D365 app)"]
+      DELIVERY{"CRM UX delivery"}
+      COCKPIT_B["Native model-driven\nbaseline"]
+      CODE_B1["B1: standalone\nCode App"]
+      CODE_B2["B2: Code App\ninside MDA"]
     end
 
     subgraph OC["Option C — Hybrid"]
@@ -103,7 +107,10 @@ flowchart LR
 
     ADV --> B2E
     B2E --> ANGUI --> API_A
-    B2E --> LINK --> COCKPIT_B
+    B2E --> LINK --> DELIVERY
+    DELIVERY --> COCKPIT_B
+    DELIVERY --> CODE_B1
+    DELIVERY --> CODE_B2
     B2E --> GLANCE
     B2E --> DEEP
 ```
@@ -219,13 +226,26 @@ accountable act regardless of which component renders the card
 
 ### Option B — CRM is the UX layer for customer engagement (cross-launch)
 
-The native D365 model-driven **Advisor Cockpit** — including its embedded
-Copilot Studio chat pane — is where the advisor actually works customer
-engagement. B2E remains the role-based home screen and, when the advisor
-selects "Advisory" for a household, performs an **Entra-SSO-backed
-cross-launch** (deep link to the record) exactly as it already does for
-Versicherungsprozesse, Schadenprozesse, and ARO. CRM is treated identically
-to every other core system rather than special-cased.
+Option B fixes the **ownership boundary**, not the rendering technology:
+B2E remains the role-based home screen and performs an Entra-SSO-backed
+cross-launch, while Power Apps owns the customer-engagement experience.
+CRM is therefore treated like the other core systems rather than rebuilt in
+B2E. B0 represents the native model-driven baseline option; two Code App
+variants extend the same boundary without selecting an implementation
+prematurely.
+
+The B1/B2 parity proof starts at the **CRM UX boundary**. It does not build,
+simulate, or test a B2E Angular shell, launcher, SSO hand-off, or integration
+contract. B2E remains landscape context for the eventual architecture decision
+only.
+
+#### Option B0 — Native model-driven baseline
+
+Under B0, the native D365 model-driven **Advisor Cockpit**, including its
+embedded Copilot Studio chat pane, would be where the advisor works customer
+engagement. When the advisor selects "Advisory" for a household, B2E would
+deep-link to the record as it already does for Versicherungsprozesse,
+Schadenprozesse, and ARO.
 
 ```mermaid
 flowchart LR
@@ -274,7 +294,7 @@ flowchart LR
 - **Licence.** Standard Dynamics 365 and Copilot Studio per-user licensing;
   no additional API/BFF consumption.
 
-#### Advisory Cockpit walk-through (Option B)
+##### Advisory Cockpit walk-through (Option B0)
 
 ```mermaid
 sequenceDiagram
@@ -310,6 +330,232 @@ flowchart TD
 **Note.** Same [ADR-0014](./ADR-0014-agents-advisory-by-design.md) guardrail
 applies — this option changes **where** the advisor lands, not who is
 accountable for the decision.
+
+#### Option B1 — Standalone Code App as the CRM experience
+
+The advisor opens a full-screen **Power Apps Code App** on the Power Apps
+managed host. The Code App receives user, app, environment, Dataverse
+organization, query-parameter, and session context from the Power Apps host.
+It uses generated, strongly typed Dataverse services under the signed-in
+advisor's identity for the bespoke cockpit. Native forms, timeline, views, and
+other deep CRM work remain in the model-driven app and are reached through
+record-aware deep links from the Code App.
+
+```mermaid
+flowchart LR
+  ADVB1(["Advisor"])
+    subgraph HOSTB1["Power Apps managed host"]
+        CODEB1["Advisor Cockpit Code App"]
+        CTXB1["App + user + session context"]
+    end
+    subgraph CRMB1["Dataverse / Dynamics 365"]
+        DVB1[("Dataverse\nuser-context access")]
+        MDAB1["Model-driven app\nnative deep work"]
+    end
+
+    ADVB1 --> CODEB1
+    CTXB1 --> CODEB1
+    CODEB1 --> DVB1
+    CODEB1 -- "record-aware deep link" --> MDAB1
+```
+
+| Endpoint | Capability / service | Role |
+| --- | --- | --- |
+| Power Apps managed host | Entra authentication, app loading, sharing, DLP, operational telemetry | Runs the standalone Code App |
+| `@microsoft/power-apps` context API | App, user, environment, query parameter, and session context | Personalizes the cockpit and correlates telemetry |
+| Generated Dataverse services | Strongly typed connector models and operations | Reads cockpit data and records structured human decisions |
+| Model-driven app deep link | Standard native navigation | Opens forms, timeline, and other deep CRM work |
+
+- **Pros.** Gives the dense cockpit the full viewport and maximum responsive
+  control without iframe/CSP coupling. It retains Power Platform-managed
+  Entra authentication, DLP, sharing, monitoring, connectors, and
+  solution-aware deployment. It also creates a clear reusable rule: Code Apps
+  build bespoke full-page experiences; model-driven configuration builds
+  native CRM forms, views, and timelines.
+- **Cons.** Adds a second Power Apps navigation surface and an explicit
+  Code App-to-MDA hand-off. Native panes and controls do not appear
+  automatically inside the standalone Code App, so the boundary must remain
+  intentional and record context must survive every deep link. Sharing and
+  entitlements apply to both destinations.
+- **Design pattern.** Managed-host micro-frontend with native deep-work links.
+- **Licence.** Power Apps Premium plus any applicable Dynamics 365 and
+  Copilot Studio entitlements; exact persona-level use rights require
+  licensing validation.
+- **Maturity.** Power Apps Code Apps are generally available. This B1
+  composition remains a design option until proved in DEV and TEST.
+
+##### Advisory Cockpit walk-through (Option B1)
+
+Concrete use case: **AG-F-01 Next-Best-Action Agent** writes ranked,
+explainable NBA records to Dataverse. The standalone Code App is the advisor's
+full-screen work surface; it records the human decision and hands off only
+native deep work to the model-driven app.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant ADV as Advisor
+    participant HOST as Power Apps managed host
+    participant CODE as Advisor Cockpit Code App
+    participant DV as Dataverse
+    participant MDA as Model-driven Advisor App
+
+    ADV->>HOST: Open standalone Code App
+    HOST->>HOST: Authenticate and enforce sharing/DLP
+    HOST->>CODE: Load app + user/query/session context
+    CODE->>DV: Query my ranked NBA cards via generated service
+    DV-->>CODE: NBA cards + explanation + provenance
+    CODE-->>ADV: Render full-screen Advisory Cockpit
+    ADV->>CODE: Accept / edit / dismiss recommendation
+    CODE->>DV: Record structured human decision
+    ADV->>CODE: Open household timeline
+    CODE->>MDA: Deep link with household record id
+    MDA-->>ADV: Open native form and timeline
+```
+
+```mermaid
+flowchart TD
+    STARTB1["Advisor opens standalone Code App"]
+    CONTEXTB1["Power Apps supplies identity, environment,\nrecord and session context"]
+    READB1["Generated Dataverse service\nloads NBA + provenance"]
+    DECIDEB1["Advisor accepts / edits / dismisses"]
+    WRITEB1["Structured decision written to Dataverse"]
+    DEEPB1{"Native deep work needed?"}
+    STAYB1["Remain in full-screen Code App"]
+    MDAB1F["Deep-link to MDA record"]
+
+    STARTB1 --> CONTEXTB1 --> READB1 --> DECIDEB1 --> WRITEB1 --> DEEPB1
+    DEEPB1 -- "No" --> STAYB1
+    DEEPB1 -- "Yes" --> MDAB1F
+```
+
+**Challenge exposed by the use case.** B1 is credible only if the selected
+record and advisor context survive the Code App-to-MDA hand-off, the same
+Dataverse security role constrains both surfaces, and the advisor's decision is
+written exactly once. A visually successful standalone cockpit that loses
+record context or creates a second decision path fails the proof.
+
+#### Option B2 — Code App embedded in the model-driven Advisor App
+
+The advisor opens the model-driven Advisor App, which hosts the deployed Code
+App in a full-page sitemap web-resource iframe while retaining the MDA command
+surface, forms, timeline, and native navigation around it. The environment's
+Content Security Policy adds only the specific Dynamics 365 organization
+origin to `frame-ancestors`; same-tenant users still require the Code App to be
+shared with them.
+
+```mermaid
+flowchart LR
+  ADVB2(["Advisor"])
+    subgraph MDAB2["Model-driven Advisor App"]
+        SHELLB2["Sitemap + native navigation"]
+        FRAMEB2["Full-page web-resource host\niframe"]
+    end
+    subgraph HOSTB2["Power Apps managed host"]
+        CODEB2["Advisor Cockpit Code App"]
+    end
+    DVB2[("Dataverse\nuser-context access")]
+
+    ADVB2 --> SHELLB2 --> FRAMEB2 --> CODEB2 --> DVB2
+```
+
+| Endpoint | Capability / service | Role |
+| --- | --- | --- |
+| Model-driven Advisor App | Sitemap, forms, views, timeline, native navigation | Owns the containing CRM shell |
+| Full-page web-resource iframe | Supported host for the Code App play URL | Places the bespoke cockpit inside the MDA |
+| Environment CSP `frame-ancestors` | Least-privilege organization-origin allowlist | Permits the MDA to frame the Code App |
+| Power Apps managed host + generated Dataverse services | Entra-authenticated runtime and typed data access | Runs the cockpit and records the advisor decision |
+
+- **Pros.** Keeps advisors inside one CRM navigation model and places bespoke
+  Code App pages beside native forms and views. Native deep work is one MDA
+  navigation action away, while Code App source retains normal React,
+  TypeScript, Vite, and test practices.
+- **Cons.** Adds a web-resource host, environment-specific CSP
+  configuration, nested loading/navigation, and viewport/accessibility
+  constraints. The embedded path must be tested in the real MDA, not only in
+  the standalone player. Framed Code Apps are same-tenant only, and both MDA
+  access and Code App sharing must be correct.
+- **Design pattern.** Governed iframe micro-frontend inside the native CRM
+  shell.
+- **Licence.** Power Apps Premium plus any applicable Dynamics 365 and
+  Copilot Studio entitlements; exact persona-level use rights require
+  licensing validation.
+- **Maturity.** Power Apps Code Apps and documented iframe hosting are
+  generally available. This B2 composition remains a design option until
+  proved in DEV and TEST.
+
+##### Advisory Cockpit walk-through (Option B2)
+
+The same **AG-F-01** NBA records validate B2, but the model-driven Advisor App
+owns the outer navigation and hosts the Code App cockpit. The walkthrough
+therefore tests the extra CSP, iframe, sharing, and nested-navigation boundary
+that B1 avoids.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant ADV as Advisor
+    participant MDA as Model-driven Advisor App
+    participant FRAME as Web-resource iframe host
+    participant HOST as Power Apps managed host
+    participant CODE as Advisor Cockpit Code App
+    participant DV as Dataverse
+
+    ADV->>MDA: Open Advisor Cockpit sitemap page
+    MDA->>FRAME: Load full-page host
+    FRAME->>HOST: Frame Code App play URL
+    HOST->>HOST: Enforce Entra, sharing, DLP, and frame-ancestors CSP
+    HOST->>CODE: Load app + user/query/session context
+    CODE->>DV: Query ranked NBA cards via generated service
+    DV-->>CODE: NBA cards + explanation + provenance
+    CODE-->>ADV: Render cockpit inside MDA shell
+    ADV->>CODE: Accept / edit / dismiss recommendation
+    CODE->>DV: Record structured human decision
+    ADV->>MDA: Navigate to native household timeline
+    MDA-->>ADV: Open native form without leaving CRM shell
+```
+
+```mermaid
+flowchart TD
+    STARTB2["Advisor opens cockpit sitemap in MDA"]
+    FRAMEB2F["MDA web resource frames Code App"]
+    GATEB2["Entra + sharing + least-privilege CSP"]
+    READB2["Generated Dataverse service\nloads NBA + provenance"]
+    DECIDEB2["Advisor decision written once"]
+    NATIVEB2["MDA navigation opens native deep work"]
+
+    STARTB2 --> FRAMEB2F --> GATEB2 --> READB2 --> DECIDEB2 --> NATIVEB2
+```
+
+**Challenge exposed by the use case.** B2 is credible only if the embedded
+cockpit receives the correct household context, fits the production MDA
+viewport without nested-navigation or accessibility regressions, and survives
+DEV-to-TEST promotion with environment-specific CSP and app identity resolved
+without source edits. Passing the standalone Code App tests alone does not
+prove B2.
+
+#### Option B Code App variant comparison
+
+| Criterion | B1 — Standalone Code App | B2 — Embedded Code App |
+| --- | --- | --- |
+| Advisor shell | Dedicated full-screen Power Apps experience | Model-driven Advisor App |
+| Native CRM deep work | Record-aware cross-launch from Code App | Adjacent MDA navigation |
+| Viewport and responsive freedom | Highest | Constrained by MDA + iframe host |
+| Environment configuration | App identity, sharing, and solution deployment | Same, plus least-privilege CSP `frame-ancestors` |
+| Runtime coupling | Code App + Dataverse | Code App + iframe host + MDA + Dataverse |
+| Primary failure mode | Lost context or duplicate UX across Code App/MDA | CSP, sharing, viewport, or nested-navigation failure |
+| Required E2E proof | Power Apps player → Code App → decision → MDA deep link | MDA sitemap → embedded Code App → decision → native page |
+
+Neither B1 nor B2 is selected. Both preserve the candidate engineering rule
+that Code Apps are primary for **bespoke full-page experiences**, while
+model-driven configuration remains primary for forms, views, timelines, and
+other native CRM capabilities.
+
+The approved visual baseline for this proof is the fixture-backed local PCF
+harness and its captured screenshots. Although the PCF artifact is deployed to
+DEV, it is not attached to a user-visible running surface and is therefore
+neither live comparison evidence nor a runtime fallback. The live comparison
+is B1 versus B2 in DEV and TEST.
 
 ### Option C — Hybrid: embedded glance surfaces + cross-launch for deep work
 
@@ -418,16 +664,16 @@ points.
 
 | Criterion | Option A — CRM headless | Option B — CRM is the UX layer | Option C — Hybrid |
 | --- | --- | --- | --- |
-| Custom UI build/maintenance burden | Highest — everything re-built | None | Medium — glance widgets only |
-| Native D365/Copilot Studio feature inheritance | None — must be re-implemented | Full, automatic | Full for deep work; partial for glance widgets |
+| Custom UI build/maintenance burden | Highest — everything re-built | None for B0; focused bespoke-page build for B1/B2 | Medium — glance widgets only |
+| Native D365/Copilot Studio feature inheritance | None — must be re-implemented | Full in B0/deep-work MDA; deliberate hand-off from B1/B2 | Full for deep work; partial for glance widgets |
 | Consistency with other core systems' pattern | Diverges — CRM is special-cased into B2E | Matches — same cross-launch pattern as ARO/Versicherungsprozesse/Schadenprozesse | Matches for deep work; diverges for glance widgets |
-| Time to deliver | Slowest | Fastest | Medium |
-| Responsible AI/Content Safety inheritance | Must be re-implemented and kept in parity | Inherited natively | Inherited for deep work; must be re-verified for the embedded chat widget |
-| Advisor context-switch | None — one shell throughout | Yes, between B2E and D365 | Only when deep work is needed |
-| Licence cost driver | Dataverse API + Copilot Studio message consumption, possibly BFF compute | Standard per-user licensing only | Superset of A and B |
-| Upgrade impact | High | Low | Medium |
-| Reversibility | Low — large custom investment to unwind | High — nothing custom to unwind | Medium — glance widgets to unwind, deep-link path unaffected |
-| Design pattern fit | BFF / API Gateway | Cross-launch / deep-link with SSO | Composite UI / micro-frontend |
+| Time to deliver | Slowest | B0 fastest; B1 simpler than B2 | Medium |
+| Responsible AI/Content Safety inheritance | Must be re-implemented and kept in parity | Native for MDA capabilities; explicitly implemented/tested in bespoke B1/B2 pages | Inherited for deep work; must be re-verified for the embedded chat widget |
+| Advisor context-switch | None — one shell throughout | B0: B2E→MDA; B1 adds Code App→MDA; B2 stays inside MDA | Only when deep work is needed |
+| Licence cost driver | Dataverse API + Copilot Studio message consumption, possibly BFF compute | Dynamics 365 for B0; B1/B2 add Power Apps Code App entitlement validation | Superset of A and B |
+| Upgrade impact | High | Low for B0; medium for focused B1/B2 pages | Medium |
+| Reversibility | Low — large custom investment to unwind | High for B0; medium-high for isolated B1/B2 pages | Medium — glance widgets to unwind, deep-link path unaffected |
+| Design pattern fit | BFF / API Gateway | Cross-launch + native baseline or managed-host micro-frontend | Composite UI / micro-frontend |
 
 ## Decision or working hypothesis
 
@@ -439,6 +685,12 @@ does not force an all-or-nothing choice between "rebuild everything" and
 "accept every context-switch" — but it is not automatically the
 recommendation, since it also carries the added governance burden of
 running two integration mechanisms at once.
+
+Option B now has three delivery shapes: native baseline B0 and Code App
+variants B1/B2. No delivery shape is selected either. The Advisory Cockpit
+walkthrough is mandatory for each future variant added to this ADR: an option
+that cannot preserve identity, CRM record context, one accountable human
+decision, and a governed DEV-to-TEST path is not a viable architecture option.
 
 ## Evidence and assumptions
 
@@ -458,6 +710,17 @@ running two integration mechanisms at once.
   (embedding the whole D365 UCI app inside a third-party shell via iframe)
   is not a documented, supported pattern and is deliberately **not**
   proposed as an option here.
+- **Known (verified, Code Apps).** Power Apps Code Apps are generally
+  available and run on the Power Apps managed host with Entra authentication,
+  DLP, sharing, and platform monitoring. The Power Apps client library
+  generates models/services for connector requests; `getContext` exposes app,
+  environment, Dataverse organization, query-parameter, user, tenant, and
+  session context. Microsoft documents framing a deployed Code App in a
+  model-driven app web resource and requires the Dynamics 365 organization
+  origin in the environment's CSP `frame-ancestors`; embedded users must be
+  in the same tenant. Source: [Code Apps architecture](https://learn.microsoft.com/power-apps/developer/code-apps/architecture),
+  [get context](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/retrieve-context),
+  and [embed in an iframe](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/embed-iframe).
 - **Inferred, not yet confirmed.** That B2E already performs SSO-backed
   cross-launch for Versicherungsprozesse/Schadenprozesse/ARO today, as
   described conceptually by the customer — the actual mechanism (deep link,
@@ -471,6 +734,13 @@ running two integration mechanisms at once.
   (framework version, hosting, extensibility APIs). Copilot Studio Direct
   Line channel governance and message-cost model at the customer's actual
   advisor headcount.
+- **Evidence still required for B1/B2.** A like-for-like Advisory Cockpit
+  proof in DEV and TEST: generated Dataverse service behavior under the
+  advisor role; app/session context and record-aware navigation into native MDA
+  work; one-write decision semantics; responsive/accessibility results;
+  telemetry correlation; Code App sharing and environment rebinding; and, for
+  B2 only, least-privilege CSP plus real MDA viewport/navigation behavior. B2E
+  integration evidence is explicitly outside this proof.
 
 ## Validation and review triggers
 
@@ -484,6 +754,11 @@ and advisor feedback is collected. Decision owner: `AG-E-03` Enterprise
 Architect (accountable), with `AG-E-02` Developer, `AG-E-06`
 Responsible-AI & Compliance Officer, and the customer's IT/Architect
 stakeholder as required reviewers.
+
+For B1/B2 specifically, reopen when the Advisory Cockpit proof produces DEV
+and TEST evidence or when Code Apps hosting, ALM, licensing, CSP, context, or
+model-driven embedding guidance changes. A local Vite pass or standalone
+player screenshot is insufficient evidence for either end-to-end option.
 
 ## Consequences
 
@@ -501,9 +776,9 @@ stakeholder as required reviewers.
   ([ADR-0034](./ADR-0034-aro-case-task-management-integration-pattern.md))
   should use the same UX-placement answer this ADR eventually settles on,
   for consistency across the B2E landscape's core systems.
-- **Reversibility.** Highest for Option B (native, nothing custom to
-  unwind), lowest for Option A (large custom investment), medium for
-  Option C.
+- **Reversibility.** Highest for Option B0 (native, nothing custom to
+  unwind), medium-high for B1/B2 because each bespoke page remains isolated,
+  lowest for Option A (large custom investment), and medium for Option C.
 
 ## Competitive note
 

--- a/docs/design/ADR-0033-crm-ux-placement-options.md
+++ b/docs/design/ADR-0033-crm-ux-placement-options.md
@@ -2,6 +2,7 @@
 
 **Audience:** EA / IT / UX stakeholders evaluating where CRM screens should live relative to the overarching B2E (Angular) employee experience layer.
 **Related ADR:** `docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md`
+**Parity proof:** [Power Apps Code Apps Foundation and Advisor Cockpit B1/B2 Parity Proof](../superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md)
 
 ## Why this matters
 
@@ -22,12 +23,110 @@ B2E's Angular front end owns **100% of the customer-engagement screens**. CRM is
 
 ### Option B — CRM is the UX layer for customer engagement (cross-launch)
 
-The native D365 model-driven **Advisor Cockpit** — including its embedded Copilot Studio chat pane — is where the advisor works customer engagement. B2E remains the role-based home screen and, when the advisor selects "Advisory" for a household, performs an **Entra-SSO-backed cross-launch** (deep link to the record) exactly as it already does for Versicherungsprozesse, Schadenprozesse, and ARO. CRM is treated identically to every other core system rather than special-cased.
+Option B fixes the **ownership boundary**, not the rendering technology: B2E
+remains the role-based home and performs an Entra-SSO-backed cross-launch, while
+Power Apps owns the customer-engagement experience. The native D365
+model-driven **Advisor Cockpit** is the B0 architecture baseline. Two Code App
+variants extend that pattern without turning B2E into a custom CRM front end.
+
+The B1/B2 proof deliberately starts at the **CRM UX boundary**. It does not
+build, simulate, or test a B2E Angular shell, launcher, SSO hand-off, or
+integration contract. B2E remains landscape context for the eventual
+architecture decision only.
 
 - **Design pattern.** Cross-launch / deep-link with SSO — the same integration pattern already used for the other core systems, extended to CRM.
 - **Pros.** Near-zero custom UX code. Every native capability is available immediately and stays available as Microsoft ships new features (forms, business rules, timeline, embedded Copilot Chat / Sales Copilot). Fully aligned with the config-first design preference. Fastest to deliver and cheapest to keep current across upgrades. Highest reversibility.
 - **Cons.** The advisor experiences a visual/navigational context-switch between B2E's shell and the D365 app — acceptable if that is already the accepted pattern for other systems, but CRM does not contribute to a "one app" feel over time. Two "homes" to context-switch between for workflows that span B2E and CRM in the same moment.
 - **Licence.** Standard Dynamics 365 and Copilot Studio per-user licensing; no additional API/BFF consumption.
+
+#### Option B1 — Standalone Code App as the CRM experience
+
+The advisor opens a full-screen **Power Apps Code App** on the Power Apps
+managed host. The Code App uses the signed-in advisor's Entra identity and
+generated Dataverse services for the bespoke cockpit. Native forms, timelines,
+and other deep CRM work remain in the model-driven app and are reached through
+record-aware deep links from the Code App.
+
+```mermaid
+flowchart LR
+    ADV1(["Advisor"])
+        CODE1["Advisor Cockpit Code App\nPower Apps managed host"]
+        DV1[("Dataverse\nuser-context access")]
+        MDA1["Model-driven app\nnative deep work"]
+
+    ADV1 --> CODE1
+        CODE1 --> DV1
+        CODE1 -- "record-aware deep link" --> MDA1
+```
+
+- **Design pattern.** Managed-host micro-frontend with native deep-work links.
+- **Pros.** Gives a dense cockpit the full viewport and responsive control;
+    avoids iframe/CSP coupling; retains Power Platform identity, DLP, sharing,
+    monitoring, connectors, and solution-aware deployment. The Code App can be
+    a reusable front door while the MDA remains the standard workspace for
+    native CRM capabilities.
+- **Cons.** Adds a second Power Apps navigation surface and an explicit
+    Code App-to-MDA context hand-off. Native MDA panes and controls are not
+    inherited inside the Code App, so each boundary must be deliberate rather
+    than duplicated.
+- **Licence and maturity.** Power Apps Code Apps are generally available.
+    Power Apps Premium and any Dynamics 365/Copilot Studio use rights must be
+    validated for the target personas and tenant.
+
+#### Option B2 — Code App embedded in the model-driven Advisor App
+
+The advisor opens the model-driven Advisor App, which hosts the deployed Code
+App in a full-page sitemap web-resource iframe while retaining the MDA command
+surface, forms, timeline, and native navigation around it. The environment's
+Content Security Policy explicitly allows only the Dynamics 365 organization
+origin in `frame-ancestors`.
+
+```mermaid
+flowchart LR
+    ADV2(["Advisor"])
+        MDA2["Model-driven Advisor App"]
+        HOST2["Full-page web-resource host\niframe"]
+        CODE2["Advisor Cockpit Code App\nPower Apps managed host"]
+        DV2[("Dataverse\nuser-context access")]
+
+    ADV2 --> MDA2 --> HOST2 --> CODE2 --> DV2
+```
+
+- **Design pattern.** Governed iframe micro-frontend inside the native CRM
+    shell.
+- **Pros.** Keeps advisors in one MDA navigation model and places bespoke
+    Code App pages beside native forms and views. Identity and data access remain
+    Power Platform-managed, and native deep work is one MDA navigation action
+    away.
+- **Cons.** Adds a web-resource host, environment-specific CSP configuration,
+    nested loading/navigation, and viewport/accessibility constraints. The
+    embedded path must be tested in the MDA, not only in the standalone Code App
+    player. Embedded access is same-tenant only.
+- **Licence and maturity.** Power Apps Code Apps and documented iframe hosting
+    are generally available. Power Apps Premium and Dynamics 365/Copilot Studio
+    use rights still require persona-level validation.
+
+#### B1/B2 comparison
+
+| Criterion | B1 — Standalone Code App | B2 — Embedded Code App |
+| --- | --- | --- |
+| Advisor shell | Dedicated full-screen Power Apps experience | Model-driven Advisor App |
+| Native CRM deep work | Cross-launch from the Code App | Adjacent MDA navigation |
+| Viewport and responsive freedom | Highest | Constrained by MDA + iframe host |
+| Environment configuration | App sharing and solution deployment | Same, plus least-privilege CSP `frame-ancestors` |
+| Runtime coupling | Code App + Dataverse | Code App + iframe host + MDA + Dataverse |
+| End-to-end proof | Power Apps player → Code App → MDA deep link | MDA sitemap → embedded Code App → native MDA page |
+
+Both variants preserve the same governing rule: Code Apps are the primary
+build path for **bespoke full-page experiences**, while model-driven
+configuration remains primary for forms, views, timelines, and other native
+CRM capabilities. Neither variant is selected by this pattern.
+
+The approved visual baseline for this proof is the fixture-backed local PCF
+harness and its captured screenshots. Although the PCF artifact is deployed to
+DEV, it is not attached to a user-visible running surface and is therefore
+neither live comparison evidence nor a runtime fallback. The live comparison
+is B1 versus B2 in DEV and TEST.
 
 ### Option C — Hybrid: embedded glance surfaces + cross-launch for deep work
 
@@ -42,16 +141,16 @@ B2E embeds lightweight, high-frequency **"glance" widgets** directly in its own 
 
 | Criterion | Option A — CRM headless | Option B — CRM is the UX layer | Option C — Hybrid |
 | --- | --- | --- | --- |
-| Custom UI build/maintenance burden | Highest — everything re-built | None | Medium — glance widgets only |
-| Native D365/Copilot Studio feature inheritance | None — must be re-implemented | Full, automatic | Full for deep work; partial for glance widgets |
+| Custom UI build/maintenance burden | Highest — everything re-built | None for native baseline; focused for B1/B2 bespoke pages | Medium — glance widgets only |
+| Native D365/Copilot Studio feature inheritance | None — must be re-implemented | Full in baseline/deep-work MDA; deliberate hand-off from B1/B2 | Full for deep work; partial for glance widgets |
 | Consistency with other core systems' pattern | Diverges — CRM is special-cased into B2E | Matches — same cross-launch pattern as ARO/Versicherungsprozesse/Schadenprozesse | Matches for deep work; diverges for glance widgets |
-| Time to deliver | Slowest | Fastest | Medium |
-| Responsible AI/Content Safety inheritance | Must be re-implemented and kept in parity | Inherited natively | Inherited for deep work; must be re-verified for the embedded chat widget |
-| Advisor context-switch | None — one shell throughout | Yes, between B2E and D365 | Only when deep work is needed |
-| Licence cost driver | Dataverse API + Copilot Studio message consumption, possibly BFF compute | Standard per-user licensing only | Superset of A and B |
-| Upgrade impact | High | Low | Medium |
-| Reversibility | Low — large custom investment to unwind | High — nothing custom to unwind | Medium — glance widgets to unwind, deep-link path unaffected |
-| Design pattern fit | BFF / API Gateway | Cross-launch / deep-link with SSO | Composite UI / micro-frontend |
+| Time to deliver | Slowest | Native baseline fastest; B1 simpler than B2 | Medium |
+| Responsible AI/Content Safety inheritance | Must be re-implemented and kept in parity | Native for MDA capabilities; explicitly implemented and tested in bespoke B1/B2 pages | Inherited for deep work; must be re-verified for the embedded chat widget |
+| Advisor context-switch | None — one shell throughout | Baseline: B2E→MDA; B1 adds Code App→MDA; B2 stays inside MDA | Only when deep work is needed |
+| Licence cost driver | Dataverse API + Copilot Studio message consumption, possibly BFF compute | Dynamics 365 baseline; B1/B2 add Power Apps Code App entitlement validation | Superset of A and B |
+| Upgrade impact | High | Low for native baseline; medium for focused B1/B2 pages | Medium |
+| Reversibility | Low — large custom investment to unwind | High for baseline; medium-high for isolated B1/B2 pages | Medium — glance widgets to unwind, deep-link path unaffected |
+| Design pattern fit | BFF / API Gateway | Cross-launch + native baseline or managed-host micro-frontend | Composite UI / micro-frontend |
 
 ## Key diagram
 
@@ -71,7 +170,10 @@ flowchart LR
     subgraph OB["Option B — CRM is the UX layer"]
         direction LR
         LINK["Cross-launch\n(SSO deep link)"]
-        COCKPIT_B["Advisor Cockpit\n(native D365 app)"]
+        CHOICE{"CRM UX delivery"}
+        COCKPIT_B["Native model-driven\nbaseline"]
+        CODE_B1["B1: standalone\nCode App"]
+        CODE_B2["B2: Code App\ninside MDA"]
     end
 
     subgraph OC["Option C — Hybrid"]
@@ -82,7 +184,10 @@ flowchart LR
 
     ADV --> B2E
     B2E --> ANGUI --> API_A
-    B2E --> LINK --> COCKPIT_B
+    B2E --> LINK --> CHOICE
+    CHOICE --> COCKPIT_B
+    CHOICE --> CODE_B1
+    CHOICE --> CODE_B2
     B2E --> GLANCE
     B2E --> DEEP
 ```

--- a/docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+++ b/docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
@@ -1,0 +1,1614 @@
+# Power Apps Code Apps Advisor Cockpit Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish Power Apps Code Apps as the primary repository path for bespoke full-page CRM experiences and prove standalone B1 versus model-driven-hosted B2 with the complete Advisor Cockpit in DEV and TEST.
+
+**Architecture:** Extract the reviewed Advisor Cockpit implementation into shared domain and UI workspace packages, then consume those packages from two independently initialized Code Apps. B1 runs in the Power Apps player and deep-links to native CRM records; B2 runs through a full-page model-driven sitemap web resource with an allowlisted navigation bridge. Both use app-local generated Dataverse services, one shared mapping/capability contract, environment-bound URLs, and the local fixture-backed PCF harness as the visual baseline.
+
+**Tech Stack:** TypeScript, React 18, Fluent UI v9, Vite, Vitest, React Testing Library, axe, Playwright, npm workspaces, `@microsoft/power-apps`, `@microsoft/power-apps-vite`, Power Apps CLI (`pa`), Dataverse generated services, PowerShell 7, Pester 6, Power Platform solutions, model-driven apps, GitHub Actions, OIDC-based solution promotion.
+
+**Spec:** [2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md](../specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md)
+
+**Traceability:** US-301 · UC-01 · ADR-0014 · ADR-0017 · ADR-0027 · ADR-0033 · new ADR-0041.
+
+**Execution rule:** Commit after every task. Stage and commit only the task's explicit paths. Do not use `git add -A`. Design-sensitive streams run attended; autopilot is permitted only for execution-only packets after their dependencies have merged.
+
+---
+
+## Scope Check
+
+This is one integrated parity proof, not independent products. The shared
+extraction and capability contract must land before either host; B1 and B2 may
+then proceed in parallel; comparison and TEST evidence require both. Keep one
+plan and use isolated Sprint 005 worktrees per stream.
+
+## Stream Map
+
+| Stream | Autonomy | Tasks | Depends on | Allowed scope |
+| --- | --- | --- | --- | --- |
+| `governance` | DESIGN-SENSITIVE | 0–1 | Approved spec | `docs/**`, `.github/instructions/code-apps.instructions.md`, `.github/agents/ux-designer.agent.md`, governance Pester |
+| `shared-foundation` | DESIGN-SENSITIVE | 2–4 | governance | `solution/apps/sales/package*.json`, `solution/apps/sales/tsconfig*`, shared packages, existing AdvisorCockpit harness/PCF imports/tests |
+| `b1-standalone` | DESIGN-SENSITIVE | 5 | shared-foundation | `solution/apps/sales/code-apps/advisor-cockpit-b1/**` |
+| `b2-embedded` | DESIGN-SENSITIVE | 6–7 | shared-foundation | B2 Code App, host web resource, app contract/publisher/tests |
+| `quality-gates` | EXECUTION-ONLY | 8 | Tasks 5–7 | CI workflow, release-policy scripts/tests |
+| `dev-proof` | DESIGN-SENSITIVE | 9 | Tasks 5–8 merged | attended DEV config, runbook, Sprint 005 evidence |
+| `test-proof` | DESIGN-SENSITIVE | 10 | DEV proof | TEST workflow/smoke, attended advisor evidence |
+| `decision-evidence` | DESIGN-SENSITIVE | 11 | DEV + TEST proof | scorecard, ADR-0033 evidence update, sprint close-out |
+
+Do not dispatch `b1-standalone` and `b2-embedded` until `shared-foundation` is
+merged. Do not allow either host stream to edit shared packages; shared defects
+return to the `shared-foundation` stream.
+
+## Target File Structure
+
+```text
+.github/
+  instructions/code-apps.instructions.md
+  workflows/ci-solution.yml
+docs/
+  adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md
+  superpowers/patterns/code-app-local-first-polish-loop.md
+  superpowers/sprints/sprint-005-code-app-parity/
+  testing/US-301-code-app-host-parity.md
+scripts/solution/
+  Publish-CodeAppsDev.ps1
+  Test-CodeAppsRelease.ps1
+  Get-CodeAppsPromotionFacts.ps1
+  tests/CodeAppsGovernance.Tests.ps1
+  tests/Publish-CodeAppsDev.Tests.ps1
+  tests/Test-CodeAppsRelease.Tests.ps1
+  tests/Get-CodeAppsPromotionFacts.Tests.ps1
+solution/apps/sales/
+  package.json
+  package-lock.json
+  tsconfig.base.json
+  playwright.config.ts
+  packages/
+    advisor-cockpit-domain/
+    advisor-cockpit-ui/
+  code-apps/
+    advisor-cockpit-b1/
+    advisor-cockpit-b2/
+  code-app-host/
+    advisor-cockpit-code-app-host.html
+    advisor-cockpit-code-app-host.js
+  Controls/AdvisorCockpit/              # local baseline + thin PCF wrapper
+solution/schema/
+  advisor-cockpit-app.json
+  advisor-cockpit-code-app-host.json
+```
+
+---
+
+### Task 0: Create the Sprint 005 Control Plane
+
+**Files:**
+
+- Create: `docs/superpowers/sprints/sprint-005-code-app-parity/sprint.md`
+- Create: `docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md`
+- Create: `docs/superpowers/sprints/sprint-005-code-app-parity/streams/*.md`
+- Modify: `docs/superpowers/sprints/README.md`
+
+- [ ] **Step 1: Create the Sprint Charter issue**
+
+Run from the trunk checkout:
+
+```powershell
+$sprintUrl = gh issue create `
+  --title '[Sprint Charter] Sprint 005 - Power Apps Code Apps Advisor Cockpit parity' `
+  --label 'sprint-charter' `
+  --body 'Approved design: docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md. Outcome: establish the Code Apps foundation, prove B1/B2 in DEV and TEST, and produce a human-reviewed recommendation. No B2E, Azure, or Dataverse schema extension.'
+if ($LASTEXITCODE -ne 0) { throw 'Sprint Charter issue creation failed.' }
+$sprintIssue = [int]($sprintUrl.Trim() -replace '^.*/', '')
+$sprintIssue
+```
+
+Expected: one issue URL and a numeric `$sprintIssue`.
+
+- [ ] **Step 2: Create one issue per stream and isolated worktrees**
+
+```powershell
+$streams = @(
+  @{ Id='governance';        Class='DESIGN-SENSITIVE'; Title='S5: Code Apps governance and primary-build rule' },
+  @{ Id='shared-foundation'; Class='DESIGN-SENSITIVE'; Title='S5: shared Advisor Cockpit workspace and parity baseline' },
+  @{ Id='b1-standalone';     Class='DESIGN-SENSITIVE'; Title='S5: standalone B1 Code App proof' },
+  @{ Id='b2-embedded';       Class='DESIGN-SENSITIVE'; Title='S5: embedded B2 Code App proof' },
+  @{ Id='quality-gates';     Class='EXECUTION-ONLY';   Title='S5: Code Apps CI and release-policy gates' },
+  @{ Id='dev-proof';         Class='DESIGN-SENSITIVE'; Title='S5: attended DEV parity proof' },
+  @{ Id='test-proof';        Class='DESIGN-SENSITIVE'; Title='S5: managed TEST parity proof' },
+  @{ Id='decision-evidence'; Class='DESIGN-SENSITIVE'; Title='S5: B1/B2 scorecard and recommendation' }
+)
+. ./scripts/orchestration/New-SprintWorktree.ps1
+foreach ($stream in $streams) {
+  $url = gh issue create --title $stream.Title --body "Parent Sprint Charter: #$sprintIssue`nApproved design: docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md`nAutonomy: $($stream.Class)"
+  if ($LASTEXITCODE -ne 0) { throw "Issue creation failed for $($stream.Id)." }
+  $issue = [int]($url.Trim() -replace '^.*/', '')
+  New-SprintWorktree -SprintId 'sprint-005' -StreamId $stream.Id -IssueNumber $issue -AutonomyClass $stream.Class
+}
+```
+
+Expected: eight worktrees under `..\wt\` and eight packet files under the
+Sprint 005 folder.
+
+- [ ] **Step 3: Write the charter and status board**
+
+The charter must copy the approved spec's Definition of Done verbatim and
+include `## Live DEV + TEST evidence`. The initial status table contains one
+row per stream with the issue number, autonomy class, branch, PR column, and
+`not started` status.
+
+- [ ] **Step 4: Validate orchestration metadata**
+
+Run:
+
+```powershell
+Invoke-Pester -Path scripts/orchestration/tests -Output Detailed
+. ./scripts/orchestration/Get-SprintStatus.ps1
+Get-SprintStatus
+```
+
+Expected: all orchestration tests pass and all eight Sprint 005 worktrees are
+listed.
+
+- [ ] **Step 5: Commit only sprint control-plane files**
+
+```powershell
+git add docs/superpowers/sprints/sprint-005-code-app-parity docs/superpowers/sprints/README.md
+git commit -m "docs(sprint-005): charter Code Apps parity proof (US-301)" -- docs/superpowers/sprints/sprint-005-code-app-parity docs/superpowers/sprints/README.md
+```
+
+---
+
+### Task 1: Establish the Code Apps Governance Rule
+
+**Files:**
+
+- Create: `docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md`
+- Create: `docs/superpowers/patterns/code-app-local-first-polish-loop.md`
+- Create: `.github/instructions/code-apps.instructions.md`
+- Create: `scripts/solution/tests/CodeAppsGovernance.Tests.ps1`
+- Modify: `docs/adr/ADR-0017-alm-everything-through-the-pipeline.md`
+- Modify: `docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md`
+- Modify: `docs/EXTENSIBILITY.md`
+- Modify: `docs/COPILOT-BUILD-GUIDE.md`
+- Modify: `.github/agents/ux-designer.agent.md`
+
+- [ ] **Step 1: Write the failing governance test**
+
+Create `scripts/solution/tests/CodeAppsGovernance.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    $root = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $adr = Join-Path $root 'docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md'
+    $pattern = Join-Path $root 'docs/superpowers/patterns/code-app-local-first-polish-loop.md'
+    $instructions = Join-Path $root '.github/instructions/code-apps.instructions.md'
+}
+
+Describe 'Code Apps governance foundation' {
+    It 'records the primary-build decision' {
+        Test-Path $adr | Should -BeTrue
+        Get-Content $adr -Raw | Should -Match 'Code Apps are primary for bespoke full-page CRM experiences'
+    }
+
+    It 'anchors the attended local-first loop' {
+        Test-Path $pattern | Should -BeTrue
+        $text = Get-Content $pattern -Raw
+        $text | Should -Match 'npm run dev'
+        $text | Should -Match 'pa app run'
+        $text | Should -Match 'Visual Studio Code'
+        $text | Should -Match 'DEV and TEST'
+    }
+
+    It 'scopes Code App source instructions' {
+        Test-Path $instructions | Should -BeTrue
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match 'power.config.json'
+        $text | Should -Match 'generated Dataverse services'
+        $text | Should -Match 'no fixture fallback'
+    }
+}
+```
+
+- [ ] **Step 2: Run the governance test and verify RED**
+
+```powershell
+Invoke-Pester -Path scripts/solution/tests/CodeAppsGovernance.Tests.ps1 -Output Detailed
+```
+
+Expected: FAIL because ADR-0041, the pattern, and instruction file do not exist.
+
+- [ ] **Step 3: Write ADR-0041**
+
+Use `docs/adr/ADR-TEMPLATE.md`. Record these exact committed decisions:
+
+```markdown
+## Decision or working hypothesis
+
+Code Apps are primary for bespoke full-page CRM experiences. Model-driven
+configuration remains primary for native forms, views, timelines and commands;
+PCF remains the extension path for embedded controls requiring form, dataset or
+field context. The Advisor Cockpit B1/B2 proof validates host placement without
+changing that build rule.
+
+DEV Code App creation and update use an attended maker `pa app push` because
+the current noninteractive CLI requires secret-based service-principal
+authentication. Git remains source of truth; TEST receives only the managed
+solution artifact exported from DEV by the OIDC pipeline. No client secret is
+introduced.
+```
+
+Options must compare: page-level PCF default; Code Apps for every CRM surface;
+and the selected bounded rule above. Set status `Accepted`, decision mode
+`Committed decision`, confidence `Medium`, license `🧩`, upgrade impact
+`Medium`, and list the DEV/TEST parity evidence as the review trigger.
+
+- [ ] **Step 4: Update existing governance documents**
+
+Make these precise changes:
+
+- ADR-0027 status becomes `Superseded by ADR-0041 for bespoke full-page
+  experiences; retained for embedded PCF controls and its local polish method`.
+- ADR-0017 gains a bounded exception subsection: attended `pa app push` to DEV,
+  reviewed source/build evidence required, no direct TEST authoring, OIDC
+  solution export/import unchanged.
+- `EXTENSIBILITY.md` distinguishes low-code canvas/model-driven configuration
+  from pro-code Code Apps and records the selected build order.
+- `COPILOT-BUILD-GUIDE.md` points full-page bespoke work to the Code App loop.
+- `ux-designer.agent.md` references the new pattern and keeps visual decisions
+  attended.
+
+- [ ] **Step 5: Add path-scoped Code App instructions**
+
+Create `.github/instructions/code-apps.instructions.md`:
+
+```markdown
+---
+description: Power Apps Code Apps architecture, local development, data access and ALM
+applyTo: 'solution/apps/**/{code-apps,packages}/**/*.{ts,tsx,js,json,html,css}'
+---
+
+# Power Apps Code Apps
+
+- Start from the current `microsoft/PowerAppsCodeApps` Vite template.
+- Use `@microsoft/power-apps` and `@microsoft/power-apps-vite`; keep each app's
+  generated `power.config.json`, models and services app-local.
+- Use generated Dataverse services. Do not add raw Dataverse Web API calls,
+  FetchXML, custom APIs or flows to conceal an unsupported SDK operation.
+- Keep fixture adapters local-only. Authenticated and deployed apps have no
+  fixture fallback and must show denied, failed, empty and unmapped states.
+- Run one server at a time: fixture Vite first, stop it, then `pa app run`.
+- Open visual refinement pages inside Visual Studio Code and keep UX decisions
+  attended.
+- Publish Code Apps into `crmshow_Sales`; promote the exact managed solution
+  from DEV to TEST. Never hard-code DEV play URLs in source.
+- Preserve agents-recommend/humans-decide and schema-validated writes.
+```
+
+- [ ] **Step 6: Run the governance test and full Pester suite**
+
+```powershell
+Invoke-Pester -Path scripts/solution/tests/CodeAppsGovernance.Tests.ps1 -Output Detailed
+Invoke-Pester -Path scripts/solution/tests -Output Detailed
+```
+
+Expected: both invocations pass.
+
+- [ ] **Step 7: Commit governance files**
+
+```powershell
+git add docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md docs/adr/ADR-0017-alm-everything-through-the-pipeline.md docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md docs/EXTENSIBILITY.md docs/COPILOT-BUILD-GUIDE.md docs/superpowers/patterns/code-app-local-first-polish-loop.md .github/instructions/code-apps.instructions.md .github/agents/ux-designer.agent.md scripts/solution/tests/CodeAppsGovernance.Tests.ps1
+git commit -m "docs(code-apps): establish primary full-page UX process (US-301)" -- docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md docs/adr/ADR-0017-alm-everything-through-the-pipeline.md docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md docs/EXTENSIBILITY.md docs/COPILOT-BUILD-GUIDE.md docs/superpowers/patterns/code-app-local-first-polish-loop.md .github/instructions/code-apps.instructions.md .github/agents/ux-designer.agent.md scripts/solution/tests/CodeAppsGovernance.Tests.ps1
+```
+
+---
+
+### Task 2: Extract the Shared Workspace Without Behavior Change
+
+**Files:**
+
+- Create: `solution/apps/sales/package.json`
+- Create: `solution/apps/sales/package-lock.json`
+- Create: `solution/apps/sales/tsconfig.base.json`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/package.json`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/tsconfig.json`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/index.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-ui/package.json`
+- Create: `solution/apps/sales/packages/advisor-cockpit-ui/tsconfig.json`
+- Create: `solution/apps/sales/packages/advisor-cockpit-ui/src/index.ts`
+- Move: `solution/apps/sales/Controls/AdvisorCockpit/src/types.ts`
+- Move: `solution/apps/sales/Controls/AdvisorCockpit/src/selectors.ts`
+- Move: `solution/apps/sales/Controls/AdvisorCockpit/src/selectors.test.ts`
+- Move: `solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.tsx`
+- Move: `solution/apps/sales/Controls/AdvisorCockpit/src/kpis.ts`
+- Move: `solution/apps/sales/Controls/AdvisorCockpit/src/tokens.ts`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/package.json`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/tsconfig.json`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/harness/main.tsx`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/src/fixtures.ts`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.test.tsx`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/pcf/package.json`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/pcf/package-lock.json`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/pcf/AdvisorCockpit/index.ts`
+
+- [ ] **Step 1: Capture the pre-move green baseline**
+
+```powershell
+Push-Location solution/apps/sales/Controls/AdvisorCockpit
+npm test
+npm run build
+Pop-Location
+Push-Location solution/apps/sales/Controls/AdvisorCockpit/pcf
+npm run build
+Pop-Location
+```
+
+Expected: all existing Vitest tests pass, Vite build passes, PCF build passes.
+Record the exact counts in Sprint 005 `STATUS.md`.
+
+- [ ] **Step 2: Create the workspace root**
+
+Create `solution/apps/sales/package.json`:
+
+```json
+{
+  "name": "@crmshow/sales-apps",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "code-apps/*",
+    "Controls/AdvisorCockpit"
+  ],
+  "scripts": {
+    "build": "npm run build --workspace @crmshow/advisor-cockpit-domain && npm run build --workspace @crmshow/advisor-cockpit-ui && npm run build --workspace @crmshow/advisor-cockpit-harness && npm --prefix Controls/AdvisorCockpit/pcf run build",
+    "test": "npm run test --workspace @crmshow/advisor-cockpit-domain && npm run test --workspace @crmshow/advisor-cockpit-harness",
+    "typecheck": "npm run typecheck --workspaces --if-present"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
+}
+```
+
+Create `solution/apps/sales/tsconfig.base.json` with the existing strict compiler
+options and `moduleResolution: "bundler"`.
+
+- [ ] **Step 3: Create focused package manifests**
+
+Domain package:
+
+```json
+{
+  "name": "@crmshow/advisor-cockpit-domain",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vitest": "^4.1.10"
+  }
+}
+```
+
+UI package:
+
+```json
+{
+  "name": "@crmshow/advisor-cockpit-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@crmshow/advisor-cockpit-domain": "0.1.0",
+    "@fluentui/react-components": "^9.54.0",
+    "@fluentui/react-icons": "^2.0.245"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}
+```
+
+Each package `tsconfig.json` extends `../../tsconfig.base.json` and includes
+only `src`.
+
+- [ ] **Step 4: Move files mechanically**
+
+```powershell
+git mv solution/apps/sales/Controls/AdvisorCockpit/src/types.ts solution/apps/sales/packages/advisor-cockpit-domain/src/types.ts
+git mv solution/apps/sales/Controls/AdvisorCockpit/src/selectors.ts solution/apps/sales/packages/advisor-cockpit-domain/src/selectors.ts
+git mv solution/apps/sales/Controls/AdvisorCockpit/src/selectors.test.ts solution/apps/sales/packages/advisor-cockpit-domain/src/selectors.test.ts
+git mv solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.tsx solution/apps/sales/packages/advisor-cockpit-ui/src/AdvisorCockpit.tsx
+git mv solution/apps/sales/Controls/AdvisorCockpit/src/kpis.ts solution/apps/sales/packages/advisor-cockpit-ui/src/kpis.ts
+git mv solution/apps/sales/Controls/AdvisorCockpit/src/tokens.ts solution/apps/sales/packages/advisor-cockpit-ui/src/tokens.ts
+```
+
+Create package barrels:
+
+```ts
+// packages/advisor-cockpit-domain/src/index.ts
+export * from './types';
+export * from './selectors';
+
+// packages/advisor-cockpit-ui/src/index.ts
+export * from './AdvisorCockpit';
+export * from './tokens';
+```
+
+Update UI imports from `./types` and `./selectors` to
+`@crmshow/advisor-cockpit-domain`. Update the harness, tests, fixture adapter,
+and PCF wrapper to import `AdvisorCockpit` from
+`@crmshow/advisor-cockpit-ui` and types from the domain package.
+
+Rename the existing harness package and add the workspace dependencies:
+
+```powershell
+Push-Location solution/apps/sales/Controls/AdvisorCockpit
+npm pkg set name='@crmshow/advisor-cockpit-harness'
+npm pkg set dependencies.'@crmshow/advisor-cockpit-domain'='0.1.0'
+npm pkg set dependencies.'@crmshow/advisor-cockpit-ui'='0.1.0'
+Pop-Location
+Push-Location solution/apps/sales/Controls/AdvisorCockpit/pcf
+npm pkg set dependencies.'@crmshow/advisor-cockpit-domain'='file:../../../packages/advisor-cockpit-domain'
+npm pkg set dependencies.'@crmshow/advisor-cockpit-ui'='file:../../../packages/advisor-cockpit-ui'
+Pop-Location
+```
+
+The PCF package stays outside the npm workspace because nesting it inside the
+harness workspace produces ambiguous npm ownership. It consumes the same
+source packages through explicit local file dependencies and keeps its own
+lockfile.
+
+- [ ] **Step 5: Install once at the workspace root**
+
+```powershell
+Push-Location solution/apps/sales
+npm install
+Pop-Location
+Push-Location solution/apps/sales/Controls/AdvisorCockpit/pcf
+npm install
+Pop-Location
+```
+
+Expected: `solution/apps/sales/package-lock.json` is generated and workspace
+packages are linked. Do not create or modify a repository-root lockfile.
+
+- [ ] **Step 6: Run post-move verification**
+
+```powershell
+Push-Location solution/apps/sales
+npm test
+npm run build
+Pop-Location
+```
+
+Expected: the exact pre-move tests/builds remain green with no behavior change.
+
+- [ ] **Step 7: Commit the extraction**
+
+```powershell
+git add solution/apps/sales/package.json solution/apps/sales/package-lock.json solution/apps/sales/tsconfig.base.json solution/apps/sales/packages solution/apps/sales/Controls/AdvisorCockpit
+git commit -m "refactor(code-apps): extract shared Advisor Cockpit packages (US-301)" -- solution/apps/sales/package.json solution/apps/sales/package-lock.json solution/apps/sales/tsconfig.base.json solution/apps/sales/packages solution/apps/sales/Controls/AdvisorCockpit
+```
+
+---
+
+### Task 3: Add the Minimal Host and Write-Capability Contract
+
+**Files:**
+
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/capabilities.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/capabilities.test.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/data-state.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/gateway.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/source-rows.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/map-cockpit-rows.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/map-cockpit-rows.test.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/provenance.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/write-capabilities.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-domain/src/write-capabilities.test.ts`
+- Create: `solution/apps/sales/packages/advisor-cockpit-ui/src/CapabilityButton.tsx`
+- Create: `solution/apps/sales/Controls/AdvisorCockpit/src/fixtureHost.ts`
+- Modify: `solution/apps/sales/packages/advisor-cockpit-domain/src/index.ts`
+- Modify: `solution/apps/sales/packages/advisor-cockpit-ui/src/AdvisorCockpit.tsx`
+- Modify: `solution/apps/sales/packages/advisor-cockpit-ui/src/tokens.ts`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.test.tsx`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/harness/main.tsx`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/pcf/AdvisorCockpit/index.ts`
+
+- [ ] **Step 1: Write failing contract tests**
+
+Create tests that assert:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { writeCapabilities } from './write-capabilities';
+
+describe('writeCapabilities', () => {
+  it('documents every visible write and never labels a blocked action supported', () => {
+    expect(Object.keys(writeCapabilities).sort()).toEqual([
+      'acceptNba', 'assignLead', 'bundleLeads', 'call', 'createAppointment', 'createTask',
+      'dismissNba', 'editNba', 'savePersonalView', 'snoozeNba', 'splitLeads',
+      'updateLeadQueueStatus',
+    ]);
+    expect(writeCapabilities.assignLead.availability).toBe('blocked');
+    expect(writeCapabilities.createTask.availability).toBe('blocked');
+    expect(writeCapabilities.dismissNba.availability).toBe('partial');
+  });
+});
+```
+
+Add a UI test proving a blocked `assignLead` command renders a disabled button
+whose accessible description contains `polymorphic owner lookup`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```powershell
+Push-Location solution/apps/sales
+npm test
+Pop-Location
+```
+
+Expected: FAIL because the capability files and host prop do not exist.
+
+- [ ] **Step 3: Add the closed capability types**
+
+Create `capabilities.ts`:
+
+```ts
+export type HostKind = 'fixture-harness' | 'pcf-artifact' | 'standalone-code-app' | 'embedded-code-app';
+export type CapabilityAvailability = 'supported' | 'partial' | 'blocked' | 'unverified';
+export type CockpitWriteCommand =
+  | { type: 'acceptNba'; nbaId: string }
+  | { type: 'assignLead'; leadIds: string[]; ownerId: string }
+  | { type: 'bundleLeads'; leadIds: string[]; clusterId: string }
+  | { type: 'splitLeads'; leadIds: string[] }
+  | { type: 'updateLeadQueueStatus'; leadId: string; status: string }
+  | { type: 'dismissNba'; nbaId: string }
+  | { type: 'snoozeNba'; nbaId: string }
+  | { type: 'editNba'; nbaId: string; changes: Readonly<{ channel?: string; rank?: number }> }
+  | { type: 'createAppointment'; accountId: string }
+  | { type: 'createTask'; accountId: string }
+  | { type: 'call'; phoneNumber: string }
+  | { type: 'savePersonalView'; name: string };
+
+export interface RuntimeContext {
+  hostKind: HostKind;
+  appId: string | null;
+  environmentId: string | null;
+  sessionId: string | null;
+  userObjectId: string | null;
+  locale: string;
+}
+
+export interface CommandCapability {
+  availability: CapabilityAvailability;
+  reason: string;
+  target: string;
+}
+
+export interface CommandResult {
+  ok: boolean;
+  message: string;
+}
+
+export interface AdvisorCockpitHost {
+  context: RuntimeContext;
+  capability(command: CockpitWriteCommand['type']): CommandCapability;
+  execute(command: CockpitWriteCommand): Promise<CommandResult>;
+  navigate(table: 'account' | 'lead' | 'crmshow_claimprojection', id: string): Promise<void>;
+}
+```
+
+Create `data-state.ts` with a closed union for `ready`, `empty`, `denied`,
+`error`, `unsupported`, and `unmapped`. Create `provenance.ts` with
+`'crm' | 'external' | 'unmapped'`; map CRM to normal, external to grey, and
+unmapped to yellow. Rename internal `dbx` provenance usages to `external`, but
+preserve the approved visible `Databricks (Mock)` legend wording for this parity
+sprint; translated labels and a more generic external-source vocabulary are a
+later requirement, not a parity change.
+
+Create `gateway.ts` so both app-local generated adapters implement one exact
+interface:
+
+```ts
+import type { CockpitData, LeadRecord, NbaRecord } from './types';
+import type { DataState } from './data-state';
+
+export interface NbaChanges {
+  channel?: string;
+  rank?: number;
+}
+
+export interface CockpitDataGateway {
+  load(): Promise<DataState<CockpitData>>;
+  updateNbaStatus(id: string, status: 'Accepted' | 'Planned' | 'Dismissed'): Promise<NbaRecord>;
+  updateNba(id: string, changes: NbaChanges): Promise<NbaRecord>;
+  updateLeadQueueStatus(id: string, status: string): Promise<LeadRecord>;
+  setLeadCluster(id: string, clusterId: string | null): Promise<LeadRecord>;
+}
+```
+
+`source-rows.ts` declares the canonical selected fields for each existing
+table. `map-cockpit-rows.ts` accepts those canonical arrays, joins only by
+primary GUID, and returns `CockpitData`; its tests cover missing lookups,
+permission-denied regions, external provenance, and unmapped values. Generated
+models never leak into the shared packages.
+
+- [ ] **Step 4: Implement the initial write matrix**
+
+`write-capabilities.ts` records the exact expectations approved by the spec:
+
+```ts
+export const writeCapabilities = {
+  acceptNba: { availability: 'unverified', reason: 'Generated-service update and reread must pass live verification.', target: 'crmshow_nextbestaction.crmshow_status' },
+  call: { availability: 'partial', reason: 'Phone launch only; activity logging is not supported.', target: 'tel:' },
+  dismissNba: { availability: 'partial', reason: 'Status can be stored; no dismissal-reason field exists.', target: 'crmshow_nextbestaction.crmshow_status' },
+  snoozeNba: { availability: 'partial', reason: 'Maps to Planned; no snooze-until field exists.', target: 'crmshow_nextbestaction.crmshow_status' },
+  editNba: { availability: 'partial', reason: 'Only existing allowlisted NBA fields can change.', target: 'crmshow_nextbestaction' },
+  updateLeadQueueStatus: { availability: 'unverified', reason: 'Generated-service update must pass live verification.', target: 'lead.crmshow_leadqueuestatus' },
+  bundleLeads: { availability: 'unverified', reason: 'Lookup association must pass generated-service verification.', target: 'lead.crmshow_leadclusterid' },
+  splitLeads: { availability: 'unverified', reason: 'Lookup disassociation must pass generated-service verification.', target: 'lead.crmshow_leadclusterid' },
+  assignLead: { availability: 'blocked', reason: 'Generated services do not support the polymorphic owner lookup required here.', target: 'lead.ownerid' },
+  createAppointment: { availability: 'blocked', reason: 'The regarding relationship is polymorphic.', target: 'appointment.regardingobjectid' },
+  createTask: { availability: 'blocked', reason: 'The regarding relationship is polymorphic.', target: 'task.regardingobjectid' },
+  savePersonalView: { availability: 'blocked', reason: 'No governed roaming preference contract exists.', target: 'user preference' },
+} as const;
+```
+
+- [ ] **Step 5: Refactor the UI through one host prop**
+
+Change the component signature at the current `AdvisorCockpitProps` seam:
+
+```ts
+export interface AdvisorCockpitProps {
+  data: CockpitData;
+  host: AdvisorCockpitHost;
+}
+
+export function AdvisorCockpit({ data, host }: AdvisorCockpitProps): JSX.Element {
+```
+
+Create `CapabilityButton.tsx` to wrap disabled Fluent buttons in a focusable
+tooltip span. Use `aria-disabled="true"` plus click/keyboard interception rather
+than the native `disabled` appearance so unsupported commands remain focusable,
+explainable, and pixel-neutral against the approved harness. Replace
+demo-success handlers for assign, bundle, split, create
+task/appointment, NBA accept/dismiss/snooze/edit, and call with
+`host.execute(...)`.
+Local filters, sorting, tab changes, selection, and dialogs remain local UI
+behavior. A command result is announced through the existing `aria-live`
+region. Do not display success before the promise resolves.
+
+This task must not move, resize, relabel, recolor, or add visible controls. Run
+the existing component tests and inspect the local harness inside VS Code before
+acceptance. Any visible drift is a defect and must be fixed before Task 4
+captures the baseline.
+
+- [ ] **Step 6: Add honest fixture/PCF hosts**
+
+`fixtureHost.ts` returns the static capability matrix and rejects every write
+with `ok: false`; it permits local UI operations and records no fake Dataverse
+success. The PCF artifact uses the same fixture host because it remains a
+non-user-visible fixture artifact.
+
+- [ ] **Step 7: Run tests and builds**
+
+```powershell
+Push-Location solution/apps/sales
+npm test
+npm run build
+Pop-Location
+```
+
+Expected: all prior interaction tests plus capability tests pass. Tests that
+previously asserted demo success now assert disabled state and the documented
+reason.
+
+- [ ] **Step 8: Commit the host contract**
+
+```powershell
+git add solution/apps/sales/packages solution/apps/sales/Controls/AdvisorCockpit
+git commit -m "feat(code-apps): add honest host capability contract (US-301)" -- solution/apps/sales/packages solution/apps/sales/Controls/AdvisorCockpit
+```
+
+---
+
+### Task 4: Capture the Local Harness Visual Baseline
+
+**Files:**
+
+- Create: `solution/apps/sales/playwright.config.ts`
+- Create: `solution/apps/sales/tests/visual/advisor-cockpit-parity.spec.ts`
+- Create: `solution/apps/sales/tests/visual/advisor-cockpit-parity.spec.ts-snapshots/*`
+- Modify: `solution/apps/sales/package.json`
+- Modify: `solution/apps/sales/package-lock.json`
+- Modify: `solution/apps/sales/Controls/AdvisorCockpit/vite.config.ts`
+- Modify: `docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md`
+
+- [ ] **Step 1: Add Playwright and write the missing-baseline test**
+
+Install at the workspace root:
+
+```powershell
+Push-Location solution/apps/sales
+npm install --save-dev @playwright/test@^1.55.0
+npx playwright install chromium
+Pop-Location
+```
+
+Create a test with fixed viewports:
+
+```ts
+import { expect, test } from '@playwright/test';
+
+for (const viewport of [
+  { name: 'desktop', width: 1440, height: 1000 },
+  { name: 'mobile', width: 390, height: 844 },
+]) {
+  test(`fixture harness ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await page.goto('/');
+    await expect(page.getByText('Arbeitsvorrat & persönliche Ziele')).toBeVisible();
+    await expect(page).toHaveScreenshot(`advisor-cockpit-${viewport.name}.png`, {
+      fullPage: true,
+      animations: 'disabled',
+    });
+  });
+}
+```
+
+Configure `webServer.command` as
+`npm run dev --workspace @crmshow/advisor-cockpit-harness -- --host 127.0.0.1`
+and `baseURL` as `http://127.0.0.1:5173`.
+
+- [ ] **Step 2: Run once and verify missing snapshots**
+
+```powershell
+Push-Location solution/apps/sales
+npx playwright test tests/visual/advisor-cockpit-parity.spec.ts
+Pop-Location
+```
+
+Expected: FAIL because approved baseline snapshots do not exist.
+
+- [ ] **Step 3: Capture and review snapshots inside VS Code**
+
+```powershell
+Push-Location solution/apps/sales
+npx playwright test tests/visual/advisor-cockpit-parity.spec.ts --update-snapshots
+Pop-Location
+```
+
+Open both images inside VS Code. Start the harness in a new integrated terminal,
+open `http://127.0.0.1:5173` inside VS Code, share it with Copilot, and obtain
+explicit user approval before accepting the images. Record the approval and
+viewport dimensions in `STATUS.md`.
+
+- [ ] **Step 4: Run visual tests without update mode**
+
+```powershell
+Push-Location solution/apps/sales
+npx playwright test tests/visual/advisor-cockpit-parity.spec.ts
+Pop-Location
+```
+
+Expected: both screenshot comparisons pass.
+
+- [ ] **Step 5: Commit the visual baseline**
+
+```powershell
+git add solution/apps/sales/package.json solution/apps/sales/package-lock.json solution/apps/sales/playwright.config.ts solution/apps/sales/tests/visual solution/apps/sales/Controls/AdvisorCockpit/vite.config.ts docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+git commit -m "test(code-apps): capture approved cockpit visual baseline (US-301)" -- solution/apps/sales/package.json solution/apps/sales/package-lock.json solution/apps/sales/playwright.config.ts solution/apps/sales/tests/visual solution/apps/sales/Controls/AdvisorCockpit/vite.config.ts docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+```
+
+---
+
+### Task 5: Build the Standalone B1 Code App
+
+**Files:**
+
+- Create: `solution/apps/sales/code-apps/advisor-cockpit-b1/**`
+- Modify: `solution/apps/sales/package-lock.json`
+
+- [ ] **Step 1: Scaffold from the official Vite template**
+
+```powershell
+npx degit github:microsoft/PowerAppsCodeApps/templates/vite solution/apps/sales/code-apps/advisor-cockpit-b1
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b1
+npm pkg set name='@crmshow/advisor-cockpit-b1'
+npm pkg set private=true --json
+npm pkg set dependencies.'@crmshow/advisor-cockpit-domain'='0.1.0'
+npm pkg set dependencies.'@crmshow/advisor-cockpit-ui'='0.1.0'
+npm pkg set dependencies.react='^18.3.1'
+npm pkg set dependencies.react-dom='^18.3.1'
+npm pkg set devDependencies.'@types/react'='^18.3.3'
+npm pkg set devDependencies.'@types/react-dom'='^18.3.0'
+npm pkg set devDependencies.vitest='^4.1.10'
+npm pkg set devDependencies.jsdom='^24.1.1'
+npm pkg set devDependencies.'@testing-library/react'='^16.0.1'
+npm pkg set devDependencies.'@testing-library/jest-dom'='^6.4.8'
+npm pkg set scripts.test='vitest run'
+Pop-Location
+Push-Location solution/apps/sales
+npm install
+Pop-Location
+```
+
+Verify `vite.config.ts` contains `react()` and `powerApps()` and `build` runs
+`tsc -b && vite build`. The current Microsoft template starts on React 19;
+the commands above intentionally normalize B1 to React 18.3.1 so PCF, the
+shared UI and both Code Apps compare one React runtime rather than host plus
+framework-version differences.
+
+- [ ] **Step 2: Write a failing shell test**
+
+Create `vitest.config.ts`:
+
+```ts
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+  },
+});
+```
+
+Create `src/test-setup.ts` with
+`import '@testing-library/jest-dom/vitest';`. Create `src/App.test.tsx`; render
+B1 with an injected fake `CockpitDataGateway` and `RuntimeContext`, then assert:
+
+```ts
+expect(screen.getByText('Arbeitsvorrat & persönliche Ziele')).toBeInTheDocument();
+expect(screen.getByTestId('host-kind')).toHaveTextContent('standalone-code-app');
+expect(screen.queryByText(/fixture mode/i)).not.toBeInTheDocument();
+```
+
+Run `npm test --workspace @crmshow/advisor-cockpit-b1`; expect FAIL because the
+B1 app shell does not exist.
+
+- [ ] **Step 3: Add the pass-through provider and runtime context**
+
+Keep SDK v1 initialization as a pass-through:
+
+```tsx
+export function PowerProvider({ children }: React.PropsWithChildren): JSX.Element {
+  return <>{children}</>;
+}
+```
+
+Use `getContext()` to map app, user, environment and session values into the
+shared `RuntimeContext`. Render loading and explicit context failure states.
+
+- [ ] **Step 4: Initialize B1 in DEV through an attended terminal**
+
+Preflight:
+
+```powershell
+if (-not $env:POWER_PLATFORM_DEV_ENVIRONMENT_ID) { throw 'POWER_PLATFORM_DEV_ENVIRONMENT_ID is required.' }
+pa auth status --json
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b1
+pa app init --display-name 'Advisor Cockpit - Standalone Proof' --environment-id $env:POWER_PLATFORM_DEV_ENVIRONMENT_ID --build-path dist
+Pop-Location
+```
+
+Expected: B1 `power.config.json` is generated for the authenticated demo tenant.
+
+- [ ] **Step 5: Add existing Dataverse tables**
+
+```powershell
+$tables = @(
+  'account','contact','lead','appointment','task','systemuser','businessunit',
+  'crmshow_leadcluster','crmshow_policyprojection','crmshow_claimprojection',
+  'crmshow_nextbestaction','crmshow_nbaprovenance','crmshow_measuresnapshot'
+)
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b1
+foreach ($table in $tables) {
+  pa app add data-source --connector dataverse --table $table
+  if ($LASTEXITCODE -ne 0) { throw "B1 data-source generation failed for $table." }
+}
+Pop-Location
+```
+
+Expected: generated model/service files exist under `src/generated`; no schema
+is created or changed.
+
+- [ ] **Step 6: Add the generated-service gateway and loader**
+
+First create `src/data/generatedGateway.test.ts`. Mock the app-local binding
+object and assert every `getAll` call supplies an explicit `select`, bounded
+`top`, and where applicable `filter`/`orderBy`; assert the returned canonical
+rows are passed to `mapCockpitRows`; assert a thrown service error returns the
+`error` state and never imports fixtures. Run the focused test and expect FAIL.
+
+Then create `src/data/generatedBindings.ts` with direct imports from the files
+created under `src/generated/services` and expose only `{ get, getAll, update }`
+methods needed by `GeneratedCockpitGateway`. Do not edit generated files. Create
+`src/data/GeneratedCockpitGateway.ts` implementing the shared
+`CockpitDataGateway`. Use narrow `select`, `filter`, `orderBy`, `top`, and
+paging options; normalize generated models into the canonical source-row types;
+call shared `mapCockpitRows` for all joins by primary GUID. It must never import
+`fixtures.ts` or `data/scenarios`.
+
+For NBA writes, allowlist `crmshow_status`, `crmshow_channel`, and fields already
+declared in `insurance-foundation.json`; send only changed properties; reread
+the NBA after update before returning success. `acceptNba`, `snoozeNba`, and
+`dismissNba` map only to the existing status choices `Accepted`, `Planned`, and
+`Dismissed`. Convert those semantic names through constants/types emitted by
+B1's generated model; never hard-code Dataverse option integers. The gateway
+test must assert all three mappings and fail if a generated option is absent.
+
+- [ ] **Step 7: Implement standalone navigation**
+
+Build native MDA links from `context.app.dataverseOrgUrl`, allowlisted table
+logical name, and validated GUID. Use `window.open(url, '_blank',
+'noopener,noreferrer')`. `call` may use a validated `tel:` link; it must not
+claim activity logging.
+
+- [ ] **Step 8: Run B1 tests, build and authenticated local host**
+
+```powershell
+Push-Location solution/apps/sales
+npm test --workspace @crmshow/advisor-cockpit-b1
+npm run build --workspace @crmshow/advisor-cockpit-b1
+Pop-Location
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b1
+pa app run
+```
+
+Open the Local Play URL inside VS Code with the tenant profile. Verify live
+reads, denied/error states, supported NBA status update+reread, and native
+record links. Stop the server before any other local host starts.
+
+- [ ] **Step 9: Commit B1**
+
+```powershell
+git add solution/apps/sales/code-apps/advisor-cockpit-b1 solution/apps/sales/package-lock.json
+git commit -m "feat(code-apps): add standalone Advisor Cockpit B1 (US-301)" -- solution/apps/sales/code-apps/advisor-cockpit-b1 solution/apps/sales/package-lock.json
+```
+
+---
+
+### Task 6: Build the Embedded B2 Code App
+
+**Files:**
+
+- Create: `solution/apps/sales/code-apps/advisor-cockpit-b2/**`
+- Modify: `solution/apps/sales/package-lock.json`
+
+- [ ] **Step 1: Scaffold an independent B2 identity**
+
+```powershell
+npx degit github:microsoft/PowerAppsCodeApps/templates/vite solution/apps/sales/code-apps/advisor-cockpit-b2
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b2
+npm pkg set name='@crmshow/advisor-cockpit-b2'
+npm pkg set private=true --json
+npm pkg set dependencies.'@crmshow/advisor-cockpit-domain'='0.1.0'
+npm pkg set dependencies.'@crmshow/advisor-cockpit-ui'='0.1.0'
+npm pkg set dependencies.react='^18.3.1'
+npm pkg set dependencies.react-dom='^18.3.1'
+npm pkg set devDependencies.'@types/react'='^18.3.3'
+npm pkg set devDependencies.'@types/react-dom'='^18.3.0'
+npm pkg set devDependencies.vitest='^4.1.10'
+npm pkg set devDependencies.jsdom='^24.1.1'
+npm pkg set devDependencies.'@testing-library/react'='^16.0.1'
+npm pkg set devDependencies.'@testing-library/jest-dom'='^6.4.8'
+npm pkg set scripts.test='vitest run'
+Pop-Location
+Push-Location solution/apps/sales
+npm install
+Pop-Location
+```
+
+Keep a distinct `power.config.json`, display name and generated directory. Pin
+React 18.3.1 intentionally for the same parity reason as B1.
+
+- [ ] **Step 2: Write failing B2 shell and message tests**
+
+Create the same explicit `vitest.config.ts` and `src/test-setup.ts` content
+shown in Task 5. The B2 test suite is independent and must not import B1 tests.
+Assert host kind `embedded-code-app`. Test that navigation sends exactly:
+
+```ts
+{
+  version: 1,
+  type: 'crmshow.navigate',
+  table: 'account',
+  id: '11111111-1111-1111-1111-111111111111'
+}
+```
+
+Assert unknown table names and non-GUID IDs are rejected before `postMessage`.
+Run B2 tests and expect FAIL because the embedded adapter is absent.
+
+- [ ] **Step 3: Add provider, context and exact-parent messaging**
+
+Create B2's own pass-through provider:
+
+```tsx
+export function PowerProvider({ children }: React.PropsWithChildren): JSX.Element {
+  return <>{children}</>;
+}
+```
+
+Call `getContext()` in the B2 shell and map the returned app, user, environment,
+session and locale values into the shared `RuntimeContext`. Derive the parent
+target origin from `document.referrer`; require HTTPS and a
+`.crm.dynamics.com` hostname. Send closed versioned messages only to that exact
+origin, never `'*'`.
+
+- [ ] **Step 4: Initialize B2 in DEV through an attended terminal**
+
+```powershell
+if (-not $env:POWER_PLATFORM_DEV_ENVIRONMENT_ID) { throw 'POWER_PLATFORM_DEV_ENVIRONMENT_ID is required.' }
+pa auth status --json
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b2
+pa app init --display-name 'Advisor Cockpit - Embedded Proof' --environment-id $env:POWER_PLATFORM_DEV_ENVIRONMENT_ID --build-path dist
+Pop-Location
+```
+
+- [ ] **Step 5: Generate the same existing Dataverse surfaces for B2**
+
+```powershell
+$tables = @(
+  'account','contact','lead','appointment','task','systemuser','businessunit',
+  'crmshow_leadcluster','crmshow_policyprojection','crmshow_claimprojection',
+  'crmshow_nextbestaction','crmshow_nbaprovenance','crmshow_measuresnapshot'
+)
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b2
+foreach ($table in $tables) {
+  pa app add data-source --connector dataverse --table $table
+  if ($LASTEXITCODE -ne 0) { throw "B2 data-source generation failed for $table." }
+}
+Pop-Location
+```
+
+Create B2-local `generatedBindings.ts`, `GeneratedCockpitGateway.ts`, and
+`generatedGateway.test.ts` with the exact interfaces and assertions specified
+in Task 5 Step 6, importing only B2's generated files. Normalize into the shared
+canonical source-row types and call `mapCockpitRows`; do not import B1 source,
+fixtures, or a copied domain mapper. Run the B2 gateway test RED before writing
+the adapter, then GREEN after implementation. Repeat the generated-model
+semantic-to-numeric NBA status mapping assertions independently in B2.
+
+- [ ] **Step 6: Run B2 tests, build and authenticated local host**
+
+```powershell
+Push-Location solution/apps/sales
+npm test --workspace @crmshow/advisor-cockpit-b2
+npm run build --workspace @crmshow/advisor-cockpit-b2
+Pop-Location
+Push-Location solution/apps/sales/code-apps/advisor-cockpit-b2
+pa app run
+```
+
+Open Local Play inside VS Code. This proves generated services and child-side
+message validation only; record iframe/CSP/MDA behavior as unproven until Task 9.
+Stop the server.
+
+- [ ] **Step 7: Commit B2**
+
+```powershell
+git add solution/apps/sales/code-apps/advisor-cockpit-b2 solution/apps/sales/package-lock.json
+git commit -m "feat(code-apps): add embedded Advisor Cockpit B2 shell (US-301)" -- solution/apps/sales/code-apps/advisor-cockpit-b2 solution/apps/sales/package-lock.json
+```
+
+---
+
+### Task 7: Add the B2 MDA Sitemap Host and Environment Binding
+
+**Files:**
+
+- Create: `solution/apps/sales/code-app-host/advisor-cockpit-code-app-host.html`
+- Create: `solution/apps/sales/code-app-host/advisor-cockpit-code-app-host.js`
+- Create: `solution/schema/advisor-cockpit-code-app-host.json`
+- Create: `scripts/solution/publish-advisor-cockpit-code-app-host.ps1`
+- Create: `scripts/solution/Set-CodeAppsEnvironmentConfiguration.ps1`
+- Create: `scripts/solution/tests/PublishAdvisorCockpitCodeAppHost.Tests.ps1`
+- Create: `scripts/solution/tests/SetCodeAppsEnvironmentConfiguration.Tests.ps1`
+- Modify: `solution/schema/advisor-cockpit-app.json`
+- Modify: `scripts/solution/publish-advisor-cockpit-app.ps1`
+- Modify: `scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1`
+
+- [ ] **Step 1: Write failing host contract tests**
+
+Assert the contract declares exactly these environment-variable schema names:
+
+```text
+crmshow_AdvisorCockpitB1PlayUrl
+crmshow_AdvisorCockpitB2PlayUrl
+crmshow_AdvisorCockpitB2AllowedOrigin
+```
+
+Assert the sitemap contains a `Beratercockpit (B2 Code App)` subarea whose URL
+is `/WebResources/crmshow_advisorcockpitcodeapphost.html`. Assert the host source
+contains no literal environment GUID, tenant URL, or wildcard `postMessage`.
+Assert the configuration setter requires three HTTPS values, rejects a B2
+allowed origin containing path/query content, updates only current-value rows,
+redacts values from output, and honors `ShouldProcess`.
+
+Run the two focused Pester files and expect FAIL.
+
+- [ ] **Step 2: Write the host HTML and JavaScript**
+
+The HTML contains a fixed-size responsive iframe, loading/error region and
+script reference. The script must:
+
+1. Use `parent.Xrm.WebApi.retrieveMultipleRecords` to resolve the B2 play URL
+   and allowed child origin from environment-variable definition/value rows.
+2. Require an HTTPS `https://apps.powerapps.com/play/` URL.
+3. Append `hideNavBar=true` without discarding existing query parameters.
+4. Set iframe `title="Advisor Cockpit"` and `allow="local-network-access"`
+   only for local development; the deployed host omits device permissions.
+5. Validate `event.origin` against `crmshow_AdvisorCockpitB2AllowedOrigin`.
+6. Validate message version, type, table allowlist and GUID.
+7. Call `parent.Xrm.Navigation.openForm({ entityName, entityId })`.
+8. Render a visible configuration or navigation error without exposing data.
+
+- [ ] **Step 3: Add idempotent web-resource publication**
+
+`publish-advisor-cockpit-code-app-host.ps1` reads the two source files, inlines
+the JavaScript into the HTML for one web-resource component, base64-encodes the
+content, queries `webresourceset` by exact `name`, and POSTs or PATCHes as
+required. It also reconciles the three environment-variable **definitions**
+from the contract and adds the definitions plus web resource to
+`crmshow_Sales`; it never writes an environment-specific value. All network
+calls pass through one mockable function and honor `ShouldProcess`. Publish
+changes only after every component is attached.
+
+- [ ] **Step 4: Add environment-specific value reconciliation**
+
+Create `Set-CodeAppsEnvironmentConfiguration.ps1` with mandatory
+`EnvironmentUrl`, `B1PlayUrl`, `B2PlayUrl`, and `B2AllowedOrigin` parameters.
+Require HTTPS; require each play URL to start with
+`https://apps.powerapps.com/play/`; require `B2AllowedOrigin` to be a bare
+origin. Query each definition by exact schema name, then POST or PATCH its
+current-value row. Send requests through one injectable/mocked transport, honor
+`ShouldProcess`, and output only schema names plus `Configured = $true`.
+
+Run its focused Pester test RED before implementation and GREEN afterward.
+
+- [ ] **Step 5: Extend the app contract without guessing custom-page types**
+
+Extend sitemap subareas to support either `pageUniqueName` or `url`. Add
+`WebResource = 61` to component types and resolve `webresourceid` by exact name.
+Do not change the unresolved custom-page behavior. Add Pester coverage for URL
+XML escaping, web-resource resolution, idempotent component attachment, and
+missing-host failure.
+
+- [ ] **Step 6: Run focused and full Pester suites**
+
+```powershell
+Invoke-Pester -Path @(
+  'scripts/solution/tests/PublishAdvisorCockpitCodeAppHost.Tests.ps1',
+  'scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1',
+  'scripts/solution/tests/SetCodeAppsEnvironmentConfiguration.Tests.ps1'
+) -Output Detailed
+Invoke-Pester -Path scripts/solution/tests -Output Detailed
+```
+
+Expected: all tests pass without a live environment.
+
+- [ ] **Step 7: Commit the B2 host**
+
+```powershell
+git add solution/apps/sales/code-app-host solution/schema/advisor-cockpit-code-app-host.json solution/schema/advisor-cockpit-app.json scripts/solution/publish-advisor-cockpit-code-app-host.ps1 scripts/solution/Set-CodeAppsEnvironmentConfiguration.ps1 scripts/solution/publish-advisor-cockpit-app.ps1 scripts/solution/tests/PublishAdvisorCockpitCodeAppHost.Tests.ps1 scripts/solution/tests/SetCodeAppsEnvironmentConfiguration.Tests.ps1 scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+git commit -m "feat(sales): add environment-bound B2 sitemap host (US-301)" -- solution/apps/sales/code-app-host solution/schema/advisor-cockpit-code-app-host.json solution/schema/advisor-cockpit-app.json scripts/solution/publish-advisor-cockpit-code-app-host.ps1 scripts/solution/Set-CodeAppsEnvironmentConfiguration.ps1 scripts/solution/publish-advisor-cockpit-app.ps1 scripts/solution/tests/PublishAdvisorCockpitCodeAppHost.Tests.ps1 scripts/solution/tests/SetCodeAppsEnvironmentConfiguration.Tests.ps1 scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1
+```
+
+---
+
+### Task 8: Add CI and Release-Policy Gates
+
+**Files:**
+
+- Create: `scripts/solution/Test-CodeAppsRelease.ps1`
+- Create: `scripts/solution/tests/Test-CodeAppsRelease.Tests.ps1`
+- Modify: `.github/workflows/ci-solution.yml`
+- Modify: `solution/apps/sales/package.json`
+- Modify: `solution/apps/sales/package-lock.json`
+
+- [ ] **Step 1: Write failing release-policy tests**
+
+The pure evaluator accepts an injected file map and fails when:
+
+- B1/B2 custom source imports `fixtures` or `data/scenarios`.
+- custom TS/HTML contains `.crm.dynamics.com` or a literal
+  `apps.powerapps.com/play/e/` URL.
+- B1/B2 lacks `power.config.json`.
+- either app omits `@microsoft/power-apps-vite`.
+- the B2 host uses wildcard `postMessage` or accepts an unlisted table.
+
+Run the test and expect RED before the evaluator exists.
+
+- [ ] **Step 2: Implement `Test-CodeAppsRelease.ps1`**
+
+Return a structured object with `Overall` and checks named
+`NoFixtureFallback`, `NoEnvironmentUrls`, `PowerConfigPresent`,
+`PowerAppsPluginPresent`, and `B2MessageBoundary`. The live script exits nonzero
+when `Overall` is false and prints relative paths only.
+
+- [ ] **Step 3: Add workspace quality scripts**
+
+At the Sales workspace root add:
+
+```json
+{
+  "scripts": {
+    "test:visual": "playwright test tests/visual/advisor-cockpit-parity.spec.ts",
+    "test:a11y": "vitest run --testNamePattern accessibility",
+    "release:check": "pwsh ../../../scripts/solution/Test-CodeAppsRelease.ps1 -Root ."
+  }
+}
+```
+
+Add `vitest-axe` to the harness dev dependencies and tests for no critical axe
+violations, keyboard focus return, and 320px reflow.
+
+- [ ] **Step 4: Extend CI with one deterministic workspace step**
+
+After Pester and before solution packing, add:
+
+```yaml
+      - name: Build and test Sales Code Apps workspace
+        shell: pwsh
+        run: |
+          $node = [version]((node --version).TrimStart('v'))
+          if ($node -lt [version]'20.19.0') { throw "Node 20.19+ required; found $node" }
+          Push-Location solution/apps/sales
+          npm ci
+          npm test
+          npm run build
+          npx playwright install --with-deps chromium
+          npm run test:visual
+          npm run release:check
+          Pop-Location
+```
+
+Update workflow path filters to include the new workspace, governance
+instruction, and Code App scripts/tests. Do not add cloud credentials to CI.
+
+- [ ] **Step 5: Run the full local gate**
+
+```powershell
+Push-Location solution/apps/sales
+npm ci
+npm test
+npm run build
+npm run test:visual
+npm run release:check
+Pop-Location
+Invoke-Pester -Path scripts/solution/tests -Output Detailed
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Commit quality gates**
+
+```powershell
+git add scripts/solution/Test-CodeAppsRelease.ps1 scripts/solution/tests/Test-CodeAppsRelease.Tests.ps1 .github/workflows/ci-solution.yml solution/apps/sales/package.json solution/apps/sales/package-lock.json solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.test.tsx
+git commit -m "ci(code-apps): gate builds parity accessibility and release safety (US-301)" -- scripts/solution/Test-CodeAppsRelease.ps1 scripts/solution/tests/Test-CodeAppsRelease.Tests.ps1 .github/workflows/ci-solution.yml solution/apps/sales/package.json solution/apps/sales/package-lock.json solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.test.tsx
+```
+
+---
+
+### Task 9: Publish and Prove B1/B2 in DEV
+
+**Files:**
+
+- Create: `scripts/solution/Publish-CodeAppsDev.ps1`
+- Create: `scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1`
+- Create: `docs/runbooks/publish-code-apps-dev.md`
+- Modify: `.github/workflows/cd-solution-dev.yml`
+- Modify: `docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md`
+
+- [ ] **Step 1: Write failing wrapper tests**
+
+Mock all process execution. Assert the wrapper:
+
+- refuses missing environment/solution GUIDs;
+- checks `pa auth status --json` before build/push;
+- runs B1 then B2 builds and `pa app push --solution-id`;
+- never sets `PA_CLI_USE_SP_AUTH`, `SP_CLIENT_SECRET`, or calls TEST;
+- writes evidence containing commit SHA, CLI version, app name, timestamp and
+  exit code, but no token or credential.
+
+Run focused Pester and expect RED.
+
+- [ ] **Step 2: Implement the attended DEV wrapper**
+
+Parameters are `EnvironmentId`, `SolutionId`, and `EvidencePath`, each required.
+Validate GUIDs. Require an interactive active account returned by `pa auth
+status --json`. Build and push each app sequentially, stop on first failure,
+and write BOM-free UTF-8 evidence JSON.
+
+- [ ] **Step 3: Write the attended runbook**
+
+The runbook includes:
+
+```powershell
+pa auth login
+pa auth status --json
+./scripts/solution/Publish-CodeAppsDev.ps1 `
+  -EnvironmentId $env:POWER_PLATFORM_DEV_ENVIRONMENT_ID `
+  -SolutionId $env:CRM_SHOWCASE_SALES_SOLUTION_ID `
+  -EvidencePath ./artifacts/code-apps-dev-publish.json
+```
+
+Then instruct the maker to:
+
+1. Share play access for B1/B2 with the advisor user.
+2. Sign in with `az login --allow-no-subscriptions` and run:
+
+  ```powershell
+  ./scripts/solution/Set-CodeAppsEnvironmentConfiguration.ps1 `
+    -EnvironmentUrl $env:POWER_PLATFORM_DEV_ENV_URL `
+    -B1PlayUrl $env:ADVISOR_COCKPIT_B1_PLAY_URL `
+    -B2PlayUrl $env:ADVISOR_COCKPIT_B2_PLAY_URL `
+    -B2AllowedOrigin $env:ADVISOR_COCKPIT_B2_ALLOWED_ORIGIN `
+    -Confirm:$false
+  ```
+
+  Store those values in the local shell or approved operator configuration;
+  do not commit them.
+3. Publish the B2 web resource and app contract through the DEV authoring step.
+4. Configure Code Apps CSP `frame-ancestors` with the exact DEV Dynamics origin.
+5. Wait for propagation and verify the browser console has no CSP violation.
+
+- [ ] **Step 4: Add DEV authoring after attended app publication**
+
+The CD-DEV workflow must not run `pa app push`. It may publish the source-driven
+B2 host, reconcile the MDA sitemap, and export the solution only after a
+preflight proves both Code Apps and environment variables exist in DEV. Add a
+clear failure that points to the attended runbook when preflight is missing.
+
+- [ ] **Step 5: Run offline tests**
+
+```powershell
+Invoke-Pester -Path scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 -Output Detailed
+Invoke-Pester -Path scripts/solution/tests -Output Detailed
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Execute the attended DEV publication**
+
+Run the runbook as maker/admin. Do not transmit credentials through chat.
+Record sanitized evidence and app IDs in the Sprint 005 issue/STATUS; do not
+commit tenant IDs or full play URLs.
+
+- [ ] **Step 7: Run least-privilege DEV journeys**
+
+As the advisor user, run B1 and B2 with the same synthetic seed:
+
+- all tabs/views/filters/dialogs;
+- normal/grey/yellow provenance and accessible legend;
+- NBA supported update followed by reread;
+- every blocked action disabled with the matrix reason;
+- B1 native record deep link;
+- B2 sitemap, iframe, CSP, message validation and native navigation;
+- screenshot, session ID, browser timing, Power Platform Monitor evidence.
+
+Record failures as `Concern` or `Blocker`; do not change host UX without
+returning to attended design review.
+
+- [ ] **Step 8: Commit source/runbook changes and DEV evidence references**
+
+```powershell
+git add scripts/solution/Publish-CodeAppsDev.ps1 scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 docs/runbooks/publish-code-apps-dev.md .github/workflows/cd-solution-dev.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+git commit -m "feat(code-apps): add attended DEV publication and proof gate (US-301)" -- scripts/solution/Publish-CodeAppsDev.ps1 scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 docs/runbooks/publish-code-apps-dev.md .github/workflows/cd-solution-dev.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+```
+
+---
+
+### Task 10: Promote and Prove the Managed Apps in TEST
+
+**Files:**
+
+- Create: `scripts/solution/Get-CodeAppsPromotionFacts.ps1`
+- Create: `scripts/solution/tests/Get-CodeAppsPromotionFacts.Tests.ps1`
+- Modify: `scripts/solution/Get-PromotionSmokeResult.ps1`
+- Modify: `scripts/solution/tests/Get-PromotionSmokeResult.Tests.ps1`
+- Modify: `.github/workflows/cd-solution-test.yml`
+- Modify: `docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md`
+
+- [ ] **Step 1: Write failing promotion-fact tests**
+
+Given mocked Dataverse responses, assert the gatherer returns:
+
+```powershell
+[pscustomobject]@{
+    CodeApps = @('Advisor Cockpit - Standalone Proof','Advisor Cockpit - Embedded Proof')
+    WebResources = @('crmshow_advisorcockpitcodeapphost.html')
+    EnvironmentVariables = @(
+        'crmshow_AdvisorCockpitB1PlayUrl',
+        'crmshow_AdvisorCockpitB2PlayUrl',
+        'crmshow_AdvisorCockpitB2AllowedOrigin'
+    )
+    ContainsDevUrl = $false
+}
+```
+
+Extend smoke-result tests so missing app, host, variable, managed Sales solution,
+or a DEV URL makes `Overall` false.
+
+- [ ] **Step 2: Implement fact gathering and pure smoke checks**
+
+Use OIDC-authenticated `az rest` only to query app, web-resource,
+environment-variable and solution facts. Redact values from output; report
+only names and boolean checks. Keep the evaluator transport-free and fully
+unit-tested.
+
+- [ ] **Step 3: Complete TEST workflow steps**
+
+After managed import:
+
+1. Read `ADVISOR_COCKPIT_B1_PLAY_URL`, `ADVISOR_COCKPIT_B2_PLAY_URL`, and
+  `ADVISOR_COCKPIT_B2_ALLOWED_ORIGIN` from TEST GitHub Environment **variables**
+  and call `Set-CodeAppsEnvironmentConfiguration.ps1`. Fail before smoke when
+  any value is absent; never echo values.
+2. Seed the synthetic Advisor Cockpit scenario with the existing idempotent
+   script.
+3. Gather facts and run `Get-PromotionSmokeResult` with expected Foundation,
+   DataModel, Integration and Sales solutions.
+4. Fail on missing B1/B2, host, variables, unmanaged Sales, or DEV URL.
+5. Upload a redacted smoke JSON artifact.
+
+The workflow does not run `pa app push` and does not store user credentials.
+
+- [ ] **Step 4: Run offline promotion tests**
+
+```powershell
+Invoke-Pester -Path @(
+  'scripts/solution/tests/Get-CodeAppsPromotionFacts.Tests.ps1',
+  'scripts/solution/tests/Get-PromotionSmokeResult.Tests.ps1'
+) -Output Detailed
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Dispatch managed TEST promotion**
+
+Dispatch `cd-solution-test.yml`, approve the TEST environment, and verify the
+exact `crmshow_Sales` artifact exported from DEV is imported. Apply TEST app
+sharing and exact TEST CSP as attended environment configuration; do not author
+app code directly in TEST.
+
+- [ ] **Step 6: Run least-privilege TEST journeys**
+
+Repeat the DEV B1/B2 script unchanged as the TEST advisor. Capture pipeline URL,
+step table, test counts, screenshots, session IDs, timings, Monitor evidence,
+supported write+reread, blocked actions, and defects fixed.
+
+- [ ] **Step 7: Demonstrate rollback**
+
+Reinstall the prior managed `crmshow_Sales` version and restore prior sitemap
+and environment configuration. Verify proof entries are absent/reverted. Then
+reinstall the candidate managed package and rerun smoke. Do not claim the
+deployed PCF as a fallback.
+
+- [ ] **Step 8: Commit TEST pipeline and evidence references**
+
+```powershell
+git add scripts/solution/Get-CodeAppsPromotionFacts.ps1 scripts/solution/tests/Get-CodeAppsPromotionFacts.Tests.ps1 scripts/solution/Get-PromotionSmokeResult.ps1 scripts/solution/tests/Get-PromotionSmokeResult.Tests.ps1 .github/workflows/cd-solution-test.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+git commit -m "ci(code-apps): prove managed B1 and B2 in TEST (US-301)" -- scripts/solution/Get-CodeAppsPromotionFacts.ps1 scripts/solution/tests/Get-CodeAppsPromotionFacts.Tests.ps1 scripts/solution/Get-PromotionSmokeResult.ps1 scripts/solution/tests/Get-PromotionSmokeResult.Tests.ps1 .github/workflows/cd-solution-test.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+```
+
+---
+
+### Task 11: Produce the Comparative Recommendation and Close the Sprint
+
+**Files:**
+
+- Create: `docs/testing/US-301-code-app-host-parity.md`
+- Modify: `docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md`
+- Modify: `docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md`
+- Modify: `docs/superpowers/sprints/README.md`
+
+- [ ] **Step 1: Write the evidence scorecard**
+
+For B1 and B2, record `Pass`, `Concern`, `Blocker`, or `Not applicable`, an
+evidence link, and a concise finding for:
+
+- visual/functional parity;
+- advisor workflow/navigation;
+- responsive behavior/accessibility;
+- load/interaction performance;
+- identity/sharing/least privilege;
+- CSP/embedding complexity;
+- ALM/configuration/rollback;
+- failure visibility/resilience;
+- Monitor supportability;
+- developer polish speed;
+- maintenance/controlled divergence;
+- licensing/platform constraints.
+
+Do not calculate a weighted winner.
+
+- [ ] **Step 2: Reconcile the write-capability matrix with live evidence**
+
+Every visible command receives final B1/B2 status, exact limitation, runtime
+treatment, evidence, and a named follow-up requirement. Verify no disabled
+command reported success and no missing write was silently dropped.
+
+- [ ] **Step 3: Add evidence to ADR-0033 without selecting an option**
+
+Append the DEV/TEST proof links, scorecard link, recommendation, remaining
+blockers, and decision-owner review trigger. Keep ADR-0033 unselected until a
+separate human approval explicitly chooses B1 or B2.
+
+- [ ] **Step 4: Close Sprint 005 evidence**
+
+`STATUS.md` must include:
+
+- green DEV pipeline URL and offline test counts;
+- TEST promotion URL and per-step result table;
+- B1/B2 advisor journey results;
+- defects found/fixed;
+- rollback proof;
+- unresolved concerns/blockers;
+- explicit statement that the PCF local harness was the visual baseline and
+  the deployed PCF was not a user-visible comparator or fallback.
+
+- [ ] **Step 5: Run final repository validation**
+
+```powershell
+Push-Location solution/apps/sales
+npm ci
+npm test
+npm run build
+npm run test:visual
+npm run release:check
+Pop-Location
+Invoke-Pester -Path scripts/solution/tests -Output Detailed
+Invoke-Pester -Path scripts/orchestration/tests -Output Detailed
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 6: Commit the recommendation package**
+
+```powershell
+git add docs/testing/US-301-code-app-host-parity.md docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md docs/superpowers/sprints/README.md
+git commit -m "docs(code-apps): recommend Advisor Cockpit host from live evidence (US-301)" -- docs/testing/US-301-code-app-host-parity.md docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md docs/superpowers/sprints/README.md
+```
+
+The named human then reviews the recommendation. Selecting B1/B2 and retiring
+or repurposing the PCF artifact requires a separate ADR decision and is not part
+of this implementation plan.
+
+---
+
+## Final Definition of Done
+
+- ADR-0041 and the Code App local-first pattern are accepted and enforced.
+- Shared domain/UI packages build once and feed the harness, PCF artifact, B1
+  and B2 without copied business rules.
+- The approved local fixture harness is the visual baseline.
+- B1 and B2 have separate identities, generated services and host adapters.
+- Provenance and error states remain honest and accessible.
+- Every visible write is implemented or visibly disabled and documented.
+- No B2E, Azure, schema extension, raw Web API, custom API, flow, secret-based
+  CI, DEV URL literal, or deployed fixture fallback is introduced.
+- B1 and B2 pass least-privilege journeys in DEV and TEST.
+- Managed promotion and previous-version rollback are demonstrated.
+- The scorecard makes an evidence-backed recommendation without automatically
+  choosing a winner.

--- a/docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md
+++ b/docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md
@@ -2,13 +2,13 @@
 
 | Field | Value |
 | --- | --- |
-| **Status** | Approved design; written-spec review pending |
+| **Status** | Approved design and written specification |
 | **Date** | 2026-08-19 |
 | **Story** | US-301 — AG-F-01 Next-Best-Action / Advisor Cockpit |
 | **Use case** | UC-01 — Advisor Cockpit |
 | **Deciders** | Repo owner · AG-E-03 Enterprise Architect · AG-E-02 Developer · AG-E-04 SecDevOps · AG-E-11 UX Designer |
 | **Related ADRs** | [ADR-0014](../../adr/ADR-0014-agents-advisory-by-design.md) · [ADR-0017](../../adr/ADR-0017-alm-everything-through-the-pipeline.md) · [ADR-0027](../../adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md) · [ADR-0033](../../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md) |
-| **Design pattern** | [06 — CRM UX placement](../../design/06-crm-ux-placement-options.md) |
+| **Design pattern** | [CRM UX placement](../../design/ADR-0033-crm-ux-placement-options.md) |
 | **Licence** | 🧩 pro-code on Power Apps managed hosting; Power Apps Premium and applicable Dynamics 365 / Copilot Studio rights require persona-level validation |
 | **Maturity** | Power Apps Code Apps: generally available · B1/B2 Advisor Cockpit compositions: design/proof |
 | **Upgrade impact** | Medium — two isolated Code App shells, shared source packages, one MDA host, and environment configuration |

--- a/docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md
+++ b/docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md
@@ -1,0 +1,522 @@
+# Power Apps Code Apps Foundation and Advisor Cockpit B1/B2 Parity Proof
+
+| Field | Value |
+| --- | --- |
+| **Status** | Approved design; written-spec review pending |
+| **Date** | 2026-08-19 |
+| **Story** | US-301 — AG-F-01 Next-Best-Action / Advisor Cockpit |
+| **Use case** | UC-01 — Advisor Cockpit |
+| **Deciders** | Repo owner · AG-E-03 Enterprise Architect · AG-E-02 Developer · AG-E-04 SecDevOps · AG-E-11 UX Designer |
+| **Related ADRs** | [ADR-0014](../../adr/ADR-0014-agents-advisory-by-design.md) · [ADR-0017](../../adr/ADR-0017-alm-everything-through-the-pipeline.md) · [ADR-0027](../../adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md) · [ADR-0033](../../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md) |
+| **Design pattern** | [06 — CRM UX placement](../../design/06-crm-ux-placement-options.md) |
+| **Licence** | 🧩 pro-code on Power Apps managed hosting; Power Apps Premium and applicable Dynamics 365 / Copilot Studio rights require persona-level validation |
+| **Maturity** | Power Apps Code Apps: generally available · B1/B2 Advisor Cockpit compositions: design/proof |
+| **Upgrade impact** | Medium — two isolated Code App shells, shared source packages, one MDA host, and environment configuration |
+
+## 1. Outcome
+
+Establish Power Apps Code Apps as the repository's primary build path for
+**bespoke full-page CRM user experiences**, then prove the foundation by
+refactoring the existing Advisor Cockpit implementation into two independently
+deployable host options:
+
+- **B1 — standalone Code App:** a full-screen Power Apps managed-host
+  experience with record-aware deep links to native model-driven CRM work.
+- **B2 — embedded Code App:** a separate Code App identity hosted in a
+  dedicated full-page sitemap web resource inside the model-driven Advisor App.
+
+Both options reuse one domain model and one parity UI implementation. They are
+tested independently in DEV and TEST so host-specific constraints are visible.
+The proof ends with an evidence-backed recommendation; it does not automatically
+select a winner or retire any component.
+
+## 2. Governing Build Rule
+
+Use the following order for CRM user experiences:
+
+1. **Model-driven configuration** for native forms, views, timelines, commands,
+   and standard record workflows.
+2. **Power Apps Code Apps** for bespoke full-page CRM experiences.
+3. **PCF controls** for embedded controls that require model-driven form,
+   dataset, or field context.
+
+An exception requires a documented reason and architecture review. A dedicated
+ADR must record this rule before implementation starts and clarify that
+ADR-0027 remains valid for PCF controls but no longer makes page-level PCF the
+default for bespoke full-page experiences. ADR-0033 remains the comparative
+record for selecting B1 or B2 after evidence exists.
+
+## 3. Approved Decisions
+
+| Area | Decision |
+| --- | --- |
+| Delivery approach | Parity-first dual-host experiment |
+| Source structure | npm workspace with shared domain/UI packages and thin host shells |
+| App identity | Separate B1 and B2 Code App identities and `power.config.json` files |
+| UI divergence | Establish strict parity first; allow documented controlled divergence later |
+| UX scope | Migrate the current cockpit experience in full; do not add new requirements in this sprint |
+| Data model | Freeze the current Dataverse schema |
+| Data access | Generated Dataverse models/services only; no raw Web API, flows, or custom APIs |
+| Data fallback | No fixture fallback in `pa app run`, DEV, or TEST |
+| Provenance | CRM normal; external/projected grey; unmapped yellow; accessible text legend always present |
+| Interaction policy | Honest mixed mode: supported operations work; unsupported operations remain visible but disabled with a reason |
+| Missing writes | Record every missing write contract in a write-capability matrix |
+| Local workflow | Sequential Vite polish, `pa app run`, then live DEV host validation |
+| B2 host | Dedicated full-page MDA sitemap web-resource iframe with `hideNavBar=true` |
+| Environment binding | Solution environment variables resolve environment-specific B1/B2 play URLs |
+| DEV publication | Attended maker/admin `pa app push` with evidence |
+| TEST promotion | Existing OIDC pipeline imports the exact managed DEV artifact |
+| Runtime persona | Least-privilege advisor; maker/admin is deployment-only |
+| Observability | Power Platform Monitor, `getContext()` session IDs, browser/network timings, and test evidence |
+| Azure | Entirely out of scope; the tenant has no Azure subscription and does not plan to obtain one |
+| B2E | Entirely out of implementation/test scope; no shell, launcher, simulation, or integration contract |
+| Comparison outcome | Evidence scorecard plus recommendation; human ADR approval selects a target |
+| PCF status | Local harness is the approved visual baseline; deployed PCF is not user-visible runtime evidence or a fallback |
+| Post-parity work | Carve out a broader host contract and add requirements only through a later design cycle |
+
+## 4. Current-State Facts
+
+- The Advisor Cockpit is a tested React 18 + Fluent UI v9 implementation with
+  typed fixtures, selectors, provenance tokens, and a Vite harness under
+  `solution/apps/sales/Controls/AdvisorCockpit/`.
+- The PCF wrapper currently renders fixture data; it does not complete the
+  planned live `context.webAPI` binding.
+- The PCF artifact is deployed in DEV but is not attached to a running,
+  user-visible surface. It cannot be cited as live UX evidence.
+- The reviewed visual baseline is the local fixture-backed PCF harness and its
+  captured screenshots.
+- The existing `DATA-BOM.md` already distinguishes CRM, external/projected,
+  agent-produced, runtime, and static values and lists unmapped fields and
+  incomplete writes.
+- The current cockpit contains five tabs, three lead views, filters, dialogs,
+  provenance, and visible actions. The parity sprint preserves that experience
+  rather than closing its pre-existing feature gaps.
+
+## 5. Scope
+
+### 5.1 In scope
+
+- Repository-level Code Apps workspace foundation.
+- Shared Advisor Cockpit domain and UI packages extracted from the reviewed
+  local harness implementation.
+- Separate B1 and B2 Code App projects initialized from the current Microsoft
+  `PowerAppsCodeApps` Vite template.
+- Separate generated Dataverse models and services for each app.
+- Fixture-backed local visual harness.
+- Generated-service live adapters for authenticated runtime.
+- Minimal typed host-capability boundary for parity only.
+- Standalone B1 player and record-aware native MDA links.
+- B2 full-page MDA sitemap web-resource host, CSP, and host navigation bridge.
+- Environment-variable URL binding for DEV and TEST.
+- Write-capability matrix covering every visible action.
+- Limitations register and B1/B2 comparison scorecard.
+- Automated CI checks and attended least-privilege DEV/TEST journeys.
+- Managed DEV-to-TEST promotion and rollback evidence.
+
+### 5.2 Out of scope
+
+- Any B2E Angular implementation, simulator, launcher, SSO contract, or test.
+- Dataverse tables, columns, choices, relationships, or action-layer extensions.
+- Azure resources or services, including Application Insights, Functions, Key
+  Vault, or Azure-hosted APIs.
+- New connectors beyond Dataverse.
+- Raw Dataverse Web API calls, FetchXML, custom APIs, or aggregation flows.
+- Silent fixture fallback in authenticated or deployed environments.
+- New cockpit requirements or host-optimized layouts before parity is proven.
+- Generalizing the minimal host boundary into a reusable application framework.
+- Selecting B1/B2, retiring PCF source, or claiming the PCF is a live fallback.
+- PROD deployment.
+
+## 6. Architecture
+
+### 6.1 Repository shape
+
+```text
+solution/apps/sales/
+  package.json                         # npm workspace root
+  packages/
+    advisor-cockpit-domain/            # types, selectors, provenance, capabilities
+    advisor-cockpit-ui/                # reviewed full cockpit UI
+  code-apps/
+    advisor-cockpit-b1/
+      power.config.json                # standalone app identity
+      src/generated/                   # B1-generated Dataverse code
+      src/host/                        # standalone context/navigation adapter
+    advisor-cockpit-b2/
+      power.config.json                # embedded app identity
+      src/generated/                   # B2-generated Dataverse code
+      src/host/                        # embedded context/navigation adapter
+  Controls/AdvisorCockpit/
+    harness/                           # retained local visual baseline
+    pcf/                               # retained deployed artifact, not runtime baseline
+```
+
+Generated code remains app-local because each Code App owns its Power Platform
+identity and data-source configuration. Shared packages do not import PCF,
+generated services, or Power Apps host APIs.
+
+### 6.2 Runtime topology
+
+```mermaid
+flowchart LR
+    FIX["Fixture adapter"] --> UI["Shared Advisor Cockpit UI"]
+    DOMAIN["Shared domain + provenance + capabilities"] --> UI
+
+    subgraph B1["B1 — standalone"]
+        B1HOST["Power Apps managed host"]
+        B1GEN["B1 generated Dataverse services"]
+        B1NAV["MDA deep-link adapter"]
+    end
+
+    subgraph B2["B2 — embedded"]
+        MDA["Model-driven Advisor App"]
+        FRAME["Full-page sitemap web resource"]
+        B2HOST["Power Apps managed host"]
+        B2GEN["B2 generated Dataverse services"]
+        B2NAV["Allowlisted host-message adapter"]
+    end
+
+    B1GEN --> UI
+    B1HOST --> B1GEN
+    UI --> B1NAV
+
+    MDA --> FRAME --> B2HOST --> B2GEN --> UI
+    UI --> B2NAV --> MDA
+```
+
+### 6.3 Minimal host-capability boundary
+
+The parity UI receives typed capabilities rather than importing host globals:
+
+- `runtimeContext`: user, environment, app, session, locale, and optional
+  query context.
+- `loadCockpitData`: returns the shared `CockpitData` result with explicit
+  loading, empty, denied, failed, and unmapped states.
+- `writeCapabilities`: identifies supported, partial, blocked, and unverified
+  commands with user-facing reasons.
+- `executeCommand`: accepts closed typed commands only.
+- `navigateToRecord`: opens an allowlisted table/record destination.
+- `layoutContext`: identifies standalone versus embedded viewport constraints.
+
+The boundary is intentionally small. Broader reuse is a later design problem.
+
+## 7. Data Flow and Provenance
+
+### 7.1 Runtime modes
+
+| Mode | Adapter | Data policy |
+| --- | --- | --- |
+| Local Vite polish | Typed synthetic fixtures | Visual and interaction refinement only |
+| `pa app run` | Generated Dataverse services | Live authenticated data; no fixture fallback |
+| DEV | Generated Dataverse services | Live least-privilege advisor data; no fixture fallback |
+| TEST | Generated Dataverse services | Managed promoted app; no fixture fallback |
+
+### 7.2 Generated-service policy
+
+Each app adds existing Dataverse tables with `pa app add data-source --connector
+dataverse --table <logical-name>`. Adapters use narrow `select`, `filter`,
+`orderBy`, `top`, and paging options and join records by primary GUID in the
+shared domain mapping layer.
+
+Do not introduce FetchXML, alternate-key access, polymorphic-lookup dependence,
+schema CRUD, raw Web API calls, custom APIs, or Power Automate aggregation flows
+to hide SDK limitations.
+
+### 7.3 Provenance contract
+
+Provenance represents authoritative origin, not only current storage location:
+
+| Presentation | Meaning |
+| --- | --- |
+| Normal background | CRM-native/mastered Dataverse value |
+| Grey | External-origin or analytical value, including a Dataverse materialized projection |
+| Yellow | UX field with no implemented source mapping |
+| Untinted | Static presentation copy or client runtime value |
+
+Mixed cards classify individual fields or regions. Every classification has an
+accessible name and a persistent localized legend; color is never the only cue.
+
+The UI must distinguish:
+
+- **Unmapped:** no implemented source mapping; yellow.
+- **Empty:** mapped source returned no value; neutral empty state.
+- **Permission denied:** advisor lacks access; explicit denied state.
+- **Load failure:** authenticated request failed; explicit error and retry.
+- **Unsupported query:** generated-service limitation; explicit limitation.
+
+Only genuinely unmapped content is yellow.
+
+## 8. Interaction and Write Safety
+
+### 8.1 Write-capability matrix
+
+Every visible command has a versioned matrix entry containing:
+
+| Field | Purpose |
+| --- | --- |
+| Action | UI command label and stable identifier |
+| Intended effect | Local, read, navigate, or write |
+| Target | Table, field, relationship, or destination |
+| B1 support | Supported, partial, blocked, or unverified |
+| B2 support | Supported, partial, blocked, or unverified |
+| Limitation | Missing field, lookup, permission, or SDK constraint |
+| Runtime treatment | Enabled, partially enabled, or disabled with reason |
+| Evidence | Test or live run proving the outcome |
+| Future remediation | Deferred requirement outside this sprint |
+
+### 8.2 Initial capability expectations
+
+| Action | Expected parity-sprint treatment |
+| --- | --- |
+| Tabs, filters, views, dialogs | Supported local UI behavior |
+| Open Account, Lead, Case, timeline | Enable after GUID mapping and host navigation are proven |
+| NBA `Accepted`, `Planned`, `Dismissed` | Existing schema supports status; enable only after generated-service update and reread pass |
+| Update existing NBA fields | Allowlist only fields already present and approved |
+| Call | `tel:` navigation may work; phone-call activity logging remains blocked by activity relationship complexity |
+| Snooze | Partial: map to `Planned`; no `snoozeUntil` field exists |
+| Dismiss with reason | Partial: persist `Dismissed`; no dismissal-reason field exists |
+| Edit proposal | Partial: existing fields only; timing/scope remain unsupported |
+| Assign lead | Blocked pending polymorphic owner-lookup support |
+| Bundle/split leads | Unverified until lookup association/disassociation works through generated services |
+| Create task/appointment | Blocked by polymorphic regarding relationships |
+| Save personal view | Blocked; no governed persistence contract exists |
+
+Unsupported actions remain visible but disabled with a concise explanation.
+They never simulate success.
+
+### 8.3 Command and navigation safety
+
+- Writes use closed typed commands and explicit human confirmation.
+- Free-text or model output never writes directly to Dataverse.
+- Success appears only after the generated service completes and a reread
+  confirms the result.
+- B1 opens allowlisted native MDA record links.
+- B2 posts a schema-validated navigation message to its web-resource parent.
+- The B2 parent validates the exact child origin, table allowlist, GUID shape,
+  and command type before invoking native navigation.
+- Unknown origins, destinations, or commands are rejected and logged without
+  customer data.
+- Accept/edit/dismiss remains a named human decision per ADR-0014.
+
+## 9. Local-First Polish Loop
+
+The proven PCF process becomes a sequential Code Apps parity loop.
+
+### Gate 1 — fixture-backed Vite polish
+
+1. Start `npm run dev` in a new VS Code integrated terminal.
+2. Open the local page inside VS Code and share it with Copilot.
+3. Compare it with captured screenshots of the approved local PCF harness.
+4. Refine via the Copilot chat window with the user reviewing each visual
+   choice.
+5. Record screenshots and parity findings at fixed desktop and mobile
+   viewports.
+6. Stop the server before moving to Gate 2.
+
+### Gate 2 — authenticated local host
+
+1. Start B1 with `pa app run` in a fresh integrated terminal.
+2. Open the Local Play URL inside VS Code using the tenant browser profile.
+3. Validate generated services, identity, permission states, and navigation.
+4. Stop B1, then repeat for B2.
+5. Never run a second Vite or Code Apps local server concurrently.
+
+Local Network Access permission may be required. For an embedded local probe,
+the iframe must declare only the documented local-network permission. A local
+pass is not deployed-host evidence.
+
+### Gate 3 — live DEV hosts
+
+1. Publish B1/B2 through the attended maker step.
+2. Validate B1 in the standalone Power Apps player.
+3. Validate B2 inside the actual MDA sitemap host.
+4. Only this gate proves B2 iframe, CSP, MDA viewport, nested loading, and host
+   navigation behavior.
+
+### Refinement ownership
+
+- Shared defects are fixed in `advisor-cockpit-ui` or the domain package.
+- Host defects are fixed only in the relevant shell/adapter.
+- Host-specific divergence is recorded before implementation.
+- Visual decisions remain attended; autopilot executes approved changes only.
+- Accessibility, component, and visual-regression checks rerun after each
+  accepted refinement batch.
+
+## 10. Limitations and Constraints
+
+| Constraint | Impact | Design response |
+| --- | --- | --- |
+| No FetchXML, alternate keys, polymorphic lookups, or schema CRUD in generated services | Some reads/writes cannot be implemented faithfully | Use GUIDs and supported queries; expose limitations |
+| Lookup ergonomics remain limited | Relationship actions may fail or require unsupported patterns | Prove each lookup operation before enabling it |
+| App sharing, Dataverse roles, and MDA access are separate | Admin testing can hide real access failures | Test all layers as a least-privilege advisor |
+| B2 framing is same-tenant only | No guest/cross-tenant embed proof | Keep cross-tenant access out of scope |
+| B2 requires environment-admin CSP changes | Misconfiguration blocks the entire frame | Allow exact Dynamics origin; capture propagation and rollback evidence |
+| Code App play URLs may differ by environment | Hard-coded DEV URL can leak into TEST | Resolve URLs through solution environment variables and convergence checks |
+| Hosted assets do not support IP restrictions | Sensitive bundle content would be public before authentication | Store no sensitive/user data in assets; rely on Entra, Conditional Access, DLP, and Dataverse |
+| Runtime environment-variable support is limited | Arbitrary app configuration cannot be assumed | Use supported host/solution configuration; fail visibly when absent |
+| Power Platform Git source integration is unsupported | Platform state is not the source repository | GitHub remains source of truth; reconcile reviewed assets and solution membership |
+| Noninteractive `pa app push` requires secret-based SP auth and prior sharing | Conflicts with repository OIDC/no-secret position | Attended DEV publication; OIDC pipeline promotion only |
+| `pa app run` needs tenant profile and local-network permission | Local setup can be mistaken for app failure | Add preflight and classify setup failures separately |
+| B2 cannot be proved locally | Vite/player pass misses iframe/CSP/MDA behavior | Require real DEV and TEST MDA-host evidence |
+| No Azure subscription | Azure observability/backend patterns are impossible | Use Power Platform capabilities only |
+| Dataverse schema freeze | Several UX fields/actions remain incomplete | Keep unmapped fields yellow and actions disabled/documented |
+| Two app identities can drift | Comparison validity degrades | Shared packages, parity tests, adapter contract tests, scorecard |
+| Fixture fallback could hide failures | Demo could appear healthy with broken integration | Prohibit fixture imports in authenticated/deployed bundles |
+| PCF is deployed but not user-visible | It cannot be a live comparator or fallback | Use its local harness screenshots only as visual baseline |
+| Licensing is persona-dependent | Technical success may not be deployable | Validate Power Apps Premium and Dynamics/Copilot rights before rollout |
+
+A blocker prevents an end-to-end pass claim. A limitation may remain only when
+it is visible in the UI where applicable, the capability/limitations registers,
+and the final scorecard.
+
+## 11. ALM and Environment Promotion
+
+### 11.1 Solution placement
+
+- B1 and B2 belong to `crmshow_Sales` as separate Code App components.
+- The B2 web-resource host and sitemap entry also belong to `crmshow_Sales`.
+- Environment-variable definitions belong to the solution; DEV/TEST values do
+  not enter source.
+- Each first publish targets the explicit solution GUID with `pa app push
+  --solution-id <guid>`.
+
+### 11.2 DEV authoring
+
+1. CI builds/tests the reviewed Git commit.
+2. A maker/admin runs attended `pa app push` for B1 and B2.
+3. Evidence records CLI version, commit SHA, app IDs, play URLs, solution IDs,
+   operator, timestamp, and result.
+4. The maker shares play access with the advisor persona.
+5. DEV environment-variable values are set for B1/B2 URLs.
+6. The B2 host and exact Dynamics-origin `frame-ancestors` CSP are configured.
+7. The existing OIDC workflow exports the complete solution as the only TEST
+   promotion artifact.
+
+This is a narrow, human-approved authoring exception to ADR-0017 because current
+Code Apps noninteractive publication requires secret-based service-principal
+authentication. The implementation ADR must record the exception. It never
+permits direct TEST authoring or a stored client secret.
+
+### 11.3 TEST promotion
+
+- Import the exact managed `crmshow_Sales` package exported from DEV.
+- Apply TEST environment-variable values through deployment configuration.
+- Apply the exact TEST Dynamics origin to CSP.
+- Share B1/B2 and assign required MDA/Dataverse roles to the advisor persona.
+- Prove no DEV URL, unmanaged component, or fixture mode remains.
+- Run the same authenticated B1/B2 journey used in DEV.
+
+### 11.4 Rollback
+
+Rollback reinstalls the previous managed solution version and restores the
+previous sitemap/environment configuration. The user-visible proof entries are
+removed or reverted. The deployed PCF artifact is not described as a runtime
+fallback because it is not attached to a user-visible experience.
+
+## 12. Testing and Evidence
+
+### 12.1 Automated CI
+
+- Domain selectors, mappings, provenance classification, and capability matrix.
+- Fixture and generated-service adapter contract tests.
+- React interaction tests across every tab and lead view.
+- Axe checks, keyboard journeys, focus handling, and 320px/400% reflow.
+- PCF, B1, and B2 builds from the workspace.
+- Visual regression against captured local-harness screenshots at fixed
+  fixtures/viewports.
+- Guard against fixture imports and DEV URLs in production bundles.
+- B2 origin, command allowlist, malformed message, and record-ID tests.
+- Bundle-size thresholds for both apps.
+- Localization smoke for EN/DE/FR/IT and locale-aware formatting.
+
+### 12.2 Authenticated DEV and TEST journey
+
+Use the same synthetic records, least-privilege advisor, browser profile, and
+journey in both environments:
+
+1. Open the complete cockpit.
+2. Verify identity, environment, session, and live Dataverse reads.
+3. Inspect normal, grey, and yellow provenance plus accessible labels.
+4. Exercise all tabs, filters, views, dialogs, responsive breakpoints, and
+   keyboard paths.
+5. Execute supported writes, reread the record, and verify audit behavior.
+6. Confirm every unsupported write is disabled and documented.
+7. Navigate to native Account, Lead, Case, and timeline surfaces.
+8. Capture session ID, timings, screenshots, Monitor evidence, and errors.
+9. Reset synthetic test state with the existing idempotent seed process.
+
+B2 additionally proves sitemap navigation, iframe loading, CSP, viewport,
+message validation, and return navigation to native MDA pages.
+
+### 12.3 Comparative scorecard
+
+Record evidence-backed `Pass`, `Concern`, `Blocker`, or `Not applicable` for:
+
+- Visual and functional parity.
+- Advisor workflow and navigation.
+- Responsive behavior and accessibility.
+- Load and interaction performance.
+- Identity, sharing, and least privilege.
+- CSP and embedding complexity.
+- ALM, configuration, and rollback.
+- Failure visibility and resilience.
+- Power Platform Monitor supportability.
+- Developer workflow and polish speed.
+- Maintenance and controlled divergence.
+- Licensing and platform constraints.
+
+Do not compute an automatic winner. The final report recommends B1 or B2, and a
+human-approved ADR update selects the target.
+
+## 13. Autopilot and Human Gates
+
+- Brainstorming, architecture, host-specific UX divergence, visual refinement,
+  and live publication are attended.
+- The user reviews one decision/option set at a time; no approval is inferred.
+- Visual work runs in a new VS Code integrated terminal and opens inside VS
+  Code for shared Copilot review.
+- Autopilot receives only approved implementation packets with fixed scope,
+  acceptance criteria, and deny-list controls.
+- A new design decision causes `BLOCKED: needs design` and returns to attended
+  control-plane review.
+- No agent selects B1/B2, changes the data model, adds Azure, or retires the PCF
+  artifact without explicit human approval and the required ADR review.
+
+## 14. Definition of Done
+
+The parity sprint is complete only when all of the following are true:
+
+- A dedicated ADR establishes Code Apps as primary for bespoke full-page CRM
+  experiences and records the attended DEV publication exception.
+- Shared domain/UI packages and separate B1/B2 shells build from reviewed
+  source.
+- The local fixture-backed PCF harness is captured as the approved visual
+  baseline; no live PCF claim is made.
+- B1/B2 reach documented visual and functional parity before divergence.
+- Provenance remains normal/grey/yellow with non-color accessible cues.
+- Every visible action appears in the write-capability matrix.
+- No Dataverse schema, Azure, B2E, raw Web API, custom API, aggregation flow,
+  silent fixture fallback, or new cockpit requirement is introduced.
+- B1 runs standalone with live data in DEV and TEST.
+- B2 runs in the MDA sitemap host with live data in DEV and TEST.
+- Least-privilege advisor journeys pass with linked screenshots, timings,
+  session IDs, Monitor evidence, writes/rereads, and limitations.
+- Managed DEV-to-TEST promotion and previous-version rollback are demonstrated.
+- The comparison scorecard produces a recommendation without selecting a
+  winner automatically.
+- The sprint `STATUS.md` contains the required live DEV and TEST evidence,
+  pipeline links, test counts, step results, and defects fixed.
+- A later host-contract/requirements increment is explicitly separate from
+  this parity sprint.
+
+## 15. Authoritative References
+
+- [Power Apps Code Apps documentation](https://learn.microsoft.com/power-apps/developer/code-apps/)
+- [Code Apps architecture](https://learn.microsoft.com/power-apps/developer/code-apps/architecture)
+- [Power Apps CLI reference](https://learn.microsoft.com/power-apps/developer/code-apps/reference/cli)
+- [Connect Code Apps to Dataverse](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/connect-to-dataverse)
+- [Code Apps ALM](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/alm)
+- [Embed a Code App in an iframe](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/embed-iframe)
+- [Get Code App context](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/retrieve-context)
+- [PCF Local-First Polish Loop](../patterns/pcf-local-first-polish-loop.md)
+- [PCF Review and UX Standardization](../patterns/pcf-review-and-ux-standardization.md)


### PR DESCRIPTION
## Summary
- extend ADR-0033 and the CRM UX placement pattern with standalone B1 and model-driven-hosted B2 Code App options
- validate both options through the Advisory Cockpit use case
- add the approved parity design specification and detailed Sprint 005 implementation plan
- anchor the local PCF harness as the visual baseline; no live PCF runtime claim

## Traceability
- Story: US-301
- Use case: UC-01 Advisor Cockpit
- ADR: ADR-0033
- Design: `docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md`
- Plan: `docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md`

## Scope guardrails
- no B2E implementation or simulation
- no Azure dependency
- no Dataverse schema extension
- B1/B2 remain unselected pending DEV and TEST evidence
- visual and architecture decisions remain human-reviewed

## Validation
- `git diff --check origin/main...HEAD`
- balanced Markdown fences across all four changed documents
- all workspace-local Markdown links resolve
- no placeholders in the approved design or plan
- VS Code diagnostics: clean