### PR TITLE
docs(sprint-005): create Code Apps parity control plane

### DIFF
--- a/docs/superpowers/sprints/README.md
+++ b/docs/superpowers/sprints/README.md
@@ -11,6 +11,7 @@ part of an active sprint (it is a standalone feature/blocker/idea in the backlog
 | sprint-001 | [sprint-001/](./sprint-001/) | #43 | #44 | Proof #1 — the delegated operating model | merged |
 | sprint-002 | [sprint-002-insurance-foundation-promotion/](./sprint-002-insurance-foundation-promotion/) | #46 | #47 · #48 · #49 | Proof #2 — Insurance Foundation DEV→TEST | merged |
 | sprint-003 | [sprint-003-advisor-cockpit/](./sprint-003-advisor-cockpit/) | #55 | #56–#65 (see charter) | Advisor Cockpit + Sales Leader Dashboard | in progress |
+| sprint-005 | [sprint-005/](./sprint-005/) | #139 | #140–#147 | Power Apps Code Apps Advisor Cockpit B1/B2 parity | control plane |
 
 ## Backlog issues not tied to a sprint
 

--- a/docs/superpowers/sprints/sprint-005/STATUS.md
+++ b/docs/superpowers/sprints/sprint-005/STATUS.md
@@ -1,0 +1,32 @@
+# Sprint 005 Status - Power Apps Code Apps Parity
+
+Live status for charter [#139](https://github.com/urruegg/CRMShowcase/issues/139).
+
+| Stream | Issue | Autonomy | Branch | PR | Status |
+| --- | --- | --- | --- | --- | --- |
+| governance | #140 | DESIGN-SENSITIVE | `feat/sprint-005-governance` | - | not started |
+| shared-foundation | #141 | DESIGN-SENSITIVE | `feat/sprint-005-shared-foundation` | - | blocked by governance |
+| b1-standalone | #142 | DESIGN-SENSITIVE | `feat/sprint-005-b1-standalone` | - | blocked by shared foundation |
+| b2-embedded | #143 | DESIGN-SENSITIVE | `feat/sprint-005-b2-embedded` | - | blocked by shared foundation |
+| quality-gates | #144 | EXECUTION-ONLY | `feat/sprint-005-quality-gates` | - | blocked by B1/B2 |
+| dev-proof | #145 | DESIGN-SENSITIVE | `feat/sprint-005-dev-proof` | - | blocked by implementation |
+| test-proof | #146 | DESIGN-SENSITIVE | `feat/sprint-005-test-proof` | - | blocked by DEV proof |
+| decision-evidence | #147 | DESIGN-SENSITIVE | `feat/sprint-005-decision-evidence` | - | blocked by DEV/TEST proof |
+
+## Baseline
+
+- Control-plane design and plan merged through PR #138 at `1015ab7`.
+- Orchestration baseline: 12 passed, 0 failed, 0 skipped.
+- Eight stream issues and isolated worktrees created on 2026-08-19.
+- Local PCF harness is the visual baseline; no live PCF runtime claim.
+
+## Live DEV + TEST evidence
+
+| Environment | Pipeline / session | Result | Tests / smoke | Notes |
+| --- | --- | --- | --- | --- |
+| DEV | pending | not run | pending | Requires attended maker publication after implementation gates. |
+| TEST | pending | not run | pending | Requires managed promotion of the exact DEV artifact. |
+
+## Decisions and Escalations
+
+- None. New design questions must return to the control-plane chat.

--- a/docs/superpowers/sprints/sprint-005/sprint.md
+++ b/docs/superpowers/sprints/sprint-005/sprint.md
@@ -1,0 +1,55 @@
+# Sprint 005 - Power Apps Code Apps Advisor Cockpit Parity
+
+| Field | Value |
+| --- | --- |
+| **Charter issue** | [#139](https://github.com/urruegg/CRMShowcase/issues/139) |
+| **Story / use case** | US-301 / UC-01 Advisor Cockpit |
+| **Design** | [Power Apps Code Apps Foundation and Advisor Cockpit B1/B2 Parity Proof](../../specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md) |
+| **Plan** | [Implementation plan](../../plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md) |
+| **Architecture record** | [ADR-0033](../../../adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md) plus planned ADR-0041 |
+| **Runtime target** | DEV and TEST; no PROD |
+
+## Outcome
+
+Establish Power Apps Code Apps as the primary repository path for bespoke
+full-page CRM experiences. Prove the complete Advisor Cockpit as two separate
+applications: standalone B1 and model-driven-hosted B2. Validate both with live
+Dataverse data in DEV and TEST, then produce an evidence-backed recommendation
+without automatically selecting a winner.
+
+## Streams
+
+| Stream | Issue | Autonomy | Goal | Dependency |
+| --- | --- | --- | --- | --- |
+| governance | [#140](https://github.com/urruegg/CRMShowcase/issues/140) | DESIGN-SENSITIVE | Record the build rule and attended ALM exception | approved design |
+| shared-foundation | [#141](https://github.com/urruegg/CRMShowcase/issues/141) | DESIGN-SENSITIVE | Extract shared packages and capture parity baseline | governance |
+| b1-standalone | [#142](https://github.com/urruegg/CRMShowcase/issues/142) | DESIGN-SENSITIVE | Build standalone Code App | shared-foundation |
+| b2-embedded | [#143](https://github.com/urruegg/CRMShowcase/issues/143) | DESIGN-SENSITIVE | Build embedded Code App and MDA host | shared-foundation |
+| quality-gates | [#144](https://github.com/urruegg/CRMShowcase/issues/144) | EXECUTION-ONLY | Add deterministic CI and release checks | B1 and B2 |
+| dev-proof | [#145](https://github.com/urruegg/CRMShowcase/issues/145) | DESIGN-SENSITIVE | Publish and validate both hosts in DEV | implementation and gates |
+| test-proof | [#146](https://github.com/urruegg/CRMShowcase/issues/146) | DESIGN-SENSITIVE | Promote, validate, and roll back in TEST | DEV proof |
+| decision-evidence | [#147](https://github.com/urruegg/CRMShowcase/issues/147) | DESIGN-SENSITIVE | Score B1/B2 and recommend a host | DEV and TEST proof |
+
+## Guardrails
+
+- No B2E implementation or simulation.
+- No Azure dependency or Dataverse schema extension.
+- No raw Dataverse Web API, custom API, flow, secret-based CI, literal DEV URL,
+  or deployed fixture fallback.
+- The local fixture-backed PCF harness is the visual baseline; the deployed PCF
+  is not a live comparator or fallback.
+- Architecture, visual refinement, host-specific divergence, and live
+  publication remain attended.
+- Any new design decision stops with `BLOCKED: needs design`.
+
+## Definition of Done
+
+- [ ] All streams merged to `main` through reviewed PRs.
+- [ ] Shared packages and separate B1/B2 identities build from source.
+- [ ] B1/B2 visual and functional parity is documented before divergence.
+- [ ] Provenance remains normal/grey/yellow with accessible non-color cues.
+- [ ] Every visible action is covered by the write-capability matrix.
+- [ ] B1/B2 run with live data under a least-privilege advisor in DEV and TEST.
+- [ ] Managed DEV-to-TEST promotion and previous-version rollback are proven.
+- [ ] The scorecard recommends without automatically selecting a winner.
+- [ ] DEV and TEST evidence satisfies the Sprint Operating Model requirements.

--- a/docs/superpowers/sprints/sprint-005/streams/b1-standalone.md
+++ b/docs/superpowers/sprints/sprint-005/streams/b1-standalone.md
@@ -1,0 +1,39 @@
+# Handover Packet - b1-standalone
+
+- **Sprint:** sprint-005
+- **Stream:** b1-standalone
+- **GitHub issue:** #142
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-b1-standalone
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-b1-standalone
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Build a distinct standalone B1 Code App identity.
+- Use generated Dataverse services only and no fixture fallback.
+- Prove record-aware native MDA navigation and supported write/reread behavior.
+
+## Allowed scope (paths)
+
+- `solution/apps/sales/code-apps/advisor-cockpit-b1/**`
+- `solution/apps/sales/package-lock.json`
+
+## Verification commands
+
+```powershell
+Push-Location solution/apps/sales
+npm test --workspace @crmshow/advisor-cockpit-b1
+npm run build --workspace @crmshow/advisor-cockpit-b1
+Pop-Location
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/b2-embedded.md
+++ b/docs/superpowers/sprints/sprint-005/streams/b2-embedded.md
@@ -1,0 +1,45 @@
+# Handover Packet - b2-embedded
+
+- **Sprint:** sprint-005
+- **Stream:** b2-embedded
+- **GitHub issue:** #143
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-b2-embedded
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-b2-embedded
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Build a distinct embedded B2 Code App identity.
+- Add the environment-bound full-page MDA sitemap host.
+- Enforce exact-origin, allowlisted, schema-validated host navigation.
+
+## Allowed scope (paths)
+
+- `solution/apps/sales/code-apps/advisor-cockpit-b2/**`
+- `solution/apps/sales/code-app-host/**`
+- `solution/schema/advisor-cockpit*.json`
+- `scripts/solution/*CodeApp*`
+- `scripts/solution/publish-advisor-cockpit-app.ps1`
+- `scripts/solution/tests/*CodeApp*`
+- `scripts/solution/tests/PublishAdvisorCockpitApp.Tests.ps1`
+
+## Verification commands
+
+```powershell
+Push-Location solution/apps/sales
+npm test --workspace @crmshow/advisor-cockpit-b2
+npm run build --workspace @crmshow/advisor-cockpit-b2
+Pop-Location
+Invoke-Pester -Path scripts/solution/tests/*CodeApp*.Tests.ps1 -Output Detailed
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/decision-evidence.md
+++ b/docs/superpowers/sprints/sprint-005/streams/decision-evidence.md
@@ -1,0 +1,39 @@
+# Handover Packet - decision-evidence
+
+- **Sprint:** sprint-005
+- **Stream:** decision-evidence
+- **GitHub issue:** #147
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-decision-evidence
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-decision-evidence
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Reconcile every visible action with live B1/B2 evidence.
+- Score both hosts without computing an automatic winner.
+- Recommend a host and close the sprint without selecting it autonomously.
+
+## Allowed scope (paths)
+
+- `docs/testing/US-301-code-app-host-parity.md`
+- `docs/adr/ADR-0033-crm-ux-placement-in-b2e-landscape.md`
+- `docs/superpowers/sprints/sprint-005/**`
+- `docs/superpowers/sprints/README.md`
+
+## Verification commands
+
+```powershell
+git diff --check
+# Verify all evidence links and required DEV/TEST result tables are present.
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/dev-proof.md
+++ b/docs/superpowers/sprints/sprint-005/streams/dev-proof.md
@@ -1,0 +1,40 @@
+# Handover Packet - dev-proof
+
+- **Sprint:** sprint-005
+- **Stream:** dev-proof
+- **GitHub issue:** #145
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-dev-proof
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-dev-proof
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Publish reviewed B1/B2 assets through an attended maker action.
+- Configure sharing, environment URLs, and exact DEV CSP without secrets.
+- Capture least-privilege advisor evidence for both hosts.
+
+## Allowed scope (paths)
+
+- `scripts/solution/Publish-CodeAppsDev.ps1`
+- `scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1`
+- `docs/runbooks/publish-code-apps-dev.md`
+- `.github/workflows/cd-solution-dev.yml`
+- `docs/superpowers/sprints/sprint-005/**`
+
+## Verification commands
+
+```powershell
+Invoke-Pester -Path scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 -Output Detailed
+# Then run the attended live DEV journey from the approved plan.
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/governance.md
+++ b/docs/superpowers/sprints/sprint-005/streams/governance.md
@@ -1,0 +1,39 @@
+# Handover Packet - governance
+
+- **Sprint:** sprint-005
+- **Stream:** governance
+- **GitHub issue:** #140
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-governance
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-governance
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- ADR-0041 records Code Apps as primary for bespoke full-page CRM UX.
+- The attended DEV publication exception is bounded and traceable.
+- The local-first Code App polish loop and path-scoped instructions are tested.
+
+## Allowed scope (paths)
+
+- `docs/**`
+- `.github/instructions/code-apps.instructions.md`
+- `.github/agents/ux-designer.agent.md`
+- `scripts/solution/tests/CodeAppsGovernance.Tests.ps1`
+
+## Verification commands
+
+```powershell
+Invoke-Pester -Path scripts/solution/tests/CodeAppsGovernance.Tests.ps1 -Output Detailed
+Invoke-Pester -Path scripts/solution/tests -Output Detailed
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/quality-gates.md
+++ b/docs/superpowers/sprints/sprint-005/streams/quality-gates.md
@@ -1,0 +1,46 @@
+# Handover Packet - quality-gates
+
+- **Sprint:** sprint-005
+- **Stream:** quality-gates
+- **GitHub issue:** #144
+- **Autonomy class:** EXECUTION-ONLY
+- **Branch:** feat/sprint-005-quality-gates
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-quality-gates
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Add deterministic workspace build, unit, accessibility, and visual gates.
+- Reject fixture fallback, literal environment URLs, and unsafe B2 messaging.
+- Preserve read-only GitHub permissions and existing OIDC deployment posture.
+
+## Allowed scope (paths)
+
+- `.github/workflows/ci-solution.yml`
+- `scripts/solution/Test-CodeAppsRelease.ps1`
+- `scripts/solution/tests/Test-CodeAppsRelease.Tests.ps1`
+- `solution/apps/sales/package*.json`
+- `solution/apps/sales/Controls/AdvisorCockpit/src/AdvisorCockpit.test.tsx`
+
+## Verification commands
+
+```powershell
+Push-Location solution/apps/sales
+npm ci
+npm test
+npm run build
+npm run test:visual
+npm run release:check
+Pop-Location
+Invoke-Pester -Path scripts/solution/tests/Test-CodeAppsRelease.Tests.ps1 -Output Detailed
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/shared-foundation.md
+++ b/docs/superpowers/sprints/sprint-005/streams/shared-foundation.md
@@ -1,0 +1,44 @@
+# Handover Packet - shared-foundation
+
+- **Sprint:** sprint-005
+- **Stream:** shared-foundation
+- **GitHub issue:** #141
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-shared-foundation
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-shared-foundation
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Extract shared domain/UI packages without behavior or pixel drift.
+- Add the minimal typed host and write-capability contract.
+- Capture approved desktop/mobile visual baselines from the local harness.
+
+## Allowed scope (paths)
+
+- `solution/apps/sales/package*.json`
+- `solution/apps/sales/tsconfig*`
+- `solution/apps/sales/packages/**`
+- `solution/apps/sales/Controls/AdvisorCockpit/**`
+- `solution/apps/sales/tests/visual/**`
+- `solution/apps/sales/playwright.config.ts`
+
+## Verification commands
+
+```powershell
+Push-Location solution/apps/sales
+npm test
+npm run build
+npm run test:visual
+Pop-Location
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.

--- a/docs/superpowers/sprints/sprint-005/streams/test-proof.md
+++ b/docs/superpowers/sprints/sprint-005/streams/test-proof.md
@@ -1,0 +1,41 @@
+# Handover Packet - test-proof
+
+- **Sprint:** sprint-005
+- **Stream:** test-proof
+- **GitHub issue:** #146
+- **Autonomy class:** DESIGN-SENSITIVE
+- **Branch:** feat/sprint-005-test-proof
+- **Worktree:** C:\Users\urruegg\source\urruegg\wt\sprint-005-test-proof
+- **Approved design ref:** ADR-0033; docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md; docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+
+## Goal / Definition of Done
+
+- Promote the exact managed Sales artifact from DEV to TEST.
+- Run the unchanged least-privilege B1/B2 journey in TEST.
+- Demonstrate previous-version rollback and candidate restoration.
+
+## Allowed scope (paths)
+
+- `scripts/solution/Get-CodeAppsPromotionFacts.ps1`
+- `scripts/solution/Get-PromotionSmokeResult.ps1`
+- `scripts/solution/tests/Get-CodeAppsPromotionFacts.Tests.ps1`
+- `scripts/solution/tests/Get-PromotionSmokeResult.Tests.ps1`
+- `.github/workflows/cd-solution-test.yml`
+- `docs/superpowers/sprints/sprint-005/**`
+
+## Verification commands
+
+```powershell
+Invoke-Pester -Path scripts/solution/tests/Get-CodeAppsPromotionFacts.Tests.ps1,scripts/solution/tests/Get-PromotionSmokeResult.Tests.ps1 -Output Detailed
+# Then run the managed TEST journey and rollback from the approved plan.
+```
+
+## Guardrails
+
+Inherit SUPERPOWERS_CONTRACT.md section 1. Headless streams additionally deny
+`shell(git push)`, `shell(rm)`, `shell(git reset)`.
+
+## Escalation rule
+
+If a new design decision is needed -> STOP, write `BLOCKED: needs design`,
+surface the question to the control-plane chat. Never self-approve.


### PR DESCRIPTION
## Summary

- create Sprint 005 charter/status documentation for issue #139
- add governed handover packets for streams #140-#147
- record autonomy classes, dependency gates, and allowed paths
- anchor required DEV and TEST evidence without starting implementation

## Traceability

- Story: US-301
- Use case: UC-01 Advisor Cockpit
- Design PR: #138
- Charter: #139
- Plan: `docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md`

## Validation

- all eight packets parse through `Read-HandoverPacket`
- orchestration Pester: 12 passed, 0 failed, 0 skipped
- Markdown diagnostics: clean
- `git diff --check`: clean

## Guardrails

- no implementation starts from this PR
- design-sensitive streams remain attended
- execution-only applies only to quality-gates after dependencies merge