### PR TITLE
docs(code-apps): establish governed full-page UX process

### DIFF
--- a/.github/agents/ux-designer.agent.md
+++ b/.github/agents/ux-designer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ux-designer
-description: Improves the Model-Driven App and Dynamics 365 (Sales, Service, Marketing) experience for the CRM Frontier Firm Showcase — out-of-the-box MDA configuration, React + Fluent UI v9 PCF code components, and Copilot Studio agent UX via adaptive cards.
+description: Improves the Model-Driven App and Dynamics 365 experience for the CRM Frontier Firm Showcase through native configuration, Power Apps Code Apps, embedded Fluent UI v9 PCF controls and Copilot Studio agent UX.
 tools: ['edit', 'create', 'view', 'grep', 'glob', 'fetch']
 ---
 
@@ -14,33 +14,47 @@ coherent, accessible, multilingual experience where **agents are visible teammat
 — improving the Model-Driven App (MDA) and Dynamics 365 **Sales / Service /
 Marketing** surfaces across the showcase's solution design.
 
-## The three ways you extend the experience (prefer in this order)
+## How you extend the experience
+
 1. **Out-of-the-box MDA / D365 configuration** — forms, views, quick-view /
    quick-create, command bar, app navigation, business-rule-driven UI, dashboards.
    Configuration first.
-2. **React + Fluent UI v9 PCF code components** — only when configuration cannot
-   express the interaction. Follow
+2. **Power Apps Code Apps** — the primary path for bespoke full-page CRM
+   experiences after native configuration is shown to be insufficient. Follow
+   [code-apps instructions](../instructions/code-apps.instructions.md) and the
+   **[Code App Local-First Polish Loop](../../docs/superpowers/patterns/code-app-local-first-polish-loop.md)**
+   ([ADR-0041](../../docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md)).
+   Run fixture Vite and `pa app run` sequentially in new Visual Studio Code
+   integrated terminals, open pages inside Visual Studio Code, and keep every
+   visual choice attended.
+3. **React + Fluent UI v9 PCF code components** — for embedded controls that
+   require form, dataset or field context. Follow
    [pcf-best-practices](../instructions/pcf-best-practices.instructions.md) and
    [pcf-alm](../instructions/pcf-alm.instructions.md); use Fluent v9 tokens and
    theming so the control matches the host MDA theme. Controls live under
-   `solution/**/Controls/**`. For pixel-faithful surfaces, build via the
+   `solution/**/Controls/**`. For pixel-faithful embedded controls, build via the
    **[PCF Local-First Polish Loop](../../docs/superpowers/patterns/pcf-local-first-polish-loop.md)**
    ([ADR-0027](../../docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md)).
-3. **Copilot Studio agent UX** — extend the runtime agents (`AG-F-##`) via
+4. **Copilot Studio agent UX** — extend the runtime agents (`AG-F-##`) via
    **adaptive cards** and rich, actionable interactions so a human accepts, edits
    or dismisses an agent proposal in-context.
 
 ## You may propose
 - MDA form / view / command-bar / app designs and the configuration that expresses them.
+- Power Apps Code App layouts, responsive states, provenance treatments and
+  attended visual refinements for bespoke full-page CRM work.
 - Fluent v9 PCF control designs (component, states, tokens) — an implementable spec
   or the control itself.
 - Adaptive-card / Copilot Studio interaction designs for agent hand-offs into the cockpit.
 - A `docs/UX.md` design-system note where a pattern is introduced or changed.
 
 ## You may not decide alone
-- **Going pro-code (PCF) when configuration or low-code would do** — justify the
+- **Going pro-code (Code Apps or PCF) when configuration or low-code would do** — justify the
   tier ([copilot-instructions §5](../copilot-instructions.md)); a Developer / EA
   review confirms it.
+- **Visual approval** — present one visual choice at a time and wait for explicit
+  user review; autopilot may execute an approved design but may not invent or
+  approve visual direction.
 - **Data-model or schema changes** — hand to Dataverse Modeler (`AG-E-08`) /
   Enterprise Architect (`AG-E-03`).
 - **Customer-visible AI-generated content** — hand to Responsible-AI Officer
@@ -49,8 +63,10 @@ Marketing** surfaces across the showcase's solution design.
 ## Guardrails you enforce
 - **Configuration → low-code → pro-code**, in that order — and say which you chose
   and why.
-- Every PCF component declares its **upgrade impact** in an ADR and carries a
-  **licensing flag** (pro-code) ([CONTRIBUTING.md](../../CONTRIBUTING.md)).
+- Every Code App and PCF component declares its **upgrade impact** in an ADR and
+  carries a **licensing flag** (pro-code)
+  ([CONTRIBUTING.md](../../CONTRIBUTING.md)). Code Apps require Power Apps
+  Premium and applicable Dynamics 365 / Copilot Studio persona validation.
 - **Accessibility (WCAG)** and **multilingual UI** — EN (`1033`) base plus DE
   (`1031`), FR (`1036`), IT (`1040`) via native Dataverse localization; never
   hard-code user-facing strings.

--- a/.github/agents/ux-designer.agent.md
+++ b/.github/agents/ux-designer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: ux-designer
 description: Improves the Model-Driven App and Dynamics 365 experience for the CRM Frontier Firm Showcase through native configuration, Power Apps Code Apps, embedded Fluent UI v9 PCF controls and Copilot Studio agent UX.
-tools: ['edit', 'create', 'view', 'grep', 'glob', 'fetch']
+tools: ['read', 'edit', 'search', 'web', 'execute']
 ---
 
 # Agent — UX Designer (`AG-E-11`)
@@ -24,9 +24,11 @@ Marketing** surfaces across the showcase's solution design.
    [code-apps instructions](../instructions/code-apps.instructions.md) and the
    **[Code App Local-First Polish Loop](../../docs/superpowers/patterns/code-app-local-first-polish-loop.md)**
    ([ADR-0041](../../docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md)).
-   Run fixture Vite and `pa app run` sequentially in new Visual Studio Code
-   integrated terminals, open pages inside Visual Studio Code, and keep every
-   visual choice attended.
+  Run fixture Vite and `pa app run` sequentially, starting each server in a new
+  Visual Studio Code integrated terminal. When interactive browser tools are
+  unavailable, ask the controlling VS Code chat to open and share the page
+  inside Visual Studio Code. Never claim to open a browser page directly
+  without a browser tool, and keep every visual choice attended.
 3. **React + Fluent UI v9 PCF code components** — for embedded controls that
    require form, dataset or field context. Follow
    [pcf-best-practices](../instructions/pcf-best-practices.instructions.md) and
@@ -68,8 +70,9 @@ Marketing** surfaces across the showcase's solution design.
   ([CONTRIBUTING.md](../../CONTRIBUTING.md)). Code Apps require Power Apps
   Premium and applicable Dynamics 365 / Copilot Studio persona validation.
 - **Accessibility (WCAG)** and **multilingual UI** — EN (`1033`) base plus DE
-  (`1031`), FR (`1036`), IT (`1040`) via native Dataverse localization; never
-  hard-code user-facing strings.
+  (`1031`), FR (`1036`), IT (`1040`). Dataverse/MDA metadata labels use native
+  localization. Code App-owned strings use versioned app-local catalogs and an
+  explicitly validated locale source; never hard-code user-facing strings.
 - Agent-surfaced content is **advisory** — a human accepts / edits / dismisses, and
   the provenance of agent contributions is visible
   ([ADR-0014](../../docs/adr/ADR-0014-agents-advisory-by-design.md)).

--- a/.github/instructions/code-apps.instructions.md
+++ b/.github/instructions/code-apps.instructions.md
@@ -1,0 +1,28 @@
+---
+description: Power Apps Code Apps architecture, local development, data access and ALM
+applyTo: 'solution/apps/**/{code-apps,packages}/**/*.{ts,tsx,js,json,html,css}'
+---
+
+# Power Apps Code Apps
+
+- Start from the official current `microsoft/PowerAppsCodeApps` Vite template.
+- Use `@microsoft/power-apps` and `@microsoft/power-apps-vite`; keep each app's
+  generated `power.config.json`, models and services app-local.
+- Use generated Dataverse services only. Do not add raw Dataverse Web API
+  calls, FetchXML, custom APIs or flow workarounds to conceal an unsupported
+  SDK operation.
+- Keep fixture adapters local-only. Authenticated and deployed apps have
+  no fixture fallback and must show denied, failed, empty and unmapped states.
+- Run one server at a time: fixture Vite first, stop it, then `pa app run`.
+- Start each server in a new Visual Studio Code integrated terminal. Open
+  visual refinement pages inside Visual Studio Code, share them with Copilot,
+  and keep visual choices attended.
+- Publish Code Apps into `crmshow_Sales` with attended `pa app push` to DEV
+  only. Promote the exact managed solution from DEV to TEST through the
+  existing OIDC pipeline; never author directly in TEST or store a client
+  secret.
+- Resolve environment-specific host and play URLs through managed
+  configuration. Never hard-code a DEV URL in source.
+- Preserve agents-recommend/humans-decide. Use closed typed commands,
+  schema-validated writes, explicit human confirmation and a post-write reread
+  before reporting success.

--- a/.github/instructions/code-apps.instructions.md
+++ b/.github/instructions/code-apps.instructions.md
@@ -17,10 +17,27 @@ applyTo: 'solution/apps/**/{code-apps,packages}/**/*.{ts,tsx,js,json,html,css}'
 - Start each server in a new Visual Studio Code integrated terminal. Open
   visual refinement pages inside Visual Studio Code, share them with Copilot,
   and keep visual choices attended.
-- Publish Code Apps into `crmshow_Sales` with attended `pa app push` to DEV
-  only. Promote the exact managed solution from DEV to TEST through the
-  existing OIDC pipeline; never author directly in TEST or store a client
-  secret.
+- Support EN/DE/FR/IT. Dataverse/MDA metadata labels use native localization.
+  Code App-owned strings use versioned app-local catalogs. Resolve locale
+  identically in B1 and B2 from `navigator.languages` in preference order and
+  canonicalize candidates with `Intl.getCanonicalLocales`. Map `de`, `fr`, and
+  `it` to their catalogs and fallback to `en`. `getContext()` does not expose a
+  locale; never hard-code user-facing strings or infer locale from it.
+- Publish to DEV only from a clean reviewed checkout at the reviewed commit.
+  Verify each app's `power.config.json` is bound to the approved DEV
+  environment ID. Build and test immediately before publication. Create a
+  sorted per-file SHA-256 manifest of `dist` using normalized relative paths,
+  serialize it as a BOM-free UTF-8 manifest, and hash the manifest. Leave
+  `dist` unchanged between hashing and push, then use attended
+  `pa app push --solution-id <crmshow_Sales GUID>`.
+- Capture the returned play URL, open the published app, and verify
+  `getContext().app.environmentId` equals the approved DEV environment ID.
+- Publication evidence records the commit, manifest hash, successful build and
+  test evidence, CLI version, app identity, solution identity, approved DEV
+  environment ID, returned play URL, runtime environment ID, operator,
+  timestamp and result. No client secret is introduced or stored.
+- TEST receives the exact managed artifact through the existing OIDC pipeline.
+  Direct TEST authoring is prohibited.
 - Resolve environment-specific host and play URLs through managed
   configuration. Never hard-code a DEV URL in source.
 - Preserve agents-recommend/humans-decide. Use closed typed commands,

--- a/docs/COPILOT-BUILD-GUIDE.md
+++ b/docs/COPILOT-BUILD-GUIDE.md
@@ -18,7 +18,7 @@ slides cannot win and a working pipeline wins easily.
 
 ## The loop
 
-```
+```text
 change request
   → AG-E-03 Enterprise Architect  → ADR: options · trade-offs · upgrade impact
   → AG-E-02 Developer             → solution change + test
@@ -29,6 +29,35 @@ change request
   → rollback                      → and it is gone again
 ```
 
+## Route CRM UX work before building
+
+Use the placement rule committed by
+[ADR-0041](./adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md):
+
+1. Model-driven configuration for native forms, views, timelines and commands.
+2. Power Apps Code Apps for bespoke full-page CRM experiences.
+3. PCF for embedded controls requiring form, dataset or field context.
+
+Code Apps are a pro-code own-build extension even though Power Apps supplies
+the managed host. Validate Power Apps Premium and applicable Dynamics 365 /
+Copilot Studio rights per persona before rollout.
+
+For bespoke full-page work, use the attended
+[Code App Local-First Polish Loop](./superpowers/patterns/code-app-local-first-polish-loop.md):
+fixture-backed `npm run dev`, stop the Vite server, authenticated `pa app run`,
+then live DEV and TEST evidence. Start each server in a new Visual Studio Code
+integrated terminal, open the page inside Visual Studio Code and keep visual
+choices attended.
+
+Git remains the source of truth. While noninteractive Code App publication
+requires secret-based service-principal authentication, a maker/admin may run
+attended `pa app push` in DEV only with reviewed build evidence. No client
+secret is stored. TEST receives only the exact managed solution exported from
+DEV through the existing OIDC pipeline; direct TEST authoring is prohibited.
+
+The Advisor Cockpit B1 and B2 hosts remain unselected until both produce the
+approved live DEV/TEST parity evidence and a human reviews the scorecard.
+
 ## Story shape
 
 Every story links to a use case in [PRD.md](./PRD.md) and one or more
@@ -36,7 +65,7 @@ principles in [DESIGN-PRINCIPLES.md](./DESIGN-PRINCIPLES.md).
 
 ## PR template (paste into every PR description)
 
-```
+```markdown
 ### What
 <one-line summary>
 
@@ -68,6 +97,8 @@ Add an ADR under [adr/](./adr/) when the change:
 - Changes the human/agent split in a workflow.
 - Changes the identity or network posture.
 - Changes the CI / IaC pipeline.
+- Introduces a bespoke full-page CRM surface or changes the Code App / PCF /
+   model-driven placement rule.
 
 ## When to refuse
 
@@ -97,9 +128,14 @@ Refuse and open a `governance-escalation` issue if the ask requires:
 
 Selection criteria: touches the golden thread · pure configuration or low-code
 · reversible · under 8 minutes of agent work · licensing flag is ✅ or 🧩.
-`[TBD — select and validate before the next review.]`
+The active candidate is named and validated in the approved sprint charter and
+handover packet before the demonstration. A substitute is not introduced live.
+
+Pro-code Code App or PCF changes use an attended engineering session rather
+than the under-eight-minute configuration/low-code demonstration path.
 
 ## Fallback
 
-`[TBD — record a clean run of the full flow and cue it. Test the playback on
-the room's hardware.]`
+Use the clean recorded run linked from the sprint evidence when a live service
+or environment is unavailable. Verify playback on the room hardware before the
+session and state clearly that the recording, not a live deployment, is shown.

--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -25,13 +25,35 @@ Always in this order. State which tier you chose and why.
 
 | Tier | Use when | Upgrade impact | Who can do it (A9) |
 | --- | --- | --- | --- |
-| **1 · Configuration** | Fields, forms, views, business rules, security roles, templates | **None** — carried by the platform | Business function, within governance |
-| **2 · Low-code** | Flows, Power Apps surfaces, Copilot Studio agents, declarative logic | **Low** — versioned, testable, reversible | IT / Power Platform team |
-| **3 · Pro-code** | Plugins, custom APIs, PCF controls, external services | **Declared per change** — requires ADR | IT / partner, with EA approval |
+| **1 · Configuration** | Fields, model-driven forms, views, timelines, commands, business rules, security roles, templates | **None** — carried by the platform | Business function, within governance |
+| **2 · Low-code** | Declarative canvas apps, flows, Copilot Studio agents and declarative logic | **Low** — versioned, testable, reversible | IT / Power Platform team |
+| **3 · Pro-code** | Power Apps Code Apps, plugins, custom APIs, PCF controls and external services | **Declared per change** — requires ADR | IT / partner, with EA approval |
 
 **The rule that makes this real:** an extension with no declared upgrade impact
 does not merge. It is enforced in the ADR template and in CI — not in a
 governance handbook nobody reads.
+
+## CRM UX build order
+
+[ADR-0041](./adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md)
+commits this placement rule:
+
+1. Use **model-driven configuration** for native forms, views, timelines and
+   commands.
+2. Use **Power Apps Code Apps** for bespoke full-page CRM experiences after the
+   native path is shown to be insufficient.
+3. Use **PCF** for embedded controls that require form, dataset or field
+   context.
+
+Code Apps use Power Apps managed hosting, but their TypeScript/React source is
+an own-build pro-code extension for governance and upgrade purposes. A
+declarative canvas app remains a low-code option when its interaction model is
+sufficient; it is not interchangeable with a Code App in the extension tier.
+Every Code App requires a declared upgrade impact and Power Apps Premium plus
+applicable Dynamics 365 / Copilot Studio persona-level licensing validation.
+
+The Advisor Cockpit B1/B2 parity proof validates host placement. It does not
+change this build order or select B1/B2 before live DEV and TEST evidence.
 
 ## GA individuality vs. standardisation
 
@@ -55,13 +77,27 @@ before. Answer with both halves:
 
 - **What is straightforward:** forms, views, dashboards, command bar,
   role-based surfaces, branded model-driven experiences.
-- **Where the boundaries are:** `[TBD — enumerate honestly. An unqualified
-  "fully customisable" will not survive contact with the customer's architects.]`
+- **Where Code Apps fit:** bespoke full-page CRM work that needs a controlled
+  responsive React experience, app-local generated Dataverse services and
+  managed Power Apps hosting. Native forms and timelines remain model-driven
+  deep work rather than being rebuilt inside the Code App.
+- **Where PCF fits:** embedded controls whose behavior depends on model-driven
+  form, dataset or field context.
+- **Where the boundaries are:** generated-service limitations stay visible;
+  authenticated and deployed apps have no fixture fallback; app sharing,
+  Dataverse roles and model-driven access are validated separately; DEV
+  publication is attended; TEST is managed-pipeline only; environment URLs are
+  configuration rather than source constants.
+
+For full-page work, follow the
+[Code App Local-First Polish Loop](./superpowers/patterns/code-app-local-first-polish-loop.md).
+For embedded PCF work, follow the retained
+[PCF Local-First Polish Loop](./superpowers/patterns/pcf-local-first-polish-loop.md).
 
 ## The live demonstration
 
 See [COPILOT-BUILD-GUIDE.md](./COPILOT-BUILD-GUIDE.md). Question → ADR →
 solution change + test → PR → pipeline → sandbox → **rollback**.
 
-The closing line: *"That was not custom development. That was a pull request —
-documented, tested, reversible."*
+The closing line: *"That was not an unmanaged customization. It was reviewed
+source, tested evidence and a reversible managed release."*

--- a/docs/adr/ADR-0017-alm-everything-through-the-pipeline.md
+++ b/docs/adr/ADR-0017-alm-everything-through-the-pipeline.md
@@ -20,12 +20,36 @@ components are source-controlled under `solution/`; every change is traceable
 to a PR, an ADR and a test run; rollback is a pipeline action, not a manual
 repair.
 
+### Bounded attended DEV Code App exception
+
+[ADR-0041](./ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md)
+establishes one narrow authoring exception while the current noninteractive
+Code Apps CLI publication path requires secret-based service-principal
+authentication:
+
+- A maker/admin may run attended `pa app push` in **DEV only** for a reviewed
+  Code App commit.
+- Git remains the source of truth. The evidence records the commit, successful
+  build and tests, CLI version, app identity, solution identity, operator,
+  timestamp and result.
+- No client secret is introduced or stored in source, automation, fixtures,
+  configuration or logs.
+- There is no direct TEST authoring. The existing OIDC pipeline exports the
+  complete DEV solution and imports that exact managed artifact into TEST.
+- Existing solution validation, approval, export/import, convergence and
+  rollback controls remain unchanged.
+
+This exception permits an attended DEV publication mechanism; it does not
+permit an unreviewed environment-only change.
+
 ## Consequences
 
-- **Manual environment changes become invisible and therefore forbidden.** This
-  is the single biggest driver of long-term controllability, and it is the honest
-  answer to *"how does this stay manageable after several release cycles?"*
+- **Manual environment changes remain forbidden outside the bounded attended
+  DEV Code App publication above.** The reviewed source and publication
+  evidence make that exception visible and reconcilable.
 - **Rollback must be demonstrable, not described.** If we cannot roll a live
   change back in front of the customer, we should not make the claim.
+- **TEST remains pipeline-only.** Direct authoring, unmanaged substitution and
+  a stored service-principal secret are not accepted shortcuts.
 - Requires discipline from the customer and the implementation partner, not just
   from us — which is precisely the shared-responsibility conversation.

--- a/docs/adr/ADR-0017-alm-everything-through-the-pipeline.md
+++ b/docs/adr/ADR-0017-alm-everything-through-the-pipeline.md
@@ -27,15 +27,25 @@ establishes one narrow authoring exception while the current noninteractive
 Code Apps CLI publication path requires secret-based service-principal
 authentication:
 
-- A maker/admin may run attended `pa app push` in **DEV only** for a reviewed
-  Code App commit.
-- Git remains the source of truth. The evidence records the commit, successful
-  build and tests, CLI version, app identity, solution identity, operator,
-  timestamp and result.
+- A maker/admin may publish a reviewed Code App commit to **DEV only**. The
+  maker/admin starts from a clean reviewed checkout at the reviewed commit,
+  verifies each app's `power.config.json` is bound to the approved DEV
+  environment ID, and builds and tests immediately before publication. The
+  maker/admin creates a sorted per-file SHA-256 manifest of `dist` using
+  normalized relative paths, serializes it as a BOM-free UTF-8 manifest, and
+  hashes the manifest. Leave `dist` unchanged between hashing and push, then
+  run attended
+  `pa app push --solution-id <crmshow_Sales GUID>`.
+- Git remains the source of truth. Publication evidence records the commit,
+  manifest hash, successful build and test evidence, CLI version, app identity,
+  solution identity, approved DEV environment ID, returned play URL, runtime
+  environment ID, operator, timestamp and result. After publication, the
+  operator opens the app and verifies `getContext().app.environmentId` equals
+  the approved DEV environment ID.
 - No client secret is introduced or stored in source, automation, fixtures,
   configuration or logs.
-- There is no direct TEST authoring. The existing OIDC pipeline exports the
-  complete DEV solution and imports that exact managed artifact into TEST.
+- TEST receives the exact managed artifact through the existing OIDC pipeline.
+  Direct TEST authoring is prohibited.
 - Existing solution validation, approval, export/import, convergence and
   rollback controls remain unchanged.
 
@@ -45,8 +55,8 @@ permit an unreviewed environment-only change.
 ## Consequences
 
 - **Manual environment changes remain forbidden outside the bounded attended
-  DEV Code App publication above.** The reviewed source and publication
-  evidence make that exception visible and reconcilable.
+  DEV Code App publication above.** Only that deterministic, evidenced
+  procedure may publish a Code App directly, and only to DEV.
 - **Rollback must be demonstrable, not described.** If we cannot roll a live
   change back in front of the customer, we should not make the claim.
 - **TEST remains pipeline-only.** Direct authoring, unmanaged substitution and

--- a/docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md
+++ b/docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | --- | --- |
-| **Status** | Accepted |
+| **Status** | Superseded by ADR-0041 for bespoke full-page experiences; retained for embedded PCF controls and its local polish method |
 | **Date** | 2026-08-11 |
 | **Decision mode** | Committed decision |
 | **Confidence** | High — grounded in the pcf-best-practices / pcf-alm instructions and the pixel-fidelity requirement |
@@ -16,6 +16,11 @@
 | **Zero Trust** | Controls read Dataverse under the user's context and security roles. |
 | **Responsible AI** | Transparency — AI-authored content (NBA cards) renders a visible provenance badge + "AI-assisted" disclosure. |
 
+> **Scope after ADR-0041.** The page-level PCF default is superseded only for
+> bespoke full-page CRM experiences. PCF remains the selected extension path
+> for embedded controls requiring form, dataset or field context, and the PCF
+> Local-First Polish Loop remains active for those controls.
+
 ## Context
 
 The Advisor Cockpit must reproduce two dense, full-bleed HTML cockpits **as
@@ -26,27 +31,34 @@ the build method as a reusable pattern.
 
 ## Options
 
-### Option A — One page-level PCF per surface ✅ preferred
+### Option A — One page-level PCF per surface (historical selection)
+
 Each surface is a single React + Fluent UI v9 control rendering the whole page.
 **Why:** full control of every pixel, 1:1 with the mockup, one focused build per
 surface, clean local harness. The mockup already uses the Fluent palette, so
 tokens port directly.
 
 ### Option B — Many small PCF tiles on an MDA custom page
+
 Each region is its own PCF, arranged on the page. **Why not:** MDA page/section
 layout fights pixel-perfect spacing; the dense header/KPI band is hard to match;
 more controls to wire.
 
 ### Option C — Hybrid
+
 Page-level PCF for the hero, native + small tiles elsewhere. **Why not:** mixes
 two layout models on one page; harder to keep visually consistent for a
 pixel-perfect target.
 
 ## Decision or working hypothesis
 
-Use **Option A — one page-level PCF per surface** (`AdvisorCockpit`,
-`SalesLeaderDashboard`), and adopt the **PCF Local-First Polish Loop** as the
-build method for pixel-faithful PCF in this repo:
+The original decision used **Option A — one page-level PCF per surface** for
+`AdvisorCockpit` and `SalesLeaderDashboard`. ADR-0041 supersedes that default
+for bespoke full-page CRM UX. It does not retire the controls, their fixture
+harnesses or this polish method.
+
+For embedded PCF controls that require model-driven form, dataset or field
+context, continue to use the **PCF Local-First Polish Loop**:
 
 1. Derive TypeScript types + mock fixtures from the data model.
 2. Build the component in a **Vite** harness with fixtures (hot reload, full
@@ -73,16 +85,19 @@ and referenced by the `ux-designer` agent.
 
 Reopen if a surface needs to be recomposed from independently-reusable tiles, or
 if MDA native config can meet the fidelity bar for a future, simpler surface
-(config → low-code → pro-code still applies).
+(config → low-code → pro-code still applies). Route a new bespoke full-page
+surface through ADR-0041 and the Code App parity evidence instead of treating
+this ADR as authority for a new page-level PCF.
 
 ## Consequences
 
-- **At the next release:** two PCF controls + the pattern doc ship; the loop is
-  reusable for every future pixel-faithful surface.
+- **At the next release:** retained PCF controls and their pattern stay
+  source-controlled and tested; new bespoke full-page work follows ADR-0041.
 - **Operationally:** controls are Jest-tested and versioned; upgrade impact is
   declared per control.
 - **For the customer's teams:** a repeatable, reviewable UX build method rather
-  than ad-hoc pixel-pushing.
+  than ad-hoc pixel-pushing, without presenting embedded PCF as the default
+  full-page host.
 - **Reversibility:** medium — a control can be re-split into tiles later, but the
   component code is reusable either way.
 

--- a/docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md
+++ b/docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md
@@ -93,7 +93,7 @@ this ADR as authority for a new page-level PCF.
 
 - **At the next release:** retained PCF controls and their pattern stay
   source-controlled and tested; new bespoke full-page work follows ADR-0041.
-- **Operationally:** controls are Jest-tested and versioned; upgrade impact is
+- **Operationally:** controls are Vitest-tested and versioned; upgrade impact is
   declared per control.
 - **For the customer's teams:** a repeatable, reviewable UX build method rather
   than ad-hoc pixel-pushing, without presenting embedded PCF as the default

--- a/docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md
+++ b/docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md
@@ -63,11 +63,25 @@ PCF remains the extension path for embedded controls requiring form, dataset or
 field context. The Advisor Cockpit B1/B2 proof validates host placement without
 changing that build rule.
 
-DEV Code App creation and update use an attended maker `pa app push` because
-the current noninteractive CLI requires secret-based service-principal
-authentication. Git remains source of truth; TEST receives only the exact
-managed solution artifact exported from DEV by the existing OIDC pipeline. No
-client secret is introduced, and direct TEST authoring is prohibited.
+DEV Code App creation and update use one deterministic attended publication
+contract because the current noninteractive CLI requires secret-based
+service-principal authentication.
+A maker/admin starts from a clean reviewed checkout at the reviewed commit,
+verifies each app's `power.config.json` is bound to the approved DEV environment
+ID, and builds and tests immediately before publication. The maker/admin creates
+a sorted per-file SHA-256 manifest of `dist` using normalized relative paths,
+serializes it as a BOM-free UTF-8 manifest, and hashes the manifest. Leave
+`dist` unchanged between hashing and push, then run attended
+`pa app push --solution-id <crmshow_Sales GUID>` to DEV only. The
+operator captures the returned play URL, opens the published app, and verifies
+`getContext().app.environmentId` equals the approved DEV environment ID.
+Publication evidence records the commit, manifest hash, successful build and
+test evidence, CLI version, app identity, solution identity, approved DEV
+environment ID, returned play URL, runtime environment ID, operator, timestamp
+and result. No client secret is introduced or stored.
+
+Git remains source of truth. TEST receives the exact managed artifact through
+the existing OIDC pipeline. Direct TEST authoring is prohibited.
 
 ADR-0033 options B1 and B2 remain unselected until the same complete Advisor
 Cockpit has produced reviewable DEV and TEST parity evidence. This ADR chooses
@@ -124,9 +138,12 @@ bespoke full-page requirement without pro-code.
 - **At the next release:** Code Apps, shared packages, generated services and
   solution membership are rebuilt and retested; embedded PCF controls continue
   under their existing ALM instructions.
-- **Operationally:** attended `pa app push` is allowed only in DEV with commit,
-  CLI, app, solution, operator and result evidence. TEST changes arrive only as
-  the exact managed solution through the existing OIDC pipeline.
+- **Operationally:** attended publication is DEV-only and follows the
+  deterministic contract above. The recorded commit, sorted per-file manifest,
+  manifest hash, returned play URL and runtime environment ID bind the
+  publication to the reviewed build and DEV target; TEST changes arrive only
+  as the exact managed solution through the existing OIDC pipeline, never
+  through direct TEST authoring.
 - **For the customer's teams (shared responsibility):** makers publish to DEV,
   the pipeline promotes to TEST, administrators assign least-privilege access,
   and owners validate Power Apps Premium plus applicable product rights per

--- a/docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md
+++ b/docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md
@@ -1,0 +1,152 @@
+# ADR-0041 - Code Apps primary for bespoke full-page CRM UX
+
+| Field | Value |
+| --- | --- |
+| **Status** | Accepted |
+| **Date** | 2026-08-19 |
+| **Decision mode** | Committed decision |
+| **Confidence** | Medium - the build rule and platform boundaries are approved; Advisor Cockpit DEV and TEST parity evidence is still required before B1 or B2 can be selected |
+| **Deciders** | Repo owner - Enterprise Architect (`AG-E-03`) - Developer (`AG-E-02`) - SecDevOps (`AG-E-04`) - UX Designer (`AG-E-11`) |
+| **Topic area** | A4 - Configuration, extensibility and upgrade safety - A8 - ALM and operations |
+| **Use case** | UC-01 - Advisor Cockpit - US-301 |
+| **Licence** | 🧩 configuration / own build - validate Power Apps Premium and applicable Dynamics 365 / Copilot Studio use rights for each persona before rollout |
+| **Upgrade impact** | Medium - Code App shells, generated services, shared packages, solution membership and host configuration remain source-controlled and must be retested at platform or dependency upgrades |
+| **CAF methodology** | Adopt - Govern: establish a supported implementation path and a reviewable source-to-environment control |
+| **WAF pillar(s)** | Primary: Operational Excellence - Security and Reliability. Trade-off: pro-code maintenance and persona licensing validation increase delivery effort |
+| **Zero Trust** | Verify the environment, app identity and signed-in persona explicitly; use least-privilege Dataverse access; assume breach by storing no client secret and promoting only the reviewed artifact |
+| **Responsible AI** | Fairness, reliability and safety, privacy and security, inclusiveness, transparency and accountability remain enforced through parity evidence, explicit failure states, least privilege, accessibility, provenance and human approval |
+
+## Context
+
+The repository needs one unambiguous placement rule for CRM user experiences.
+[ADR-0027](./ADR-0027-page-level-pcf-and-local-first-polish-loop.md) made a
+page-level PCF the default for bespoke full-page surfaces before Power Apps
+Code Apps became the approved foundation. The
+[Advisor Cockpit parity design](../superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md)
+now requires a bounded rule that preserves native model-driven strengths,
+uses Code Apps where full-page control is justified, and retains PCF for
+embedded host context.
+
+The same design identifies an ALM constraint: the current noninteractive Code
+Apps CLI publication path requires secret-based service-principal
+authentication. That conflicts with the repository's OIDC and no-stored-secret
+position. The exception must therefore be attended, DEV-only and unable to
+bypass the managed TEST promotion path.
+
+## Options
+
+### Option A - Keep page-level PCF as the default
+
+Continue using one page-level PCF control for each bespoke full-page CRM
+surface. **Not selected:** PCF remains appropriate when the component requires
+form, dataset or field context, but making it the full-page default couples a
+standalone experience to an embedded-control contract.
+
+### Option B - Use Code Apps for every CRM surface
+
+Replace native forms, views, timelines, commands and embedded controls with
+Code Apps. **Not selected:** this would rebuild supported model-driven behavior
+and ignore the repository's configuration-first principle.
+
+### Option C - Use a bounded placement rule (selected)
+
+Use model-driven configuration for native CRM work, Code Apps for bespoke
+full-page experiences, and PCF for embedded host-context controls. **Selected
+as a committed decision:** each technology owns the surface that matches its
+runtime contract, while exceptions require architecture review.
+
+## Decision or working hypothesis
+
+Code Apps are primary for bespoke full-page CRM experiences. Model-driven
+configuration remains primary for native forms, views, timelines and commands;
+PCF remains the extension path for embedded controls requiring form, dataset or
+field context. The Advisor Cockpit B1/B2 proof validates host placement without
+changing that build rule.
+
+DEV Code App creation and update use an attended maker `pa app push` because
+the current noninteractive CLI requires secret-based service-principal
+authentication. Git remains source of truth; TEST receives only the exact
+managed solution artifact exported from DEV by the existing OIDC pipeline. No
+client secret is introduced, and direct TEST authoring is prohibited.
+
+ADR-0033 options B1 and B2 remain unselected until the same complete Advisor
+Cockpit has produced reviewable DEV and TEST parity evidence. This ADR chooses
+the build path, not the final host placement.
+
+## Evidence and assumptions
+
+- **Known:** the approved Sprint 005 design fixes the build order, app-local
+  generated Dataverse services, sequential local workflow, attended DEV
+  publication and managed DEV-to-TEST promotion.
+- **Known:** the existing Advisor Cockpit fixture harness is the reviewed visual
+  baseline; the deployed PCF is not a user-visible runtime fallback.
+- **Inferred:** the bounded rule will reduce custom host coupling without
+  sacrificing native model-driven workflows.
+- **Evidence still required:** complete B1 and B2 runs in DEV and TEST using the
+  same synthetic scenario, least-privilege advisor, accessibility checks,
+  provenance checks, writes and rereads, navigation checks, timings and
+  promotion evidence.
+
+## Framework and assurance alignment
+
+- **CAF Adopt and Govern:** implementation uses a supported Power Platform
+  surface and a source-controlled, reviewed promotion path.
+- **WAF Operational Excellence, Security and Reliability:** one build rule,
+  explicit runtime failure states, exact managed-artifact promotion and
+  rollback evidence make changes supportable. The trade-off is the maintenance
+  cost of pro-code packages and two proof hosts.
+- **Zero Trust:** runtime access uses the signed-in advisor's Dataverse rights;
+  maker/admin rights are deployment-only; no stored client secret or hard-coded
+  DEV URL crosses the environment boundary.
+- **Responsible AI:** the Advisor Cockpit keeps recommendations advisory;
+  schema-validated writes and rereads protect reliability and safety; least
+  privilege protects privacy and security; accessibility and locale checks
+  protect inclusiveness; provenance and AI-assisted disclosure protect
+  transparency; accept, edit and dismiss remain accountable human decisions.
+  The shared scenario and parity scorecard expose host-specific differences for
+  fairness review rather than hiding them behind fixture fallback.
+
+## Validation and review triggers
+
+Keep B1 and B2 unselected until the Sprint 005 evidence scorecard contains the
+required live DEV and TEST runs for the complete Advisor Cockpit. The repo owner
+and Enterprise Architect review that evidence with Developer, SecDevOps and UX
+input; no automated score selects a winner.
+
+Reopen this ADR if Microsoft provides a noninteractive Code App publication
+path compatible with the repository's OIDC/no-secret posture, if generated
+services cannot support the approved cockpit contract, if persona licensing
+validation fails, or if native model-driven configuration can satisfy a future
+bespoke full-page requirement without pro-code.
+
+## Consequences
+
+- **At the next release:** Code Apps, shared packages, generated services and
+  solution membership are rebuilt and retested; embedded PCF controls continue
+  under their existing ALM instructions.
+- **Operationally:** attended `pa app push` is allowed only in DEV with commit,
+  CLI, app, solution, operator and result evidence. TEST changes arrive only as
+  the exact managed solution through the existing OIDC pipeline.
+- **For the customer's teams (shared responsibility):** makers publish to DEV,
+  the pipeline promotes to TEST, administrators assign least-privilege access,
+  and owners validate Power Apps Premium plus applicable product rights per
+  persona.
+- **Reversibility:** high for the build rule because native configuration and
+  embedded PCF remain available; host selection stays reversible until B1/B2
+  parity evidence is approved.
+
+## Competitive note
+
+The decision requires comparable CRM proposals to distinguish native
+configuration, managed full-page pro-code experiences and embedded controls,
+then demonstrate the upgrade and promotion cost of each rather than describing
+all UI customization as one undifferentiated capability.
+
+## Authoritative references
+
+- [Power Apps Code Apps documentation](https://learn.microsoft.com/power-apps/developer/code-apps/)
+- [Power Apps Code Apps ALM](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/alm)
+- [Connect Code Apps to Dataverse](https://learn.microsoft.com/power-apps/developer/code-apps/how-to/connect-to-dataverse)
+- [ADR-0014 - agents advisory by design](./ADR-0014-agents-advisory-by-design.md)
+- [ADR-0017 - ALM through the pipeline](./ADR-0017-alm-everything-through-the-pipeline.md)
+- [ADR-0033 - CRM UX placement](./ADR-0033-crm-ux-placement-in-b2e-landscape.md)

--- a/docs/superpowers/patterns/code-app-local-first-polish-loop.md
+++ b/docs/superpowers/patterns/code-app-local-first-polish-loop.md
@@ -71,18 +71,26 @@ embedding, environment sharing, CSP, managed promotion or TEST parity.
 
 ### Gate 3 - live DEV and TEST evidence
 
-1. Build and test the reviewed Git commit.
-2. A maker/admin performs attended `pa app push` to DEV only and records the
-   commit, CLI version, app identity, solution identity, operator, timestamp
-   and result. Do not introduce or store a client secret.
-3. Validate the live DEV host with the least-privilege advisor and synthetic
-   scenario.
-4. Export the complete solution from DEV through the existing OIDC pipeline
-   and import that exact managed artifact into TEST. Do not author directly in
-   TEST.
-5. Apply environment-specific configuration without hard-coding a DEV play URL
+1. Start from a clean reviewed checkout at the reviewed Git commit and verify
+   each app's `power.config.json` is bound to the approved DEV environment ID.
+   Build and test immediately before publication.
+2. Create a sorted per-file SHA-256 manifest of `dist` using normalized relative
+   paths, serialize it as a BOM-free UTF-8 manifest, and hash the manifest.
+   Leave `dist` unchanged between hashing and push.
+3. A maker/admin performs attended
+   `pa app push --solution-id <crmshow_Sales GUID>` to DEV only. Publication
+   evidence records the commit, manifest hash, successful build and test
+   evidence, CLI version, app identity, solution identity, approved DEV
+   environment ID, returned play URL, runtime environment ID, operator,
+   timestamp and result. No client secret is introduced or stored.
+4. Validate the live DEV host with the least-privilege advisor and synthetic
+   scenario, including `getContext().app.environmentId` against the approved DEV
+   environment ID.
+5. TEST receives the exact managed artifact through the existing OIDC pipeline.
+   Direct TEST authoring is prohibited.
+6. Apply environment-specific configuration without hard-coding a DEV play URL
    in source.
-6. Repeat the same advisor journey in TEST and compare the evidence with DEV.
+7. Repeat the same advisor journey in TEST and compare the evidence with DEV.
 
 Only live DEV and TEST evidence can support a host-placement decision. B1 and
 B2 remain unselected until both have completed the approved parity scorecard.

--- a/docs/superpowers/patterns/code-app-local-first-polish-loop.md
+++ b/docs/superpowers/patterns/code-app-local-first-polish-loop.md
@@ -1,0 +1,148 @@
+# Pattern - Code App Local-First Polish Loop
+
+> Anchored by
+> [ADR-0041](../../adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md)
+> and the approved
+> [US-301 Advisor Cockpit parity design](../specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md).
+
+A sequential, attended method for refining a bespoke full-page Power Apps Code
+App against synthetic fixtures, validating its authenticated local host, and
+then proving the same reviewed source with live data in DEV and TEST.
+
+## When to use
+
+Use this pattern for a bespoke full-page CRM experience after model-driven
+forms, views, timelines and commands have been ruled insufficient. Use PCF
+instead when a control needs form, dataset or field context. Record any
+exception to this placement rule through architecture review.
+
+This pattern does not build or simulate B2E, add Azure services, replace native
+CRM work, or permit a deployed fixture fallback.
+
+## Preconditions
+
+- Initialize each app from the official current `microsoft/PowerAppsCodeApps`
+  Vite template and use `@microsoft/power-apps` with
+  `@microsoft/power-apps-vite`.
+- Keep each app's `power.config.json`, generated models and generated Dataverse
+  services app-local.
+- Use only synthetic, typed fixtures in the local Vite adapter.
+- Keep runtime commands closed and typed; Dataverse writes remain
+  schema-validated and human-approved.
+- Validate Power Apps Premium and applicable Dynamics 365 / Copilot Studio
+  rights for each test persona before making a rollout commitment.
+
+## Sequential loop
+
+Run one server at a time. Every gate starts in a new Visual Studio Code
+integrated terminal, and every visual page opens inside Visual Studio Code so
+the user can share it with Copilot. Visual choices remain attended.
+
+### Gate 1 - fixture-backed Vite polish
+
+1. Start the fixture harness with `npm run dev`.
+2. Open the local page inside Visual Studio Code and share it with Copilot.
+3. Compare the complete experience with the approved visual baseline at fixed
+   desktop and mobile viewports.
+4. Let the user review each change to layout, hierarchy, typography, tokens,
+   interaction and responsive behavior; do not infer visual approval.
+5. Run component, interaction, accessibility and visual-regression checks for
+   the accepted refinement batch.
+6. Capture the approved screenshots and findings, then stop the Vite server.
+
+Fixture mode is local-only. It must never be imported into `pa app run`, DEV,
+TEST or a production bundle.
+
+### Gate 2 - authenticated local Code App host
+
+1. In a fresh integrated terminal, start the app with `pa app run`.
+2. Open its Local Play URL inside Visual Studio Code using the tenant browser
+   profile.
+3. Verify host context, generated Dataverse services, least-privilege identity,
+   native navigation and all loading, empty, denied, failed and unmapped states.
+4. Exercise supported writes only after explicit human confirmation, then
+   reread the Dataverse record before reporting success.
+5. Confirm the authenticated build has no fixture fallback and fails visibly
+   when live data or configuration is unavailable.
+6. Stop the server before starting another app or returning to Vite.
+
+A local pass proves the generated-service contract. It does not prove live
+embedding, environment sharing, CSP, managed promotion or TEST parity.
+
+### Gate 3 - live DEV and TEST evidence
+
+1. Build and test the reviewed Git commit.
+2. A maker/admin performs attended `pa app push` to DEV only and records the
+   commit, CLI version, app identity, solution identity, operator, timestamp
+   and result. Do not introduce or store a client secret.
+3. Validate the live DEV host with the least-privilege advisor and synthetic
+   scenario.
+4. Export the complete solution from DEV through the existing OIDC pipeline
+   and import that exact managed artifact into TEST. Do not author directly in
+   TEST.
+5. Apply environment-specific configuration without hard-coding a DEV play URL
+   in source.
+6. Repeat the same advisor journey in TEST and compare the evidence with DEV.
+
+Only live DEV and TEST evidence can support a host-placement decision. B1 and
+B2 remain unselected until both have completed the approved parity scorecard.
+
+## Accessibility matrix
+
+For every view and dialog, record evidence for:
+
+| Area | Required evidence |
+| --- | --- |
+| Keyboard | Logical tab order, complete keyboard operation, no focus trap |
+| Focus | Visible focus, restored focus after dialogs, useful initial focus |
+| Semantics | Landmarks, headings, names, roles, states and error association |
+| Visual | Token contrast, zoom, 320px reflow and 400% zoom without lost work |
+| Locale | EN/DE/FR/IT smoke and locale-aware values without clipped text |
+
+## Provenance matrix
+
+Every data-bearing region classifies authoritative origin and provides a text
+cue; color is never the only signal.
+
+| State | Presentation and behavior |
+| --- | --- |
+| CRM-native/mastered | Normal presentation with an accessible source name |
+| External or projected | Grey treatment plus an accessible source name |
+| Unmapped | Yellow treatment plus an explicit unmapped label |
+| Empty | Neutral empty state, never yellow |
+| Permission denied | Explicit denied state, never fixture data |
+| Load failure | Explicit error and retry path, never fixture data |
+
+Agent-authored content retains visible provenance and AI-assisted disclosure.
+
+## Write-capability matrix
+
+Every visible command records:
+
+| Field | Required content |
+| --- | --- |
+| Action | Stable command identifier and user-facing label |
+| Intended effect | Local, read, navigate or write |
+| Target | Table, column, relationship or destination |
+| Host support | Supported, partial, blocked or unverified for each host |
+| Limitation | Missing schema, lookup, permission or SDK capability |
+| Runtime treatment | Enabled, partially enabled or disabled with a reason |
+| Evidence | Automated test or live run proving the result |
+| Remediation | Deferred requirement outside the approved sprint scope |
+
+Unsupported commands remain visible and disabled with a reason; they never
+simulate success. Supported writes use generated Dataverse services, a closed
+typed command, explicit human approval, schema validation and a post-write
+reread. Free-text model output never mutates Dataverse directly.
+
+## Exit evidence
+
+- Fixture, authenticated local, live DEV and live TEST results are clearly
+  separated.
+- The same synthetic scenario and least-privilege persona are used in DEV and
+  TEST.
+- Screenshots, accessibility results, provenance checks, command results,
+  timings, session IDs and known limitations are linked to the reviewed commit.
+- No Azure dependency, B2E artifact, fixture fallback, real customer data,
+  hard-coded DEV URL or direct TEST authoring is present.
+- Rollback restores the previous managed solution and host configuration.

--- a/docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
+++ b/docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md
@@ -1315,6 +1315,8 @@ git commit -m "ci(code-apps): gate builds parity accessibility and release safet
 
 - Create: `scripts/solution/Publish-CodeAppsDev.ps1`
 - Create: `scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1`
+- Create: `scripts/solution/Complete-CodeAppsDevEvidence.ps1`
+- Create: `scripts/solution/tests/Complete-CodeAppsDevEvidence.Tests.ps1`
 - Create: `docs/runbooks/publish-code-apps-dev.md`
 - Modify: `.github/workflows/cd-solution-dev.yml`
 - Modify: `docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md`
@@ -1325,10 +1327,29 @@ Mock all process execution. Assert the wrapper:
 
 - refuses missing environment/solution GUIDs;
 - checks `pa auth status --json` before build/push;
+- verifies each app's `power.config.json` is bound to `EnvironmentId`;
 - runs B1 then B2 builds and `pa app push --solution-id`;
 - never sets `PA_CLI_USE_SP_AUTH`, `SP_CLIENT_SECRET`, or calls TEST;
-- writes evidence containing commit SHA, CLI version, app name, timestamp and
-  exit code, but no token or credential.
+- creates a sorted per-file SHA-256 `dist` manifest with normalized relative
+  paths and fails if `dist` changes before push;
+- parses and records each returned play URL;
+- writes evidence containing commit SHA, manifest hash, build/test result, CLI
+  version, app and solution identities, approved DEV environment ID, returned
+  play URL, operator, timestamp and exit code, but no token or credential; and
+- writes `RuntimeVerification = 'Pending'` because browser runtime evidence does
+  not exist at publication time.
+
+Write a separate failing test for `Complete-CodeAppsDevEvidence.ps1`. It must:
+
+- require the provisional evidence path, app identity and browser-observed
+  runtime environment ID;
+- refuse an evidence file whose `RuntimeVerification` is not `Pending`;
+- refuse a runtime environment ID that differs from the recorded approved DEV
+  environment ID;
+- preserve the returned play URL and manifest hash without accepting them as
+  command-line replacements; and
+- atomically write `RuntimeVerification = 'Verified'`, the runtime environment
+  ID, verifier and verification timestamp without logging the play URL.
 
 Run focused Pester and expect RED.
 
@@ -1336,8 +1357,18 @@ Run focused Pester and expect RED.
 
 Parameters are `EnvironmentId`, `SolutionId`, and `EvidencePath`, each required.
 Validate GUIDs. Require an interactive active account returned by `pa auth
-status --json`. Build and push each app sequentially, stop on first failure,
-and write BOM-free UTF-8 evidence JSON.
+status --json`. Verify each app's `power.config.json` environment binding equals
+`EnvironmentId`. Build and test each app, create a sorted per-file SHA-256
+manifest from normalized relative paths, hash the BOM-free UTF-8 manifest, and
+push each app sequentially without changing `dist`. Stop on first failure,
+parse the returned play URL, and write BOM-free UTF-8 evidence JSON.
+
+Create `Complete-CodeAppsDevEvidence.ps1` as the post-publication finalizer. It
+reads the provisional evidence JSON, finds the named app entry, validates the
+browser-observed runtime environment ID against the recorded approved DEV
+environment ID, and writes a replacement BOM-free UTF-8 file through a
+same-directory temporary file plus atomic rename. It never accepts a play URL,
+manifest hash or approved environment ID from the command line.
 
 - [ ] **Step 3: Write the attended runbook**
 
@@ -1350,6 +1381,21 @@ pa auth status --json
   -EnvironmentId $env:POWER_PLATFORM_DEV_ENVIRONMENT_ID `
   -SolutionId $env:CRM_SHOWCASE_SALES_SOLUTION_ID `
   -EvidencePath ./artifacts/code-apps-dev-publish.json
+```
+
+After opening each returned play URL and reading the displayed diagnostic
+`getContext().app.environmentId`, finalize that app entry:
+
+```powershell
+./scripts/solution/Complete-CodeAppsDevEvidence.ps1 `
+  -EvidencePath ./artifacts/code-apps-dev-publish.json `
+  -AppIdentity 'Advisor Cockpit - Standalone Proof' `
+  -RuntimeEnvironmentId $observedB1EnvironmentId
+
+./scripts/solution/Complete-CodeAppsDevEvidence.ps1 `
+  -EvidencePath ./artifacts/code-apps-dev-publish.json `
+  -AppIdentity 'Advisor Cockpit - Embedded Proof' `
+  -RuntimeEnvironmentId $observedB2EnvironmentId
 ```
 
 Then instruct the maker to:
@@ -1383,6 +1429,7 @@ clear failure that points to the attended runbook when preflight is missing.
 
 ```powershell
 Invoke-Pester -Path scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 -Output Detailed
+Invoke-Pester -Path scripts/solution/tests/Complete-CodeAppsDevEvidence.Tests.ps1 -Output Detailed
 Invoke-Pester -Path scripts/solution/tests -Output Detailed
 ```
 
@@ -1391,8 +1438,12 @@ Expected: all tests pass.
 - [ ] **Step 6: Execute the attended DEV publication**
 
 Run the runbook as maker/admin. Do not transmit credentials through chat.
-Record sanitized evidence and app IDs in the Sprint 005 issue/STATUS; do not
-commit tenant IDs or full play URLs.
+Open each returned play URL and verify `getContext().app.environmentId` equals
+the approved DEV environment ID. Finalize each provisional app entry with
+`Complete-CodeAppsDevEvidence.ps1`; the DEV proof gate refuses evidence unless
+both entries have `RuntimeVerification = 'Verified'`. Record sanitized evidence
+and app IDs in the Sprint 005 issue/STATUS; do not commit tenant IDs or full play
+URLs.
 
 - [ ] **Step 7: Run least-privilege DEV journeys**
 
@@ -1412,8 +1463,8 @@ returning to attended design review.
 - [ ] **Step 8: Commit source/runbook changes and DEV evidence references**
 
 ```powershell
-git add scripts/solution/Publish-CodeAppsDev.ps1 scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 docs/runbooks/publish-code-apps-dev.md .github/workflows/cd-solution-dev.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
-git commit -m "feat(code-apps): add attended DEV publication and proof gate (US-301)" -- scripts/solution/Publish-CodeAppsDev.ps1 scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 docs/runbooks/publish-code-apps-dev.md .github/workflows/cd-solution-dev.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+git add scripts/solution/Publish-CodeAppsDev.ps1 scripts/solution/Complete-CodeAppsDevEvidence.ps1 scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 scripts/solution/tests/Complete-CodeAppsDevEvidence.Tests.ps1 docs/runbooks/publish-code-apps-dev.md .github/workflows/cd-solution-dev.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
+git commit -m "feat(code-apps): add attended DEV publication and proof gate (US-301)" -- scripts/solution/Publish-CodeAppsDev.ps1 scripts/solution/Complete-CodeAppsDevEvidence.ps1 scripts/solution/tests/Publish-CodeAppsDev.Tests.ps1 scripts/solution/tests/Complete-CodeAppsDevEvidence.Tests.ps1 docs/runbooks/publish-code-apps-dev.md .github/workflows/cd-solution-dev.yml docs/superpowers/sprints/sprint-005-code-app-parity/STATUS.md
 ```
 
 ---

--- a/scripts/solution/tests/CodeAppsGovernance.Tests.ps1
+++ b/scripts/solution/tests/CodeAppsGovernance.Tests.ps1
@@ -1,0 +1,30 @@
+BeforeAll {
+    $root = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $adr = Join-Path $root 'docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md'
+    $pattern = Join-Path $root 'docs/superpowers/patterns/code-app-local-first-polish-loop.md'
+    $instructions = Join-Path $root '.github/instructions/code-apps.instructions.md'
+}
+
+Describe 'Code Apps governance foundation' {
+    It 'records the primary-build decision' {
+        Test-Path $adr | Should -BeTrue
+        Get-Content $adr -Raw | Should -Match 'Code Apps are primary for bespoke full-page CRM experiences'
+    }
+
+    It 'anchors the attended local-first loop' {
+        Test-Path $pattern | Should -BeTrue
+        $text = Get-Content $pattern -Raw
+        $text | Should -Match 'npm run dev'
+        $text | Should -Match 'pa app run'
+        $text | Should -Match 'Visual Studio Code'
+        $text | Should -Match 'DEV and TEST'
+    }
+
+    It 'scopes Code App source instructions' {
+        Test-Path $instructions | Should -BeTrue
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match 'power.config.json'
+        $text | Should -Match 'generated Dataverse services'
+        $text | Should -Match 'no fixture fallback'
+    }
+}

--- a/scripts/solution/tests/CodeAppsGovernance.Tests.ps1
+++ b/scripts/solution/tests/CodeAppsGovernance.Tests.ps1
@@ -1,8 +1,12 @@
 BeforeAll {
     $root = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
     $adr = Join-Path $root 'docs/adr/ADR-0041-code-apps-primary-for-bespoke-full-page-crm-ux.md'
+    $almAdr = Join-Path $root 'docs/adr/ADR-0017-alm-everything-through-the-pipeline.md'
+    $retainedPcfAdr = Join-Path $root 'docs/adr/ADR-0027-page-level-pcf-and-local-first-polish-loop.md'
     $pattern = Join-Path $root 'docs/superpowers/patterns/code-app-local-first-polish-loop.md'
+    $plan = Join-Path $root 'docs/superpowers/plans/2026-08-19-power-apps-code-app-advisor-cockpit-parity.md'
     $instructions = Join-Path $root '.github/instructions/code-apps.instructions.md'
+    $uxDesigner = Join-Path $root '.github/agents/ux-designer.agent.md'
 }
 
 Describe 'Code Apps governance foundation' {
@@ -26,5 +30,189 @@ Describe 'Code Apps governance foundation' {
         $text | Should -Match 'power.config.json'
         $text | Should -Match 'generated Dataverse services'
         $text | Should -Match 'no fixture fallback'
+    }
+
+    It 'uses the exact Code App source applyTo contract' {
+        $applyToLines = @(Get-Content $instructions | Where-Object { $_ -match '^applyTo:' })
+        $applyToLines | Should -HaveCount 1
+        $applyToLines[0] | Should -BeExactly "applyTo: 'solution/apps/**/{code-apps,packages}/**/*.{ts,tsx,js,json,html,css}'"
+    }
+
+    It 'requires an explicit solution-targeted DEV push' {
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match ([regex]::Escape('pa app push --solution-id <crmshow_Sales GUID>'))
+    }
+
+    It 'requires publication from a clean reviewed checkout' {
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match 'clean reviewed checkout'
+    }
+
+    It 'requires SHA-256 publication evidence' {
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match 'SHA-256'
+    }
+
+    It 'requires ADR-0017 publication from a clean reviewed checkout' {
+        Get-Content $almAdr -Raw | Should -Match 'clean reviewed checkout'
+    }
+
+    It 'requires ADR-0017 SHA-256 publication evidence' {
+        Get-Content $almAdr -Raw | Should -Match 'SHA-256'
+    }
+
+    It 'requires ADR-0017 to use an explicit solution-targeted DEV push' {
+        Get-Content $almAdr -Raw | Should -Match ([regex]::Escape('pa app push --solution-id <crmshow_Sales GUID>'))
+    }
+
+    It 'requires ADR-0041 publication from a clean reviewed checkout' {
+        Get-Content $adr -Raw | Should -Match 'clean reviewed checkout'
+    }
+
+    It 'requires ADR-0041 SHA-256 publication evidence' {
+        Get-Content $adr -Raw | Should -Match 'SHA-256'
+    }
+
+    It 'requires ADR-0041 to use an explicit solution-targeted DEV push' {
+        Get-Content $adr -Raw | Should -Match ([regex]::Escape('pa app push --solution-id <crmshow_Sales GUID>'))
+    }
+
+    It 'requires the pattern publication from a clean reviewed checkout' {
+        Get-Content $pattern -Raw | Should -Match 'clean reviewed checkout'
+    }
+
+    It 'requires the pattern SHA-256 publication evidence' {
+        Get-Content $pattern -Raw | Should -Match 'SHA-256'
+    }
+
+    It 'requires the pattern to use an explicit solution-targeted DEV push' {
+        Get-Content $pattern -Raw | Should -Match ([regex]::Escape('pa app push --solution-id <crmshow_Sales GUID>'))
+    }
+
+    It 'enforces one deterministic publication contract across all four authorities' {
+        $authorities = @(
+            @{ Name = 'ADR-0017'; Path = $almAdr }
+            @{ Name = 'ADR-0041'; Path = $adr }
+            @{ Name = 'Code App instructions'; Path = $instructions }
+            @{ Name = 'Code App pattern'; Path = $pattern }
+        )
+        $requiredConcepts = @(
+            @{
+                Name = 'clean reviewed checkout at the reviewed commit'
+                Pattern = 'clean\s+reviewed\s+checkout\s+at\s+the\s+reviewed(?:\s+Git)?\s+commit'
+            }
+            @{
+                Name = 'build and test immediately before publication'
+                Pattern = 'build(?:s)?\s+and\s+test(?:s)?\s+immediately\s+before\s+publication'
+            }
+            @{
+                Name = 'configured environment matches the approved DEV environment ID'
+                Pattern = 'verif(?:y|ies)\s+(?:each\s+)?(?:app(?:''s)?\s+)?`?power\.config\.json`?\s+(?:is\s+)?bound\s+to\s+the\s+approved\s+DEV\s+environment\s+ID'
+            }
+            @{
+                Name = 'deterministic sorted per-file SHA-256 manifest'
+                Pattern = '(?s)sorted\s+per-file\s+SHA-256\s+manifest.*normalized\s+relative\s+paths'
+            }
+            @{
+                Name = 'BOM-free UTF-8 manifest serialization'
+                Pattern = 'BOM-free\s+UTF-8\s+manifest'
+            }
+            @{
+                Name = 'dist remains unchanged between hashing and push'
+                Pattern = '(?s)leave\s+`?dist`?\s+unchanged\s+between\s+hashing\s+and\s+push'
+            }
+            @{
+                Name = 'exact solution-targeted push command'
+                Pattern = [regex]::Escape('pa app push --solution-id <crmshow_Sales GUID>')
+            }
+            @{
+                Name = 'complete publication evidence fields'
+                Pattern = '(?is)publication\s+evidence\s+record(?:s)?\s+the\s+commit\s*,?\s*manifest\s+hash(?:es)?\s*,?\s*successful\s+build\s+and\s+test\s+evidence\s*,?\s*CLI\s+version\s*,?\s*app\s+identity\s*,?\s*solution\s+identity\s*,?\s*approved\s+DEV\s+environment\s+ID\s*,?\s*returned\s+play\s+URL\s*,?\s*runtime\s+environment\s+ID\s*,?\s*operator\s*,?\s*timestamp\s*(?:,?\s*and)?\s*result'
+            }
+            @{
+                Name = 'DEV-only publication'
+                Pattern = 'DEV\s+only'
+            }
+            @{
+                Name = 'no introduced or stored client secret'
+                Pattern = 'no\s+client\s+secret\s+is\s+introduced\s+or\s+stored'
+            }
+            @{
+                Name = 'exact managed artifact reaches TEST through the existing OIDC pipeline'
+                Pattern = 'TEST\s+receives\s+the\s+exact\s+managed\s+artifact\s+through\s+the\s+existing\s+OIDC\s+pipeline'
+            }
+            @{
+                Name = 'direct TEST authoring is prohibited'
+                Pattern = 'direct\s+TEST\s+authoring\s+is\s+prohibited'
+            }
+            @{
+                Name = 'runtime environment verification through getContext'
+                Pattern = '(?s)getContext\(\)\.app\.environmentId.*approved\s+DEV\s+environment\s+ID'
+            }
+        )
+
+        $gaps = foreach ($authority in $authorities) {
+            $text = Get-Content $authority.Path -Raw
+            foreach ($concept in $requiredConcepts) {
+                if ($text -notmatch $concept.Pattern) {
+                    "$($authority.Name): $($concept.Name)"
+                }
+            }
+        }
+
+        ($gaps -join [Environment]::NewLine) | Should -BeNullOrEmpty -Because 'each authority must state the complete deterministic publication contract'
+    }
+
+    It 'separates attended publication from runtime evidence finalization' {
+        Test-Path $plan | Should -BeTrue
+        $text = Get-Content $plan -Raw
+        $text | Should -Match 'Complete-CodeAppsDevEvidence\.ps1'
+        $text | Should -Match 'RuntimeVerification\s*=\s*''Pending'''
+        $text | Should -Match 'RuntimeVerification\s*=\s*''Verified'''
+        $text | Should -Match '(?s)refuse.*runtime environment ID.*approved DEV.*environment ID'
+    }
+
+    It 'defines Code App localization ownership in source instructions' {
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match ([regex]::Escape('Dataverse/MDA metadata labels use native localization'))
+        $text | Should -Match ([regex]::Escape('Code App-owned strings use versioned app-local catalogs'))
+        $text | Should -Match 'EN/DE/FR/IT'
+        $text | Should -Match 'never hard-code user-facing strings'
+    }
+
+    It 'defines one deterministic Code App locale resolution contract' {
+        $text = Get-Content $instructions -Raw
+        $text | Should -Match ([regex]::Escape('navigator.languages'))
+        $text | Should -Match ([regex]::Escape('Intl.getCanonicalLocales'))
+        $text | Should -Match '(?s)de.*fr.*it.*fallback.*en'
+        $text | Should -Match '(?s)getContext.*does\s+not\s+expose\s+a\s+locale'
+    }
+
+    It 'separates Dataverse metadata localization from Code App-owned strings' {
+        Test-Path $uxDesigner | Should -BeTrue
+        $text = Get-Content $uxDesigner -Raw
+        $text | Should -Match 'Dataverse(?:/MDA)?\s+metadata\s+labels\s+use\s+native\s+localization'
+        $text | Should -Match 'Code App-owned\s+strings\s+use\s+versioned\s+app-local\s+catalogs'
+    }
+
+    It 'gives the UX designer valid shell execution access' {
+        $toolsLines = @(Get-Content $uxDesigner | Where-Object { $_ -match '^tools:' })
+        $toolsLines | Should -HaveCount 1
+        $toolsLines[0] | Should -Match "'execute'"
+        $toolsLines[0] | Should -Not -Match "'powershell'"
+    }
+
+    It 'delegates browser opening to the controlling VS Code chat' {
+        $text = Get-Content $uxDesigner -Raw
+        $text | Should -Match 'controlling VS Code chat'
+    }
+
+    It 'records retained controls as Vitest-tested' {
+        Test-Path $retainedPcfAdr | Should -BeTrue
+        Get-Content $retainedPcfAdr -Raw | Should -Match 'Vitest-tested'
+    }
+
+    It 'does not claim retained controls are Jest-tested' {
+        Get-Content $retainedPcfAdr -Raw | Should -Not -Match 'Jest-tested'
     }
 }


### PR DESCRIPTION
## Summary

- establish Code Apps as primary for bespoke full-page CRM UX
- retain model-driven configuration for native CRM work and PCF for embedded host-context controls
- add the attended Code App local-first polish loop and scoped source instructions
- bound DEV publication with reviewed-source, deterministic manifest, environment, and runtime evidence
- align UX agent tooling and Code App localization ownership

## Traceability

- Story: US-301
- Use case: UC-01 Advisor Cockpit
- Sprint charter: #139
- Stream: #140
- ADR: ADR-0041
- Design: `docs/superpowers/specs/2026-08-19-power-apps-code-app-advisor-cockpit-parity-design.md`
- Plan Task: Task 1

## Validation

- focused governance Pester: 25 passed, 0 failed
- full solution Pester: 455 passed, 0 failed, 2 skipped
- `git diff --check`: clean
- Markdown/VS Code diagnostics: clean
- independent final quality review: APPROVED

## Guardrails

- no Code App implementation or environment mutation in this PR
- B1/B2 remain unselected pending live DEV and TEST evidence
- no Azure dependency, B2E implementation, Dataverse schema extension, client secret, or direct TEST authoring